### PR TITLE
Udp receive msg discovery response classic

### DIFF
--- a/Makefile.classicmac
+++ b/Makefile.classicmac
@@ -55,7 +55,8 @@ endif
 
 # Compiler flags
 # Ensure paths are quoted. The -I flags themselves handle spaces if the shell passes them correctly.
-CFLAGS_MAC = -g -w -ffunction-sections -D__MACOS__ -Iclassic_mac -Ishared -I"$(CINCLUDES)" -I"$(UNIVERSAL_CINCLUDES)"
+# VERSION 3: Added -fpack-struct
+CFLAGS_MAC = -g -Wall -fpack-struct -ffunction-sections -D__MACOS__ -Iclassic_mac -Ishared -I"$(CINCLUDES)" -I"$(UNIVERSAL_CINCLUDES)"
 
 # Linker flags (passed via the compiler driver using -Wl,)
 LDFLAGS_MAC = -Wl,-gc-sections -Wl,--mac-strip-macsbug

--- a/Makefile.classicmac
+++ b/Makefile.classicmac
@@ -56,7 +56,7 @@ endif
 # Compiler flags
 # Ensure paths are quoted. The -I flags themselves handle spaces if the shell passes them correctly.
 # VERSION 3: Added -fpack-struct
-CFLAGS_MAC = -g -Wall -fpack-struct -ffunction-sections -D__MACOS__ -Iclassic_mac -Ishared -I"$(CINCLUDES)" -I"$(UNIVERSAL_CINCLUDES)"
+CFLAGS_MAC = -g -w -fpack-struct -ffunction-sections -D__MACOS__ -Iclassic_mac -Ishared -I"$(CINCLUDES)" -I"$(UNIVERSAL_CINCLUDES)"
 
 # Linker flags (passed via the compiler driver using -Wl,)
 LDFLAGS_MAC = -Wl,-gc-sections -Wl,--mac-strip-macsbug

--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,127 @@
+**Bug Summary: Incorrect Stream Pointer Returned by `udpCreate` Leading to `udpBfrReturn` Failure (-23013)**
+
+**1. Issue Summary:**
+
+When attempting to use MacTCP's User Datagram Protocol (UDP) via low-level `PBControlSync` calls within an application compiled using the Retro68 GCC toolchain, the `udpCreate` control call successfully returns `noErr`. However, the `StreamPtr` value written back into the `udpStream` field of the `UDPiopb` parameter block appears to be incorrect. Instead of returning a pointer to MacTCP's internal stream control block, it returns the memory address of the user-provided receive buffer (`rcvBuff`).
+
+While this non-zero value might be sufficient for a later `udpRelease` call to succeed (possibly because `udpRelease` also receives the buffer pointer explicitly), it causes subsequent `udpBfrReturn` calls (which are necessary after successfully reading data with `udpRead`) to fail with error `-23013` (`invalidBufPtr`). MacTCP interprets this error as the provided buffer pointer not belonging to the stream identified by the (incorrect) stream pointer, leading to a failure to return the buffer to MacTCP's pool. This ultimately prevents reliable, continuous UDP reception, as MacTCP will eventually exhaust its internal references to the application's receive buffer segments.
+
+**2. Background & Context:**
+
+*   **Environment:** Classic Macintosh (System 7.5.3 on Performa 6200), MacTCP v2.0.6.
+*   **Development Toolchain:** Retro68 (GCC-based cross-compiler for m68k Macintosh).
+*   **API:** MacTCP Driver accessed via low-level Device Manager calls (`PBOpenSync`, `PBControlSync`, `PBCloseSync`).
+*   **Interface:** Using the `UDPiopb` parameter block structure defined in `<MacTCP.h>` (or equivalent Universal Headers) for UDP control calls (`udpCreate`, `udpRead`, `udpWrite`, `udpBfrReturn`, `udpRelease`).
+*   **Goal:** Implement UDP broadcast discovery and peer-to-peer communication.
+
+**3. Symptoms & Debugging Progression:**
+
+*   **Initial State (No special alignment flags):**
+    *   `udpCreate` call using `PBControlSync` returned `noErr`.
+    *   However, inspecting the `pb.udpStream` field *after* the call revealed it was `0L` (NULL).
+    *   Subsequent calls like `udpRead` or `udpWrite` would fail immediately or behave unpredictably because they require a valid `StreamPtr`.
+    *   Attempts to call `udpBfrReturn` or `udpRelease` with a NULL `StreamPtr` would fail with `invalidStreamPtr` (-23010).
+*   **With `-fpack-struct` Compiler Flag:**
+    *   The Retro68 GCC compiler was instructed to pack structure members tightly, removing default alignment padding.
+    *   `udpCreate` call using `PBControlSync` still returned `noErr`.
+    *   Inspecting `pb.udpStream` *after* the call now showed a **non-zero** value. Crucially, this value was observed to be the **exact memory address** of the `rcvBuff` pointer (`gUDPRecvBuffer`) that was passed *into* the `udpCreate` call.
+    *   `udpRead` calls now successfully returned `noErr` when packets arrived, indicating MacTCP could associate incoming data with the stream (identified somehow, perhaps via the buffer address).
+    *   **NEW FAILURE:** The `udpBfrReturn` call, made after a successful `udpRead` that received data, now consistently failed with error `-23013` (`invalidBufPtr`).
+    *   The `udpRelease` call during cleanup *succeeded* when passed the buffer address as the `udpStream`.
+
+**4. Root Cause Analysis (The "Why"):**
+
+The most likely cause is a **structure alignment mismatch** between the application code compiled by Retro68 GCC (even with `-fpack-struct`) and the pre-compiled MacTCP driver code (originally compiled with MPW C).
+
+*   **Structure Layout:** MacTCP expects the `UDPiopb` parameter block passed via `PBControlSync` to have a precise memory layout, determined by the MPW C compiler's rules at the time MacTCP was built. Modern GCC has different default alignment rules.
+*   **`-fpack-struct` Effect:** This flag forces GCC to minimize padding *between* structure members. This brought the layout *closer* to what MacTCP expects, allowing MacTCP to correctly read the *input* parameters like `csCode`, `rcvBuff`, and `rcvBuffLen` from their (now packed) locations. This is why `udpCreate` started returning `noErr`.
+*   **The Output Problem:** However, when MacTCP needs to write the *output* `StreamPtr` back into the parameter block, it calculates the memory offset based on its *internal* (likely MPW C) understanding of the structure layout. Due to subtle remaining differences (perhaps alignment *within* the `csParam` union, or the alignment of the union itself relative to `udpStream`), the offset MacTCP calculates for `udpStream` doesn't correspond to the `udpStream` field in the Retro68 `-fpack-struct` layout. Instead, it appears to correspond exactly to the location of the `csParam.create.rcvBuff` field within the union.
+*   **Result:** MacTCP writes the *intended* internal stream pointer value into the memory location it *thinks* is `udpStream`, but which is actually `csParam.create.rcvBuff` in the application's view. It might then write the *original value* it read from `csParam.create.rcvBuff` (the buffer address) into the memory location it *thinks* is `udpStream`. The application then reads `pb.udpStream` and gets the buffer address (`0x222D400` in your logs).
+*   **`udpBfrReturn` Failure:** This call requires the *true* internal `StreamPtr` to correctly identify the stream and manage its buffer queue. When it receives the buffer address instead, it cannot find a matching internal stream control block and fails with `-23013` (effectively, "this buffer doesn't belong to the stream identified by *this* pointer").
+*   **`udpRelease` Success:** This call might succeed because it receives *both* the (incorrect) stream pointer *and* the correct buffer pointer (`rcvBuff`) and length (`rcvBuffLen`) as explicit parameters within the `csParam.create` part of the union (as per the MacTCP guide). It might use the buffer pointer directly to find and release the associated resources, being more tolerant of the incorrect stream pointer value for this specific cleanup operation.
+
+**5. Code Context (The "Where" and "How"):**
+
+*   **Structure Definition (`<MacTCP.h>`):**
+
+    ```c
+    typedef struct UDPiopb {
+        // ... standard header ... (28 bytes total)
+        short             csCode;         // Offset 28
+        StreamPtr         udpStream;      // Offset 30 <- PROBLEM AREA (Output for Create, Input for others)
+        union {                         // Offset 34
+            struct UDPCreatePB  create;   // Used by udpCreate
+            struct UDPSendPB    send;     // Used by udpWrite
+            struct UDPReceivePB receive;  // Used by udpRead, udpBfrReturn
+            struct UDPMTUPB     mtu;
+        } csParam;
+    } UDPiopb;
+
+    typedef struct UDPCreatePB {
+        Ptr           rcvBuff;        // Offset 34 + 0 = 34 <- Value being returned in udpStream?
+        unsigned long rcvBuffLen;     // Offset 34 + 4 = 38
+        UDPNotifyProc notifyProc;     // Offset 34 + 8 = 42
+        unsigned short localPort;     // Offset 34 + 12 = 46
+        Ptr           userDataPtr;    // Offset 34 + 14 = 48 (Size = 18 bytes)
+    } UDPCreatePB;
+
+    typedef struct UDPReceivePB {
+        // ... other fields ...
+        Ptr            rcvBuff;       // Offset 34 + 8 = 42 <- INPUT for udpBfrReturn
+        // ... other fields ...
+    } UDPReceivePB;
+    ```
+    *(Note: Offsets calculated assuming packed layout, actual offsets might vary slightly based on compiler specifics)*
+
+*   **`udpCreate` Call in `InitUDPDiscoveryEndpoint`:**
+
+    ```c
+    // ... setup pb ...
+    pb.csParam.create.rcvBuff = gUDPRecvBuffer; // Input: 0x222D400
+    pb.csParam.create.rcvBuffLen = kMinUDPBufSize;
+    pb.udpStream = 0L; // Cleared before call
+
+    err = PBControlSync((ParmBlkPtr)&pb);
+
+    // After call:
+    // err = 0 (noErr)
+    // pb.udpStream = 0x222D400 (Problem: Contains rcvBuff address, not internal stream ptr)
+    gUDPStream = pb.udpStream;
+    ```
+
+*   **`udpBfrReturn` Call in `CheckUDPReceive`:**
+
+    ```c
+    // After successful udpRead where bytesReceived > 0...
+    memset(&bfrReturnPB, 0, sizeof(UDPiopb));
+    // ... set common fields ...
+    bfrReturnPB.csCode = udpBfrReturn;
+    bfrReturnPB.udpStream = gUDPStream; // Input: Passes 0x222D400 (the buffer address)
+    bfrReturnPB.csParam.receive.rcvBuff = gUDPRecvBuffer; // Input: Passes 0x222D400
+
+    returnErr = PBControlSync((ParmBlkPtr)&bfrReturnPB);
+    // returnErr = -23013 (invalidBufPtr - MacTCP doesn't associate stream '0x222D400' with buffer '0x222D400')
+    ```
+
+**6. Log Evidence:**
+
+```
+DEBUG: After PBControlSync(udpCreate): err=0, pb.udpStream=0x222D400, pb.csParam.create.localPort=8081
+...
+// (udpRead succeeds, receives data into gUDPRecvBuffer)
+...
+CRITICAL Error (UDP Receive): PBControlSync(udpBfrReturn) failed with stream 0x222D400. Error: -23013. UDP receive may stop working.
+...
+// (Cleanup)
+Attempting PBControlSync (udpRelease) for endpoint 0x222D400...
+PBControlSync(udpRelease) succeeded.
+Disposing UDP receive buffer at 0x222D400.
+```
+
+**7. Impact:**
+
+The inability to successfully call `udpBfrReturn` means that the memory segments within `gUDPRecvBuffer` used by MacTCP for incoming packets are never marked as available again for MacTCP's internal management of that stream. Eventually, MacTCP will believe it has no more buffer space available for this stream and will stop receiving UDP packets, likely leading to `udpRead` calls timing out or returning errors.
+
+**8. Conclusion:**
+
+The core problem is a persistent, subtle structure alignment mismatch between the Retro68/GCC build environment (even with `-fpack-struct`) and the expected layout of the `UDPiopb` by the pre-compiled MacTCP driver. This causes `udpCreate` to write the wrong value (the user buffer address) into the `udpStream` field, which subsequently breaks `udpBfrReturn`. Compiling with MPW C on a real Mac remains the best way to verify the expected structure layout and potentially resolve the issue, or alternatively, exploring higher-level UDP APIs if the low-level approach proves intractable due to these alignment problems.

--- a/classic_mac/discovery.c
+++ b/classic_mac/discovery.c
@@ -56,6 +56,11 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     log_message("Calling PBControlSync (udpCreate) for port %u...", specificPort);
     err = PBControlSync((ParmBlkPtr)&pb); // Cast UDPiopb to generic ParmBlkPtr
 
+    log_message("DEBUG: udpCreate returned pb.udpStream=0x%lX, pb.csParam.create.rcvBuff=0x%lX",
+        (unsigned long)pb.udpStream,
+        (unsigned long)pb.csParam.create.rcvBuff);
+    gUDPStream = pb.udpStream; // Assign AFTER logging
+
     if (err != noErr) {
         log_message("Error (InitUDP): PBControlSync(udpCreate) failed. Error: %d", err);
         if (gUDPRecvBuffer != NULL) {

--- a/classic_mac/discovery.c
+++ b/classic_mac/discovery.c
@@ -33,6 +33,7 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     }
 
     // Allocate buffer needed by UDPCreate for receiving data
+    // Using NewPtrClear is fine, ensures buffer is zeroed initially.
     gUDPRecvBuffer = NewPtrClear(kMinUDPBufSize);
     if (gUDPRecvBuffer == NULL) {
         log_message("Error (InitUDP): Failed to allocate UDP receive buffer (memFullErr).");
@@ -45,21 +46,21 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     pb.ioCompletion = nil;           // No completion routine for sync call
     pb.ioCRefNum = macTCPRefNum;     // Use passed-in Driver reference number
     pb.csCode = udpCreate;           // Command code for creating UDP stream
-    pb.udpStream = 0L;               // Output: Will be filled by MacTCP
+    pb.udpStream = 0L;               // IMPORTANT: MacTCP writes the output StreamPtr here
 
     // Access parameters via the csParam.create union structure
     pb.csParam.create.rcvBuff = gUDPRecvBuffer; // Pointer to allocated buffer
     pb.csParam.create.rcvBuffLen = kMinUDPBufSize; // Size of the buffer
-    pb.csParam.create.notifyProc = nil;         // No notification routine needed
+    pb.csParam.create.notifyProc = nil;         // No notification routine needed for sync operation
     pb.csParam.create.localPort = specificPort;  // Listen on the specific discovery port
+    // pb.csParam.create.userDataPtr is not needed for nil notifyProc
 
     log_message("Calling PBControlSync (udpCreate) for port %u...", specificPort);
     err = PBControlSync((ParmBlkPtr)&pb); // Cast UDPiopb to generic ParmBlkPtr
 
-    log_message("DEBUG: udpCreate returned pb.udpStream=0x%lX, pb.csParam.create.rcvBuff=0x%lX",
-        (unsigned long)pb.udpStream,
-        (unsigned long)pb.csParam.create.rcvBuff);
-    gUDPStream = pb.udpStream; // Assign AFTER logging
+    // Log the state *after* the call
+    log_message("DEBUG: After PBControlSync(udpCreate): err=%d, pb.udpStream=0x%lX, pb.csParam.create.localPort=%u",
+        err, (unsigned long)pb.udpStream, pb.csParam.create.localPort);
 
     if (err != noErr) {
         log_message("Error (InitUDP): PBControlSync(udpCreate) failed. Error: %d", err);
@@ -71,8 +72,19 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
         return err;
     }
 
-    // Retrieve the output StreamPtr from the correct field
+    // --- Retrieve the output StreamPtr from the correct field ---
+    // This is where the core problem likely lies if the log shows the wrong value here.
     gUDPStream = pb.udpStream;
+
+    // Check if the returned stream pointer seems invalid (e.g., NULL or matches buffer)
+    if (gUDPStream == NULL || gUDPStream == (StreamPtr)gUDPRecvBuffer) {
+         log_message("CRITICAL WARNING (InitUDP): udpCreate returned potentially invalid StreamPtr (0x%lX). UDP may fail.", (unsigned long)gUDPStream);
+         // Consider returning an error here? Or proceed cautiously?
+         // For now, let's proceed but the warning is important.
+         // return internalErr; // Example of returning an error
+    }
+
+
     // Retrieve the *actual* port assigned by MacTCP from the localPort field
     unsigned short assignedPort = pb.csParam.create.localPort;
     log_message("UDP Endpoint created successfully (StreamPtr: 0x%lX) on assigned port %u.", (unsigned long)gUDPStream, assignedPort);
@@ -90,8 +102,9 @@ OSErr SendDiscoveryBroadcast(short macTCPRefNum, const char *myUsername, const c
     UDPiopb pb; // Use the specific UDP parameter block structure
     int formatted_len; // To store the length returned by format_message
 
-    if (gUDPStream == NULL) {
-        log_message("Error (SendUDP): Cannot send broadcast, UDP endpoint not initialized.");
+    // Check for the invalid stream pointer *before* attempting to use it
+    if (gUDPStream == NULL || gUDPStream == (StreamPtr)gUDPRecvBuffer) {
+        log_message("Error (SendUDP): Cannot send broadcast, UDP stream pointer is invalid (0x%lX).", (unsigned long)gUDPStream);
         return invalidStreamPtr; // Or another appropriate error
     }
      if (macTCPRefNum == 0) {
@@ -130,12 +143,13 @@ OSErr SendDiscoveryBroadcast(short macTCPRefNum, const char *myUsername, const c
     pb.csParam.send.remotePort = PORT_UDP;       // Destination port
     pb.csParam.send.wdsPtr = (Ptr)wds;           // Pointer to the WDS array
     pb.csParam.send.checkSum = true;             // Calculate and send checksum
+    // pb.csParam.send.sendLength is output only for UDPWrite
 
     // Call PBControlSync
     err = PBControlSync((ParmBlkPtr)&pb); // Cast UDPiopb to generic ParmBlkPtr
 
     if (err != noErr) {
-        log_message("Error (SendUDP): PBControlSync(udpWrite) failed. Error: %d", err);
+        log_message("Error (SendUDP): PBControlSync(udpWrite) failed with stream 0x%lX. Error: %d", (unsigned long)gUDPStream, err);
         return err;
     }
 
@@ -151,8 +165,9 @@ void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *
     // DISCOVERY_INTERVAL is in seconds, TickCount() is 1/60th seconds
     const unsigned long intervalTicks = (unsigned long)DISCOVERY_INTERVAL * 60;
 
-    // Only check if the endpoint is initialized and refnum is valid
-    if (gUDPStream == NULL || macTCPRefNum == 0) return;
+    // Only check if the endpoint appears initialized (stream pointer not NULL)
+    // Add check for potentially invalid stream pointer as well
+    if (gUDPStream == NULL || gUDPStream == (StreamPtr)gUDPRecvBuffer || macTCPRefNum == 0) return;
 
     // Check for timer wraparound (unlikely but possible)
     if (currentTimeTicks < gLastBroadcastTimeTicks) {
@@ -161,118 +176,145 @@ void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *
 
     // Send immediately if never sent before, or if interval has passed
     if (gLastBroadcastTimeTicks == 0 || (currentTimeTicks - gLastBroadcastTimeTicks) >= intervalTicks) {
-        SendDiscoveryBroadcast(macTCPRefNum, myUsername, myLocalIPStr); // Ignore return value for simple periodic broadcast
+        OSErr sendErr = SendDiscoveryBroadcast(macTCPRefNum, myUsername, myLocalIPStr);
+        // Optionally log if send failed, but don't stop periodic checks
+        if (sendErr != noErr) {
+             log_message("Periodic broadcast failed (Error: %d)", sendErr);
+        }
     }
 }
 
 /**
  * @brief Checks for and processes incoming UDP packets (e.g., discovery responses).
  *        Uses PBControlSync with a short timeout for non-blocking checks.
+ *        Includes fix to call UDPBfrReturn after successful read.
  */
 void CheckUDPReceive(short macTCPRefNum, ip_addr myLocalIP) {
     OSErr   err;
-    UDPiopb pb;
-    char    senderIPStrFromHeader[INET_ADDRSTRLEN]; // Renamed: IP from UDP header
-    char    senderIPStrFromPayload[INET_ADDRSTRLEN]; // New: Buffer for parse_message output
+    UDPiopb pbRead; // Use a distinct PB for the read operation
+    char    senderIPStrFromHeader[INET_ADDRSTRLEN];
+    char    senderIPStrFromPayload[INET_ADDRSTRLEN];
     char    senderUsername[32];
     char    msgType[32];
     char    content[BUFFER_SIZE];
-    unsigned short bytesReceived; // Store actual bytes received
+    unsigned short bytesReceived = 0; // Initialize to 0
 
-    // Check if UDP is initialized
-    if (gUDPStream == NULL || macTCPRefNum == 0 || gUDPRecvBuffer == NULL) {
-        return; // Cannot receive if not initialized
+    // Check if UDP is initialized and stream pointer seems valid
+    if (gUDPStream == NULL || gUDPStream == (StreamPtr)gUDPRecvBuffer || macTCPRefNum == 0 || gUDPRecvBuffer == NULL) {
+        return; // Cannot receive if not initialized or stream invalid
     }
 
     // --- Prepare UDPiopb for UDPRead ---
-    memset(&pb, 0, sizeof(UDPiopb));
-    pb.ioCompletion = nil;
-    pb.ioCRefNum = macTCPRefNum;
-    pb.csCode = udpRead;             // Correct code (21)
-    pb.udpStream = gUDPStream;
+    memset(&pbRead, 0, sizeof(UDPiopb));
+    pbRead.ioCompletion = nil;
+    pbRead.ioCRefNum = macTCPRefNum;
+    pbRead.csCode = udpRead;             // Correct code (21)
+    pbRead.udpStream = gUDPStream;       // Use the potentially invalid stream pointer
 
     // These are treated as OUTPUT by UDPRead (csCode 21)
-    // MacTCP will write into gUDPRecvBuffer up to kMinUDPBufSize bytes
-    pb.csParam.receive.rcvBuff = gUDPRecvBuffer;
-    pb.csParam.receive.rcvBuffLen = kMinUDPBufSize; // Max length MacTCP can write
-    pb.csParam.receive.timeOut = 1; // Short timeout for non-blocking check
-    pb.csParam.receive.secondTimeStamp = 0;
-    pb.csParam.receive.remoteHost = 0;
-    pb.csParam.receive.remotePort = 0;
+    pbRead.csParam.receive.rcvBuff = gUDPRecvBuffer;    // Buffer MacTCP writes into
+    pbRead.csParam.receive.rcvBuffLen = kMinUDPBufSize; // Max length MacTCP can write
+    pbRead.csParam.receive.timeOut = 1;                 // Short timeout (in seconds) for non-blocking check
+    pbRead.csParam.receive.secondTimeStamp = 0;         // Not used here
+    // Output fields filled by MacTCP on success:
+    pbRead.csParam.receive.remoteHost = 0;
+    pbRead.csParam.receive.remotePort = 0;
+    // pbRead.csParam.receive.rcvBuffLen is also output
 
     // --- Call PBControlSync to attempt reading ---
-    err = PBControlSync((ParmBlkPtr)&pb);
+    err = PBControlSync((ParmBlkPtr)&pbRead);
 
     // --- Handle Results ---
     if (err == noErr) {
         // --- Packet Received ---
-        ip_addr senderIP = pb.csParam.receive.remoteHost;
+        ip_addr senderIP = pbRead.csParam.receive.remoteHost;
         // Get the ACTUAL number of bytes received from the output parameter
-        bytesReceived = pb.csParam.receive.rcvBuffLen;
+        bytesReceived = pbRead.csParam.receive.rcvBuffLen;
 
-        // Ignore messages from self
-        if (senderIP == myLocalIP) {
-            return;
-        }
-
-        // Convert sender IP (from header) to string using DNR
-        err = AddrToStr(senderIP, senderIPStrFromHeader); // Use renamed buffer
-        if (err != noErr) {
-            log_message("Warning: AddrToStr failed for sender IP %lu (Error: %d). Using raw IP.", senderIP, err);
-            sprintf(senderIPStrFromHeader, "%lu.%lu.%lu.%lu",
-                    (senderIP >> 24) & 0xFF, (senderIP >> 16) & 0xFF,
-                    (senderIP >> 8) & 0xFF, senderIP & 0xFF);
-        }
-
-        // Parse the message content, passing the actual received length
-        // parse_message now checks the magic number first
-        if (parse_message(gUDPRecvBuffer, bytesReceived, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
-            // Check if it's a discovery response
-            if (strcmp(msgType, MSG_DISCOVERY_RESPONSE) == 0) {
-                // Use the reliable IP from the header for adding/updating peer
-                log_message("Received DISCOVERY_RESPONSE from %s@%s", senderUsername, senderIPStrFromHeader);
-                int addResult = AddOrUpdatePeer(senderIPStrFromHeader, senderUsername);
-                if (addResult < 0) {
-                     log_message("Peer list full, could not add %s@%s", senderUsername, senderIPStrFromHeader);
+        // Only process if data was actually received
+        if (bytesReceived > 0) {
+            // Ignore messages from self
+            if (senderIP != myLocalIP) {
+                // Convert sender IP (from header) to string using DNR
+                OSErr addrErr = AddrToStr(senderIP, senderIPStrFromHeader);
+                if (addrErr != noErr) {
+                    log_message("Warning: AddrToStr failed for sender IP %lu (Error: %d). Using raw IP.", senderIP, addrErr);
+                    sprintf(senderIPStrFromHeader, "%lu.%lu.%lu.%lu",
+                            (senderIP >> 24) & 0xFF, (senderIP >> 16) & 0xFF,
+                            (senderIP >> 8) & 0xFF, senderIP & 0xFF);
                 }
-            }
-            // Handle incoming MSG_DISCOVERY requests if needed
-            else if (strcmp(msgType, MSG_DISCOVERY) == 0) {
-                 log_message("Received DISCOVERY from %s@%s", senderUsername, senderIPStrFromHeader);
-                 // TODO: Implement sending a DISCOVERY_RESPONSE back to the sender
-                 // Need a SendUDPResponse function targeting pb.csParam.receive.remoteHost/Port
-                 // Example: SendUDPResponse(macTCPRefNum, pb.csParam.receive.remoteHost, pb.csParam.receive.remotePort, gMyUsername, gMyLocalIPStr);
-            }
-            // else { log_message("Received UDP Msg Type: %s from %s", msgType, senderIPStrFromHeader); }
 
-        } else {
-            // Parse failed - could be invalid magic number or bad format after magic number
-            // Log the failure safely to GUI/main log
-            log_message("Discarding invalid/unknown UDP msg from %s (%u bytes).",
-                        senderIPStrFromHeader, bytesReceived);
-
-            // Log the raw buffer *only* to the file for debugging, printing hex
-            if (gLogFile != NULL) {
-                fprintf(gLogFile, "    Raw Data (%u bytes): [", bytesReceived);
-                // Print hex representation for safety, limit loop to buffer size
-                for (unsigned short i = 0; i < bytesReceived && i < kMinUDPBufSize; ++i) {
-                     unsigned char c = (unsigned char)gUDPRecvBuffer[i];
-                     if (c >= 32 && c <= 126) {
-                         fputc(c, gLogFile);
-                     } else {
-                         fprintf(gLogFile, "\\x%02X", c);
-                     }
+                // Parse the message content, passing the actual received length
+                if (parse_message(gUDPRecvBuffer, bytesReceived, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
+                    // Handle valid messages (DISCOVERY_RESPONSE, DISCOVERY)
+                    if (strcmp(msgType, MSG_DISCOVERY_RESPONSE) == 0) {
+                        log_message("Received DISCOVERY_RESPONSE from %s@%s", senderUsername, senderIPStrFromHeader);
+                        if (AddOrUpdatePeer(senderIPStrFromHeader, senderUsername) < 0) {
+                             log_message("Peer list full, could not add %s@%s", senderUsername, senderIPStrFromHeader);
+                        }
+                    } else if (strcmp(msgType, MSG_DISCOVERY) == 0) {
+                         log_message("Received DISCOVERY from %s@%s", senderUsername, senderIPStrFromHeader);
+                         // TODO: Send DISCOVERY_RESPONSE back
+                         // SendUDPResponse(macTCPRefNum, pbRead.csParam.receive.remoteHost, pbRead.csParam.receive.remotePort, gMyUsername, gMyLocalIPStr);
+                    }
+                    // else { log_message("Received Other UDP Msg Type: %s from %s", msgType, senderIPStrFromHeader); }
+                } else {
+                    // Parse failed (bad magic number or format)
+                    log_message("Discarding invalid/unknown UDP msg from %s (%u bytes).",
+                                senderIPStrFromHeader, bytesReceived);
+                    // Log raw data (optional, for debugging)
+                    if (gLogFile != NULL) {
+                        fprintf(gLogFile, "    Raw Data (%u bytes): [", bytesReceived);
+                        // Print hex representation for safety, limit loop to buffer size
+                        for (unsigned short i = 0; i < bytesReceived && i < kMinUDPBufSize; ++i) {
+                             unsigned char c = (unsigned char)gUDPRecvBuffer[i];
+                             if (c >= 32 && c <= 126) {
+                                 fputc(c, gLogFile);
+                             } else {
+                                 fprintf(gLogFile, "\\x%02X", c);
+                             }
+                        }
+                        fprintf(gLogFile, "]\n");
+                        fflush(gLogFile);
+                    }
                 }
-                fprintf(gLogFile, "]\n");
-                fflush(gLogFile);
-            }
-        }
+            } // End if (senderIP != myLocalIP)
 
-    } else if (err == commandTimeout || err == -23018 /* unofficial readTimeout? */) {
-        // Timeout occurred - this is normal, no packet waiting
+            // --- *** CRITICAL: Return the buffer segment to MacTCP *** ---
+            // This MUST be done after EVERY successful UDPRead that returns data (bytesReceived > 0),
+            // even if the data was ignored (from self) or failed parsing.
+            UDPiopb bfrReturnPB; // Use a separate PB for clarity
+            OSErr returnErr;
+
+            memset(&bfrReturnPB, 0, sizeof(UDPiopb));
+            bfrReturnPB.ioCompletion = nil;
+            bfrReturnPB.ioCRefNum = macTCPRefNum;
+            bfrReturnPB.csCode = udpBfrReturn; // Correct code (22)
+            bfrReturnPB.udpStream = gUDPStream; // Use the (potentially invalid) stream ptr
+
+            // UDPBfrReturn uses the 'rcvBuff' field within the 'receive' union member
+            // to identify the buffer segment being returned. Point it to the start
+            // of the buffer that MacTCP just wrote into.
+            bfrReturnPB.csParam.receive.rcvBuff = gUDPRecvBuffer;
+
+            returnErr = PBControlSync((ParmBlkPtr)&bfrReturnPB);
+            if (returnErr != noErr) {
+                // Log the error, potentially including the invalid gUDPStream value
+                log_message("CRITICAL Error (UDP Receive): PBControlSync(udpBfrReturn) failed with stream 0x%lX. Error: %d. UDP receive may stop working.", (unsigned long)gUDPStream, returnErr);
+                // This is where the -23013 error was likely happening before.
+                // If gUDPStream is invalid, this call will fail.
+            }
+            // --- End of buffer return ---
+
+        } // End if (bytesReceived > 0)
+
+    } else if (err == commandTimeout || err == -23018 /* readTimeout? */ || err == -23015 /* connectionDoesntExist? */) {
+        // Timeout or expected condition - normal, no packet waiting. Nothing to do.
     } else {
         // Some other unexpected error occurred during read attempt
-        log_message("Error (UDP Receive): PBControlSync(udpRead) failed. Error: %d", err);
+        // Log the error, including the stream pointer used
+        log_message("Error (UDP Receive): PBControlSync(udpRead) failed with stream 0x%lX. Error: %d", (unsigned long)gUDPStream, err);
+        // No buffer to return in this case, as the read itself failed.
     }
 }
 
@@ -287,7 +329,8 @@ void CleanupUDPDiscoveryEndpoint(short macTCPRefNum) {
     log_message("Cleaning up UDP Discovery Endpoint...");
 
     // --- Release UDP Endpoint ---
-    if (gUDPStream != NULL) {
+    // Check if stream pointer looks valid before attempting release
+    if (gUDPStream != NULL && gUDPStream != (StreamPtr)gUDPRecvBuffer) {
         if (macTCPRefNum == 0) {
              log_message("Warning (CleanupUDP): Invalid MacTCP RefNum (%d), cannot release UDP stream.", macTCPRefNum);
         } else {
@@ -299,20 +342,23 @@ void CleanupUDPDiscoveryEndpoint(short macTCPRefNum) {
             pb.udpStream = gUDPStream;
 
             // Set the parameters required by UDPRelease
+            // These identify the buffer associated with the stream being released.
             pb.csParam.create.rcvBuff = gUDPRecvBuffer;
-            pb.csParam.create.rcvBuffLen = kMinUDPBufSize;
+            pb.csParam.create.rcvBuffLen = kMinUDPBufSize; // Provide the original size
 
             err = PBControlSync((ParmBlkPtr)&pb);
             if (err != noErr) {
-                log_message("Warning (CleanupUDP): PBControlSync(udpRelease) failed. Error: %d", err);
+                log_message("Warning (CleanupUDP): PBControlSync(udpRelease) failed with stream 0x%lX. Error: %d", (unsigned long)gUDPStream, err);
             } else {
                 log_message("PBControlSync(udpRelease) succeeded.");
             }
         }
-        gUDPStream = NULL; // Mark as released
+    } else if (gUDPStream == (StreamPtr)gUDPRecvBuffer) {
+         log_message("Skipping udpRelease because stream pointer appears invalid (0x%lX).", (unsigned long)gUDPStream);
     } else {
         log_message("UDP Endpoint was not open, skipping release.");
     }
+    gUDPStream = NULL; // Mark as released or invalid regardless
 
     // --- Dispose UDP Receive Buffer ---
     if (gUDPRecvBuffer != NULL) {

--- a/classic_mac/discovery.h
+++ b/classic_mac/discovery.h
@@ -2,8 +2,8 @@
 #ifndef DISCOVERY_H
 #define DISCOVERY_H
 
-#include <MacTypes.h>
 #include <MacTCP.h> // For StreamPtr, UDPiopb, wdsEntry etc.
+#include <MacTypes.h>
 
 #include "common_defs.h" // For PORT_UDP, DISCOVERY_INTERVAL, BUFFER_SIZE, INET_ADDRSTRLEN
 #include "peer_mac.h"    // For AddOrUpdatePeer

--- a/classic_mac/main.c
+++ b/classic_mac/main.c
@@ -19,10 +19,10 @@
 
 // --- Project Includes ---
 #include "logging.h"   // Logging functions (InitLogFile, CloseLogFile, log_message)
-#include "network.h"   // Networking functions (InitializeNetworking, CleanupNetworking)
-#include "discovery.h" // UDP Discovery functions (InitUDPBroadcastEndpoint, CheckSendBroadcast)
-#include "dialog.h"    // Dialog functions (InitDialog, CleanupDialog, HandleDialogClick, etc.)
-#include "peer_mac.h"
+#include "network.h"   // Networking functions (InitializeNetworking, CleanupNetworking, gMacTCPRefNum, gMyLocalIP, gMyLocalIPStr)
+#include "discovery.h" // UDP Discovery functions (InitUDPDiscoveryEndpoint, CheckSendBroadcast, CheckUDPReceive, CleanupUDPDiscoveryEndpoint)
+#include "dialog.h"    // Dialog functions (InitDialog, CleanupDialog, HandleDialogClick, gMyUsername, etc.)
+#include "peer_mac.h"  // Peer list functions (InitPeerList, PruneTimedOutPeers)
 
 // --- Global Variables ---
 Boolean gDone = false; // Controls the main event loop termination
@@ -56,12 +56,13 @@ int main(void) {
         ExitToShell();
         return 1; // Indicate failure
     }
-    // At this point, gMacTCPRefNum should be valid if InitializeNetworking succeeded
+    // At this point, gMacTCPRefNum and gMyLocalIP should be valid if InitializeNetworking succeeded
 
-    // 4. Initialize UDP Broadcast Endpoint (using the ref num from network init)
-    networkErr = InitUDPBroadcastEndpoint(gMacTCPRefNum);
+    // 4. Initialize UDP Discovery Endpoint (using the ref num from network init)
+    // Use the renamed function
+    networkErr = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
     if (networkErr != noErr) {
-        log_message("Fatal: UDP Broadcast initialization failed (Error: %d). Exiting.", networkErr);
+        log_message("Fatal: UDP Discovery initialization failed (Error: %d). Exiting.", networkErr);
         CleanupNetworking(); // Clean up TCP/DNR part (will also attempt UDP cleanup)
         CloseLogFile();      // Close log file
         ExitToShell();
@@ -90,7 +91,7 @@ int main(void) {
 
     // 7. Cleanup Resources
     CleanupDialog();
-    CleanupNetworking(); // Cleans up TCP/DNR and UDP
+    CleanupNetworking(); // Cleans up TCP/DNR and UDP (calls CleanupUDPDiscoveryEndpoint internally)
     CloseLogFile();
 
     return 0;
@@ -119,7 +120,7 @@ void InitializeToolbox(void) {
 void MainEventLoop(void) {
     EventRecord event;
     Boolean     gotEvent;
-    long        sleepTime = 5L; // Sleep time for WaitNextEvent (in ticks)
+    long        sleepTime = 5L; // Sleep time for WaitNextEvent (in ticks), ~1/12 second
 
     while (!gDone) {
         // Allow TextEdit fields to idle
@@ -130,22 +131,35 @@ void MainEventLoop(void) {
         gotEvent = WaitNextEvent(everyEvent, &event, sleepTime, NULL);
 
         if (gotEvent) {
+            // Handle standard dialog events
             if (IsDialogEvent(&event)) {
                 DialogPtr whichDialog;
                 short itemHit;
                 if (DialogSelect(&event, &whichDialog, &itemHit)) {
+                    // Check if it's our dialog and an item was hit
                     if (whichDialog == gMainWindow && itemHit > 0) {
                         HandleDialogClick(whichDialog, itemHit);
                     }
                 }
             } else {
+                // Handle other events (window activation, mouse clicks outside controls, etc.)
                 HandleEvent(&event);
             }
         } else {
-            // --- Idle Time ---
-            // Pass necessary info to CheckSendBroadcast
+            // --- Idle Time: No event received ---
+            // Perform periodic tasks here:
+
+            // 1. Check for incoming UDP packets (Discovery Responses)
+            CheckUDPReceive(gMacTCPRefNum, gMyLocalIP);
+
+            // 2. Send discovery broadcast if necessary
             CheckSendBroadcast(gMacTCPRefNum, gMyUsername, gMyLocalIPStr);
+
+            // 3. Prune timed-out peers from the list
             PruneTimedOutPeers();
+
+            // 4. Give time to other processes (already handled by WaitNextEvent sleepTime)
+            // SystemTask(); // Might be needed on very old systems, but usually WNE is enough
         }
     } // end while(!gDone)
 }
@@ -164,56 +178,75 @@ void HandleEvent(EventRecord *event) {
             switch (windowPart) {
                 case inMenuBar:
                     // log_message("Menu bar clicked (not implemented)."); // Less noisy
+                    // Standard menu handling would go here if menus were added
+                    // MenuSelect(event->where);
+                    // HandleMenuChoice(menuResult);
                     break;
                 case inSysWindow:
                     SystemClick(event, whichWindow);
                     break;
                 case inDrag:
                     if (whichWindow == (WindowPtr)gMainWindow) {
+                        // Use screenBits bounds for dragging area
                         DragWindow(whichWindow, event->where, &qd.screenBits.bounds);
                     }
                     break;
                 case inGoAway:
+                    // Check if the click was in the close box of our window
                     if (whichWindow == (WindowPtr)gMainWindow) {
                         if (TrackGoAway(whichWindow, event->where)) {
                             log_message("Close box clicked. Setting gDone = true.");
-                            gDone = true;
+                            gDone = true; // Set flag to exit main loop
                         }
                     }
                     break;
                 case inContent:
+                    // If clicked in the content region of our window (but not controls)
                     if (whichWindow == (WindowPtr)gMainWindow) {
+                        // If our window isn't frontmost, bring it to front
                         if (whichWindow != FrontWindow()) {
                             SelectWindow(whichWindow);
                         }
+                        // Clicks in TE fields are handled by DialogSelect calling TEClick
                     }
                     break;
                 default:
+                    // Clicks in other regions (zoom box, grow box) ignored for now
                     break;
             }
             break;
 
         case keyDown: case autoKey:
-            // Handled by DialogSelect
+            // These are generally handled by DialogSelect if it's a dialog event.
+            // If we needed global key handling (e.g., command keys not tied to dialog items),
+            // it would go here, checking event->message for the char code.
+            // Example: if ((event->modifiers & cmdKey) != 0) { HandleCommandKey(event->message & charCodeMask); }
             break;
 
         case updateEvt:
+            // The event message points to the window needing update
             whichWindow = (WindowPtr)event->message;
             if (whichWindow == (WindowPtr)gMainWindow) {
-                BeginUpdate(whichWindow);
-                DrawDialog(whichWindow);
-                UpdateDialogTE();
-                EndUpdate(whichWindow);
+                BeginUpdate(whichWindow); // Set clipping region to update area
+                // EraseRgn(whichWindow->visRgn); // Optional: Erase background if needed
+                DrawDialog(whichWindow); // Redraw standard dialog controls (buttons, checkboxes, static text)
+                UpdateDialogTE();        // Redraw TextEdit fields
+                // TODO: Redraw List Manager list if implemented
+                // LUpdate(whichWindow->visRgn, gPeerListHandle);
+                EndUpdate(whichWindow);   // Restore clipping region
             }
             break;
 
         case activateEvt:
+            // The event message points to the window being activated/deactivated
             whichWindow = (WindowPtr)event->message;
             if (whichWindow == (WindowPtr)gMainWindow) {
+                // Check the activeFlag in the event modifiers
                 ActivateDialogTE((event->modifiers & activeFlag) != 0);
             }
             break;
 
+        // Handle other events if necessary (diskEvt, osEvt, etc.)
         default:
             break;
     }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,7 +1,7 @@
 // FILE: ./classic_mac/network.c
 #include "network.h"
 #include "logging.h"   // For log_message
-#include "discovery.h" // Include discovery.h to call CleanupUDPBroadcastEndpoint
+#include "discovery.h" // Include discovery.h to call CleanupUDPDiscoveryEndpoint // <-- Updated comment
 
 #include <Devices.h>   // For PBControlSync, PBOpenSync, CntrlParam, ParmBlkPtr
 #include <Errors.h>    // For error codes
@@ -99,7 +99,8 @@ void CleanupNetworking(void) {
 
     // --- Clean up UDP Endpoint FIRST ---
     // Call the dedicated cleanup function from discovery.c
-    CleanupUDPBroadcastEndpoint(gMacTCPRefNum);
+    // Use the RENAMED function here:
+    CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
 
     // --- Close DNR ---
     log_message("Attempting CloseResolver...");

--- a/classic_mac/network.h
+++ b/classic_mac/network.h
@@ -2,8 +2,9 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
+#include <MacTCP.h>
 #include <MacTypes.h>
-#include <MacTCP.h>          // Include this first. It defines the necessary types.
+
 
 #define __MACTCPCOMMONTYPES__ // Prevent AddressXlation.h from including conflicting types
 #include <AddressXlation.h>  // Needs types defined in MacTCP.h

--- a/codemerge.sh
+++ b/codemerge.sh
@@ -226,21 +226,25 @@ if [ "$strip_comments" = true ]; then echo "Stripping comments from .c/.h: Yes (
 # 0. Add Tree Output if requested
 tree_output_added=false
 if [ "$include_tree" = true ]; then
-    # ... (tree logic remains the same) ...
+    # Construct the ignore pattern dynamically to include the output file name and exclude .sh files
+    ignore_pattern="build|obj|tools|misc|*.md|*.sh|$output_file"
+
     if command -v tree &> /dev/null; then
         echo "Adding project structure (tree .)..."
         {
             echo "#===================================="
             echo "# Project Structure (tree .)"
+            echo "# Excluded: build/, obj/, tools/, misc/, *.md, *.sh, $output_file"
             echo "#===================================="
 
-            if ! tree_output=$(tree -I 'build|obj' . 2>/dev/null) || [ -z "$tree_output" ]; then
+            # Use the dynamically constructed ignore pattern
+            if ! tree_output=$(tree -I "$ignore_pattern" . 2>/dev/null) || [ -z "$tree_output" ]; then
                 echo "# Tree command failed or produced no output. Using simple directory listing:"
-                echo "# Main directories:"
-                find . -type d -maxdepth 1 -not -path "*/\.*" | sort
+                echo "# Main directories (excluding build, obj, tools, misc):"
+                find . -type d -maxdepth 1 -not -path "*/\.*" -not -path "./build" -not -path "./obj" -not -path "./tools" -not -path "./misc" | sort
                 echo "# ----------------"
-                echo "# Files in root:"
-                find . -type f -maxdepth 1 -not -path "*/\.*" | sort
+                echo "# Files in root (excluding .md, .sh, $output_file):"
+                find . -type f -maxdepth 1 -not -path "*/\.*" -not -name '*.md' -not -name '*.sh' -not -name "$output_file" | sort
             else
                 echo "$tree_output"
             fi
@@ -253,15 +257,16 @@ if [ "$include_tree" = true ]; then
         {
             echo "#===================================="
             echo "# Project Structure (simple directory listing)"
+            echo "# Excluded: build/, obj/, tools/, misc/, *.md, *.sh, $output_file"
             echo "#===================================="
-            echo "# Main directories:"
-            find . -type d -maxdepth 1 -not -path "*/\.*" | sort
+            echo "# Main directories (excluding build, obj, tools, misc):"
+            find . -type d -maxdepth 1 -not -path "*/\.*" -not -path "./build" -not -path "./obj" -not -path "./tools" -not -path "./misc" | sort
             echo "# ----------------"
-            echo "# Files in root:"
-            find . -type f -maxdepth 1 -not -path "*/\.*" | sort
+            echo "# Files in root (excluding .md, .sh, $output_file):"
+            find . -type f -maxdepth 1 -not -path "*/\.*" -not -name '*.md' -not -name '*.sh' -not -name "$output_file" | sort
             echo -e "\n#====================================\n"
         } >> "$output_file"
-        tree_output_added=true
+        tree_output_added=true # Mark as added even if it's the fallback
     fi
 fi
 

--- a/posix/discovery.h
+++ b/posix/discovery.h
@@ -1,3 +1,4 @@
+// FILE: ./posix/discovery.h
 // Include guard: Prevents the header file from being included multiple times
 // in the same compilation unit, which would cause redefinition errors.
 #ifndef DISCOVERY_H // If DISCOVERY_H is not defined...
@@ -64,7 +65,8 @@ int broadcast_discovery(app_state_t *state);
  *          information (username, IP) and updates the application's peer list via `add_peer`.
  *          If it's a `MSG_DISCOVERY`, it also sends a `MSG_DISCOVERY_RESPONSE` back to the sender.
  * @param state Pointer to the application state structure (for accessing peer list, username, UDP socket).
- * @param buffer A pointer to the character buffer containing the raw data received from the UDP socket.
+ * @param buffer A pointer to the constant character buffer containing the raw data received from the UDP socket.
+ * @param bytes_read The actual number of bytes received in the buffer. <-- Added parameter
  * @param sender_ip A character buffer (provided by the caller) where the function can optionally
  *                  store the parsed IP address string of the sender. Note: The implementation in
  *                  `discovery.c` primarily relies on the IP obtained from `inet_ntop` in the calling thread.
@@ -77,7 +79,7 @@ int broadcast_discovery(app_state_t *state);
  * @return -1 If the message could not be parsed, was not a relevant discovery message type,
  *            or if adding the peer failed (e.g., list full).
  */
-int handle_discovery_message(app_state_t *state, const char *buffer,
+int handle_discovery_message(app_state_t *state, const char *buffer, int bytes_read, // <-- Added bytes_read
                             char *sender_ip, socklen_t addr_len,
                             struct sockaddr_in *sender_addr);
 

--- a/shared/protocol.c
+++ b/shared/protocol.c
@@ -1,6 +1,6 @@
+// FILE: ./shared/protocol.c
 // Include the header file for this module, which declares the functions defined here
-// and defines message type constants (like MSG_TEXT). It also includes peer.h,
-// providing necessary constants like BUFFER_SIZE and INET_ADDRSTRLEN.
+// and defines message type constants (like MSG_TEXT) and the magic number.
 #include "protocol.h"
 
 // Include the utils header for the log_message() function, used for logging
@@ -14,33 +14,61 @@
 // strncpy: For safely copying strings with length limits.
 // strtok_r: For tokenizing strings (re-entrant version, safe for threads).
 // strchr: For finding characters within strings (used to find '@').
+// memcpy: For copying the magic number bytes.
 #include <string.h>
 
+// Platform-specific includes for byte order conversion
+#ifdef __MACOS__
+    // MacTCP.h or similar might define these, or we do it manually
+    // Manual Big Endian conversion (Network Byte Order is Big Endian)
+    #define my_htonl(l) (l) // Assume Classic Mac is already Big Endian
+    #define my_ntohl(l) (l) // Assume Classic Mac is already Big Endian
+    typedef unsigned long uint32_t; // Define if not available
+#else // POSIX
+    #include <arpa/inet.h> // For htonl, ntohl
+    #include <stdint.h>    // For uint32_t
+    #define my_htonl(l) htonl(l)
+    #define my_ntohl(l) ntohl(l)
+#endif
+
+
 // --- Protocol Definition ---
-// The application uses a simple text-based protocol with fields separated by pipe characters ('|').
-// Format: TYPE|SENDER@IP|CONTENT
-// Example: "TEXT|alice@192.168.1.10|Hello Bob!"
-// Example: "DISCOVERY|bob@192.168.1.11|" (Content can be empty)
+// Format: MAGIC(4 bytes)|TYPE|SENDER@IP|CONTENT
+// MAGIC: Network Byte Order (Big Endian) representation of MSG_MAGIC_NUMBER
+// Example Text Part: "TEXT|alice@192.168.1.10|Hello Bob!"
 
 /**
- * @brief Formats a message according to the application's protocol string format.
- * @details Constructs a string in the format "TYPE|SENDER@IP|CONTENT".
- *          Uses the local IP address provided by the caller.
- * @param buffer A pointer to the character buffer where the formatted message string will be written.
- * @param buffer_size The total size (in bytes) of the `buffer`.
- * @param msg_type A string representing the message type (e.g., "TEXT", "DISCOVERY", "QUIT").
- * @param sender The username of the peer sending the message.
- * @param local_ip_str The local IP address string provided by the caller. Uses "unknown" if NULL or empty.
- * @param content The main payload/content of the message. Can be an empty string.
- * @return 0 on success.
- * @return -1 if the formatted message (including null terminator) would exceed `buffer_size` or on encoding error.
+ * @brief Formats a message including the magic number and protocol string.
+ * @details Writes the 4-byte magic number (network byte order) followed by "TYPE|SENDER@IP|CONTENT".
+ * @param buffer Output buffer.
+ * @param buffer_size Total size of the output buffer.
+ * @param msg_type Message type string.
+ * @param sender Sender username string.
+ * @param local_ip_str Sender's local IP string.
+ * @param content Message content string.
+ * @return Total bytes written (including magic number and null terminator) on success.
+ * @return 0 if buffer_size is too small or on encoding error.
  */
 int format_message(char *buffer, int buffer_size, const char *msg_type,
-                  const char *sender, const char *local_ip_str, const char *content) {
-    char sender_with_ip[BUFFER_SIZE];
+                   const char *sender, const char *local_ip_str, const char *content) {
+    char sender_with_ip[BUFFER_SIZE]; // Consider a smaller, fixed size? e.g., 32 + 1 + 16 = 49
     const char *ip_to_use;
+    uint32_t magic_net_order;
+    int sender_len;
+    int text_part_len;
+    int total_len;
 
-    // Determine which IP string to use (provided or fallback)
+    // --- Basic Validation ---
+    if (buffer == NULL || buffer_size < (int)(sizeof(uint32_t) + 1)) { // Need space for magic + null term at minimum
+        log_message("Error: format_message buffer too small (%d bytes) or NULL.", buffer_size);
+        return 0;
+    }
+
+    // --- Prepare Magic Number ---
+    magic_net_order = my_htonl(MSG_MAGIC_NUMBER);
+    memcpy(buffer, &magic_net_order, sizeof(uint32_t));
+
+    // --- Prepare Sender@IP ---
     if (local_ip_str != NULL && local_ip_str[0] != '\0') {
         ip_to_use = local_ip_str;
     } else {
@@ -48,154 +76,150 @@ int format_message(char *buffer, int buffer_size, const char *msg_type,
         ip_to_use = "unknown";
     }
 
-    // Format the "sender@ip" part using snprintf for safety.
-    int sender_len = snprintf(sender_with_ip, sizeof(sender_with_ip), "%s@%s", sender, ip_to_use);
-     if (sender_len < 0 || sender_len >= (int)sizeof(sender_with_ip)) {
-         log_message("Error: format_message failed formatting sender@ip (buffer too small or encoding error).");
-         return -1;
-     }
-
-    // Format the complete message string: "TYPE|SENDER@IP|CONTENT".
-    int result = snprintf(buffer, buffer_size, "%s|%s|%s",
-                         msg_type, sender_with_ip, content);
-
-    // Check for truncation or encoding errors
-    if (result >= buffer_size) {
-        log_message("Warning: format_message output truncated (buffer size %d, needed %d).", buffer_size, result + 1);
-        return -1;
+    sender_len = snprintf(sender_with_ip, sizeof(sender_with_ip), "%s@%s", sender ? sender : "anon", ip_to_use);
+    if (sender_len < 0 || sender_len >= (int)sizeof(sender_with_ip)) {
+        log_message("Error: format_message failed formatting sender@ip.");
+        return 0;
     }
-     if (result < 0) {
-         log_message("Error: format_message failed formatting final message (encoding error).");
-         return -1;
-     }
 
-    return 0;
+    // --- Format Text Part (after magic number) ---
+    // Calculate remaining buffer space for the text part + null terminator
+    int remaining_buffer_size = buffer_size - sizeof(uint32_t);
+    char *text_buffer_start = buffer + sizeof(uint32_t);
+
+    text_part_len = snprintf(text_buffer_start, remaining_buffer_size, "%s|%s|%s",
+                             msg_type ? msg_type : "UNKNOWN",
+                             sender_with_ip,
+                             content ? content : "");
+
+    // Check for truncation or encoding errors in the text part
+    if (text_part_len >= remaining_buffer_size) {
+        log_message("Warning: format_message text part truncated (buffer size %d, needed %d).", remaining_buffer_size, text_part_len + 1);
+        return 0; // Indicate failure (truncation)
+    }
+    if (text_part_len < 0) {
+        log_message("Error: format_message failed formatting final text part (encoding error).");
+        return 0; // Indicate failure (encoding error)
+    }
+
+    // --- Calculate Total Length ---
+    // Total length includes magic number bytes + text part bytes + null terminator byte
+    total_len = sizeof(uint32_t) + text_part_len + 1;
+
+    // Final sanity check against original buffer size
+    if (total_len > buffer_size) {
+         // This case should theoretically be caught by the snprintf check above, but belt-and-suspenders
+         log_message("Error: format_message internal logic error - total_len > buffer_size.");
+         return 0;
+    }
+
+    return total_len; // Return total bytes written (including null term)
 }
 
-/**
- * @brief Parses an incoming message string according to the application protocol.
- * @details Deconstructs a message string (expected format: "TYPE|SENDER@IP|CONTENT")
- *          into its constituent parts: message type, sender username, sender IP, and content.
- *          It uses `strtok_r` for tokenization, which modifies a temporary copy of the input buffer.
- * @param buffer The constant input character buffer containing the raw message string received from the network.
- * @param sender_ip Output buffer (provided by caller) to store the extracted sender IP address string.
- *                  Should be at least `INET_ADDRSTRLEN` bytes.
- * @param sender_username Output buffer (provided by caller) to store the extracted sender username string.
- *                        Should be at least 32 bytes.
- * @param msg_type Output buffer (provided by caller) to store the extracted message type string.
- *                 Should be at least 32 bytes.
- * @param content Output buffer (provided by caller) to store the extracted message content string.
- *                Should be at least `BUFFER_SIZE` bytes (or large enough for expected content).
- * @return 0 on successful parsing of all expected parts.
- * @return -1 on parsing failure, typically indicating the input `buffer` does not conform
- *         to the expected "TYPE|SENDER@IP|CONTENT" format (e.g., missing '|' delimiters).
- * @note Assumes output buffers are sufficiently large. Uses `strncpy` for safety when copying
- *       extracted parts, but relies on the caller providing adequate buffer sizes.
- * @warning Does not perform deep validation (e.g., checking if IP is valid format, username chars).
- */
-int parse_message(const char *buffer, char *sender_ip, char *sender_username, char *msg_type, char *content) {
-    // Pointer used by strtok_r to store the next token.
-    char *token;
-    // Pointer used by strtok_r to keep track of the remaining string being tokenized.
-    char *rest;
-    // Temporary buffer to hold a mutable copy of the input buffer, as strtok_r modifies the string it parses.
-    char temp[BUFFER_SIZE];
-    // Temporary buffer to hold the extracted "SENDER@IP" part before splitting it further.
-    char sender_with_ip[BUFFER_SIZE]; // Again, consider smaller size?
 
-    // --- Pre-parsing setup ---
-    // Clear output buffers initially (optional, but good practice)
+/**
+ * @brief Parses an incoming message string after verifying the magic number.
+ * @details Checks for magic number, then parses "TYPE|SENDER@IP|CONTENT" from the rest.
+ * @param buffer The constant input buffer containing raw network data.
+ * @param buffer_len The actual number of bytes received in the buffer.
+ * @param sender_ip Output buffer for sender IP.
+ * @param sender_username Output buffer for sender username.
+ * @param msg_type Output buffer for message type.
+ * @param content Output buffer for message content.
+ * @return 0 on success.
+ * @return -1 if magic number is missing/wrong, buffer_len too short, or parsing fails.
+ */
+int parse_message(const char *buffer, int buffer_len, char *sender_ip, char *sender_username,
+                  char *msg_type, char *content) {
+    char *token;
+    char *rest;
+    // Temp buffer for the TEXT part only (after magic number)
+    char temp_text_part[BUFFER_SIZE];
+    char sender_with_ip[BUFFER_SIZE]; // Consider smaller size?
+    uint32_t received_magic;
+    const char *text_part_start;
+    int text_part_len;
+
+    // --- Clear output buffers initially ---
     sender_ip[0] = '\0';
     sender_username[0] = '\0';
     msg_type[0] = '\0';
     content[0] = '\0';
 
-
-    // Create a mutable copy of the input buffer.
-    // Use strncpy to avoid overflow if the input `buffer` is unexpectedly large (though unlikely if read into BUFFER_SIZE).
-    strncpy(temp, buffer, BUFFER_SIZE - 1);
-    // Ensure the temporary copy is null-terminated.
-    temp[BUFFER_SIZE - 1] = '\0';
-
-    // --- Parse Message Type (Part 1) ---
-    // Get the first token using '|' as the delimiter.
-    // `strtok_r` is thread-safe compared to `strtok`.
-    // `temp`: The string to tokenize (will be modified).
-    // "|": The delimiter characters.
-    // `&rest`: Pointer to save the context for subsequent calls.
-    token = strtok_r(temp, "|", &rest);
-    if (token == NULL) {
-        // If the first token is NULL, the string is empty or doesn't contain '|'. Invalid format.
-        log_message("Parse error: Could not find message type token.");
+    // --- Step 1: Check Magic Number ---
+    if (buffer == NULL || buffer_len < (int)sizeof(uint32_t)) {
+        // Not enough data even for the magic number
+        // log_message("Parse error: Received packet too short for magic number (%d bytes).", buffer_len); // Can be noisy
         return -1;
     }
-    // Copy the extracted type token into the output buffer, ensuring safety and null termination.
-    // Assuming msg_type buffer is 32 bytes.
+
+    // Read the magic number from the start of the buffer
+    memcpy(&received_magic, buffer, sizeof(uint32_t));
+    received_magic = my_ntohl(received_magic); // Convert from network to host order
+
+    if (received_magic != MSG_MAGIC_NUMBER) {
+        // Magic number mismatch - likely unrelated packet
+        // log_message("Parse error: Invalid magic number (Expected 0x%lX, Got 0x%lX). Discarding.", MSG_MAGIC_NUMBER, received_magic); // Can be noisy
+        return -1;
+    }
+
+    // --- Step 2: Prepare for Text Part Parsing ---
+    text_part_start = buffer + sizeof(uint32_t);
+    // Calculate the length of the text part (including potential null terminator if present)
+    text_part_len = buffer_len - sizeof(uint32_t);
+
+    // Create a mutable, null-terminated copy of the text part for strtok_r
+    if (text_part_len >= BUFFER_SIZE) {
+        log_message("Parse warning: Text part length (%d) exceeds temp buffer (%d). Truncating.", text_part_len, BUFFER_SIZE - 1);
+        text_part_len = BUFFER_SIZE - 1; // Prevent overflow
+    }
+    strncpy(temp_text_part, text_part_start, text_part_len);
+    temp_text_part[text_part_len] = '\0'; // Ensure null termination for strtok_r
+
+    // --- Step 3: Parse Message Type (from text part) ---
+    token = strtok_r(temp_text_part, "|", &rest);
+    if (token == NULL) {
+        log_message("Parse error: Could not find message type token after magic number.");
+        return -1;
+    }
     strncpy(msg_type, token, 31);
     msg_type[31] = '\0';
 
-    // --- Parse Sender@IP (Part 2) ---
-    // Get the next token (the part between the first and second '|').
-    // Pass NULL as the first argument to continue tokenizing the same string (`rest` maintains context).
+    // --- Step 4: Parse Sender@IP (from text part) ---
     token = strtok_r(NULL, "|", &rest);
     if (token == NULL) {
-        // If the second token is NULL, the required SENDER@IP part is missing. Invalid format.
-        log_message("Parse error: Could not find sender@ip token.");
+        log_message("Parse error: Could not find sender@ip token after magic number.");
         return -1;
     }
-    // Copy the extracted "sender@ip" token into a temporary buffer for further processing.
-    // Using BUFFER_SIZE is safe but potentially wasteful.
     strncpy(sender_with_ip, token, sizeof(sender_with_ip) - 1);
-    sender_with_ip[sizeof(sender_with_ip) - 1] = '\0'; // Ensure null termination
+    sender_with_ip[sizeof(sender_with_ip) - 1] = '\0';
 
-    // --- Split Sender@IP into Username and IP ---
-    // Find the '@' character within the "sender@ip" string.
+    // --- Step 5: Split Sender@IP ---
     char *at_sign = strchr(sender_with_ip, '@');
     if (at_sign != NULL) {
-        // '@' sign found.
-
-        // Calculate the length of the username part (characters before '@').
         int username_len = at_sign - sender_with_ip;
-        // Copy the username part into the output buffer.
-        // Ensure the length doesn't exceed the buffer size (31 chars + null term).
-        if (username_len > 31) username_len = 31; // Cap length if needed
+        if (username_len > 31) username_len = 31;
         strncpy(sender_username, sender_with_ip, username_len);
-        sender_username[username_len] = '\0'; // Manually null-terminate.
+        sender_username[username_len] = '\0';
 
-        // Copy the IP address part (characters after '@') into the output buffer.
-        // `at_sign + 1` points to the character immediately after '@'.
-        // Ensure safety with strncpy and null termination.
         strncpy(sender_ip, at_sign + 1, INET_ADDRSTRLEN - 1);
         sender_ip[INET_ADDRSTRLEN - 1] = '\0';
-
     } else {
-        // '@' sign not found in the second token. This might be an error, or maybe
-        // the protocol allows just a username or IP sometimes?
-        // Current behavior: Assume the whole token is the username and IP is unknown.
         log_message("Parse warning: '@' not found in sender token '%s'. Treating as username.", sender_with_ip);
-        strncpy(sender_username, sender_with_ip, 31); // Copy token as username
+        strncpy(sender_username, sender_with_ip, 31);
         sender_username[31] = '\0';
-        strcpy(sender_ip, "unknown"); // Set IP as unknown
-        // Depending on requirements, might want to return -1 here if '@' is mandatory.
+        strcpy(sender_ip, "unknown");
     }
 
-    // --- Parse Content (Part 3) ---
-    // Get the rest of the string after the second '|' as the content.
-    // Using "" as delimiters tells strtok_r to return the remainder of the string.
-    // Note: If the original string was "TYPE|SENDER@IP|", `rest` points to an empty string,
-    // and `token` will be that empty string. If it was "TYPE|SENDER@IP", `rest` is NULL,
-    // and `token` will be NULL.
+    // --- Step 6: Parse Content (from text part) ---
     token = strtok_r(NULL, "", &rest); // Get the remainder
     if (token == NULL) {
-        // No content part found (e.g., message ended after SENDER@IP).
-        // Set content to an empty string.
-        content[0] = '\0';
+        content[0] = '\0'; // No content part
     } else {
-        // Copy the content token into the output buffer.
+        // Use BUFFER_SIZE for the content buffer limit
         strncpy(content, token, BUFFER_SIZE - 1);
-        content[BUFFER_SIZE - 1] = '\0'; // Ensure null termination.
+        content[BUFFER_SIZE - 1] = '\0';
     }
 
-    // All parts parsed successfully (or handled gracefully).
-    return 0;
+    return 0; // Success
 }

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -1,3 +1,4 @@
+// FILE: ./shared/protocol.h
 // Include guard: Prevents the header file from being included multiple times
 // in the same compilation unit, which would cause errors due to redefinitions.
 #ifndef PROTOCOL_H // If PROTOCOL_H is not defined...
@@ -7,6 +8,17 @@
 // - BUFFER_SIZE: Defines the expected maximum size for message content and temporary buffers used in protocol.c.
 // - INET_ADDRSTRLEN: Defines the necessary size for buffers holding IPv4 address strings (used in parse_message output).
 #include "common_defs.h"
+
+#ifdef __MACOS__
+    #include <MacTypes.h> // For uint32_t equivalent on Classic Mac
+#else
+    #include <stdint.h>   // For uint32_t on POSIX
+#endif
+
+// --- Magic Number ---
+// A 4-byte sequence ('CSDC') prepended to all valid UDP/TCP messages
+// to allow quick filtering of unrelated packets. Stored in Network Byte Order (Big Endian).
+#define MSG_MAGIC_NUMBER 0x43534443UL // 'C' 'S' 'D' 'C'
 
 // --- Message Type Constants ---
 // Define string constants representing the different types of messages used in the protocol.
@@ -25,30 +37,34 @@
 // These declare the functions implemented in protocol.c, making them available to other modules.
 
 /**
- * @brief Formats message components into a single string according to the application protocol.
- * @details Constructs a string following the format: "TYPE|SENDER@IP|CONTENT".
+ * @brief Formats message components into a single string according to the application protocol,
+ *        including prepending the magic number.
+ * @details Constructs a string starting with the 4-byte MSG_MAGIC_NUMBER, followed by
+ *          the format: "TYPE|SENDER@IP|CONTENT".
  *          The caller must provide the local IP address to be embedded.
  *          This function is used before sending any message (discovery, text, quit) over the network.
  * @param buffer Pointer to the character buffer where the resulting formatted string will be written.
- *               The caller must provide a buffer large enough.
- * @param buffer_size The total size (in bytes) of the `buffer`.
+ *               The caller must provide a buffer large enough (at least 4 bytes larger than before).
+ * @param buffer_size The total size (in bytes) of the `buffer`. Must be >= 4.
  * @param msg_type A string representing the message type (e.g., MSG_TEXT).
  * @param sender The username of the peer sending the message.
  * @param local_ip_str A string containing the local IP address of the sender (e.g., "192.168.1.10").
  *                     If NULL or empty, "unknown" will be used.
  * @param content The payload or content of the message.
- * @return 0 on successful formatting.
- * @return -1 if the formatted message would exceed `buffer_size` or on encoding error.
+ * @return The total number of bytes written to the buffer (including magic number and null terminator) on success.
+ * @return 0 if the formatted message would exceed `buffer_size` or on encoding error.
  */
 int format_message(char *buffer, int buffer_size, const char *msg_type,
-    const char *sender, const char *local_ip_str, const char *content); // Added local_ip_str
+                   const char *sender, const char *local_ip_str, const char *content); // Added local_ip_str
 
 /**
- * @brief Parses an incoming message string received from the network into its components.
- * @details Deconstructs a string assumed to be in the format "TYPE|SENDER@IP|CONTENT".
- *          It extracts the message type, the sender's username, the sender's IP address,
- *          and the message content into separate output buffers provided by the caller.
+ * @brief Parses an incoming message string received from the network into its components,
+ *        after verifying the magic number.
+ * @details First checks if the buffer starts with the 4-byte MSG_MAGIC_NUMBER. If not, returns -1.
+ *          If the magic number is present, it deconstructs the *rest* of the string (assumed to be
+ *          in the format "TYPE|SENDER@IP|CONTENT") into its components.
  * @param buffer A pointer to the constant character buffer containing the raw message string received.
+ * @param buffer_len The actual length of the data received in the buffer (important for magic number check).
  * @param sender_ip Pointer to an output character buffer (allocated by caller) where the extracted
  *                  sender IP address string will be stored. **Caller must ensure this buffer is at least `INET_ADDRSTRLEN` bytes.**
  * @param sender_username Pointer to an output character buffer (allocated by caller) where the extracted
@@ -58,10 +74,11 @@ int format_message(char *buffer, int buffer_size, const char *msg_type,
  * @param content Pointer to an output character buffer (allocated by caller) where the extracted
  *                message content string will be stored. **Caller must ensure this buffer is large enough for expected content (e.g., `BUFFER_SIZE` bytes).**
  * @return 0 on successful parsing of all components according to the expected format.
- * @return -1 if the input `buffer` does not conform to the "TYPE|SENDER@IP|CONTENT" structure
- *         (e.g., missing '|' delimiters), indicating a parsing failure. Output buffers may contain partial or invalid data on failure.
+ * @return -1 if the magic number is missing, the input `buffer` does not conform to the
+ *         "TYPE|SENDER@IP|CONTENT" structure after the magic number, or buffer_len is too short.
+ *         Output buffers may contain partial or invalid data on failure.
  */
-int parse_message(const char *buffer, char *sender_ip, char *sender_username,
-                 char *msg_type, char *content);
+int parse_message(const char *buffer, int buffer_len, char *sender_ip, char *sender_username,
+                  char *msg_type, char *content); // Added buffer_len parameter
 
 #endif // End of the include guard PROTOCOL_H


### PR DESCRIPTION

## [v0.0.11](https://github.com/matthewdeaves/csend/tree/v0.0.11)

This version focuses on debugging the UDP discovery mechanism on the Classic Mac target using MacTCP and the Retro68 toolchain. Significant progress was made in understanding a core structure alignment issue, although a critical problem remains and is [documented here](/bugs.md). The shared message protocol implementation was also refined with basic validation. The most likely course of action I'll take next is to compile the classic Mac version using the MPW on Mac OS 7.5.3.

**Key Changes & Findings:**

1.  **Classic Mac UDP Debugging & Alignment:**
    *   **Compiler Flags:** Added GCC flag `-fpack-struct` to address issues where `PBControlSync` calls to MacTCP, specifically `udpCreate`, were not correctly returning the `StreamPtr`.
    *   **`-fpack-struct`:** Adding this flag to the Classic Mac build (`Makefile.classicmac`) resolved the initial issue where `udpCreate` returned `0L` in `pb.udpStream`. The call now returns `noErr` and `pb.udpStream` receives a non-zero value.
    *   **Incorrect `StreamPtr`:** Debugging revealed that the non-zero value returned in `pb.udpStream` by `udpCreate` (when compiled with Retro68 + `-fpack-struct`) is actually the memory address of the user-provided receive buffer (`gUDPRecvBuffer`), *not* the expected opaque pointer to MacTCP's internal stream control block.
    *   **`udpRead` Success:** With the non-zero (though incorrect) stream identifier, `udpRead` calls now successfully receive incoming UDP packets.
    *   **`udpBfrReturn` Failure Persists:**
        *   **Critical Issue:** Despite `udpRead` succeeding, the necessary follow-up call to `udpBfrReturn` (to return the buffer segment to MacTCP) **consistently fails** with error `-23013` (`invalidBufPtr`).
        *   **Reason:** This occurs because the `StreamPtr` value passed to `udpBfrReturn` (which is the buffer address obtained from `udpCreate`) is not the correct internal identifier MacTCP needs to manage its buffer queue for that stream. MacTCP essentially reports that the buffer doesn't belong to the stream identified by that specific pointer value.
    *   **`udpRelease` Success:** The `udpRelease` call during cleanup *does* succeed when passed the buffer address as the `udpStream`. This might be because `udpRelease` also takes the buffer pointer and length as explicit parameters within the `csParam.create` part of the union, allowing it to identify the resources to free even with the incorrect stream pointer.
    *   **Application Logic Updated:** The checking logic in `classic_mac/discovery.c` around the value of `gUDPStream` after `udpCreate` and before `udpRelease` was updated to reflect the current understanding (i.e., expecting the buffer address is incorrect, but non-NULL is required for release).

2.  **Message Protocol Implementation Refinement:**
    *   The shared protocol functions (`shared/protocol.c`) were updated.
    *   **Magic Number:** Introduced `MSG_MAGIC_NUMBER` (`0x43534443UL` / `CSDC`) at the beginning of formatted messages (`format_message`). The `parse_message` function now checks for this magic number as a basic validation step before attempting to parse the rest of the message, helping to quickly discard unrelated UDP packets. CSDC was chosen for 'CSendChat'.
    *   Used safer string handling (`snprintf`, `strncpy`, `strtok_r`) and more robust parsing logic for the `MAGIC|TYPE|SENDER@IP|CONTENT` format. [0]
    *   Added error checking and logging within `format_message` and `parse_message` for better diagnostics.

**Current State:**

*   **POSIX:** Mostly unchanged from v0.0.10, fully functional regarding peer discovery and basic TCP messaging, incorporating the magic number protocol change.
*   **Classic Mac:**
    *   Builds successfully with `-fpack-struct`.
    *   TCP listener setup: Works.
    *   UDP endpoint creation (`udpCreate`): Returns `noErr` but provides an incorrect `StreamPtr` (buffer address).
    *   UDP discovery broadcast sending (`udpWrite`): Works (sends messages with magic number).
    *   UDP packet reception (`udpRead`): Works (packets arrive).
    *   UDP message parsing (`parse_message`): Works, including magic number check.
    *   **UDP buffer return (`udpBfrReturn`): FAILS (-23013).** This is the critical blocker, preventing reliable UDP reception as buffers cannot be returned to MacTCP.
    *   UDP endpoint release (`udpRelease`): Works.
    *   Peer list management (shared logic): Integrated and functional based on available data.
    *   Receiving/Processing `MSG_DISCOVERY_RESPONSE`: **Blocked** by the `udpBfrReturn` issue.
    *   Sending `MSG_QUIT`: **Not implemented.**