### PR TITLE
Refactor: Centralize peer list using peer_manager_t

### DIFF
--- a/classic_mac/dialog_peerlist.c
+++ b/classic_mac/dialog_peerlist.c
@@ -141,21 +141,21 @@ void UpdatePeerDisplayList(Boolean forceRedraw) {
     }
     int newSelectionIndex = -1;
     for (int i = 0; i < MAX_PEERS; i++) {
-        if (gPeerList[i].active) {
-            const char *displayName = (gPeerList[i].username[0] != '\0') ? gPeerList[i].username : "???";
-            sprintf(peerStr, "%s@%s", displayName, gPeerList[i].ip);
+        if (gPeerManager.peers[i].active) {
+            const char *displayName = (gPeerManager.peers[i].username[0] != '\0') ? gPeerManager.peers[i].username : "???";
+            sprintf(peerStr, "%s@%s", displayName, gPeerManager.peers[i].ip);
             LAddRow(1, activePeerCount, gPeerListHandle);
             SetPt(&theCell, 0, activePeerCount);
             LSetCell(peerStr, strlen(peerStr), theCell, gPeerListHandle);
-            if (hadOldSelection && strcmp(gPeerList[i].ip, oldSelectedPeerData.ip) == 0) {
+            if (hadOldSelection && strcmp(gPeerManager.peers[i].ip, oldSelectedPeerData.ip) == 0) {
                  newSelectionIndex = activePeerCount;
                  selectionStillValid = true;
             }
             activePeerCount++;
         }
     }
-     (**gPeerListHandle).dataBounds.bottom = activePeerCount;
-     if (selectionStillValid && newSelectionIndex >= 0) {
+    (**gPeerListHandle).dataBounds.bottom = activePeerCount;
+    if (selectionStillValid && newSelectionIndex >= 0) {
          SetPt(&theCell, 0, newSelectionIndex);
          LSetSelect(true, theCell, gPeerListHandle);
          gLastSelectedCell = theCell;
@@ -165,9 +165,9 @@ void UpdatePeerDisplayList(Boolean forceRedraw) {
             log_to_file_only("UpdatePeerDisplayList: Selection invalidated or no previous selection.");
          }
          SetPt(&gLastSelectedCell, 0, -1);
-         Cell tempCell = {0,0};
          if (activePeerCount > 0) {
-             LSetSelect(false, tempCell, gPeerListHandle);
+             Cell firstCell = {0, 0};
+             LSetSelect(false, firstCell, gPeerListHandle);
          }
      }
     HSetState((Handle)gPeerListHandle, listState);

--- a/classic_mac/peer_mac.h
+++ b/classic_mac/peer_mac.h
@@ -1,8 +1,9 @@
 #ifndef PEER_MAC_H
 #define PEER_MAC_H 
 #include <MacTypes.h>
-#include "common_defs.h"
-extern peer_t gPeerList[MAX_PEERS];
+#include "../shared/common_defs.h"
+#include "../shared/peer_shared.h"
+extern peer_manager_t gPeerManager;
 void InitPeerList(void);
 int AddOrUpdatePeer(const char *ip, const char *username);
 Boolean MarkPeerInactive(const char *ip);

--- a/posix/peer.h
+++ b/posix/peer.h
@@ -3,10 +3,11 @@
 #include <time.h>
 #include <pthread.h>
 #include <signal.h>
-#include "common_defs.h"
+#include "../shared/common_defs.h"
+#include "../shared/peer_shared.h"
 typedef struct app_state_t {
     volatile sig_atomic_t running;
-    peer_t peers[MAX_PEERS];
+    peer_manager_t peer_manager;
     int tcp_socket;
     int udp_socket;
     char username[32];

--- a/shared/peer_shared.h
+++ b/shared/peer_shared.h
@@ -1,10 +1,13 @@
 #ifndef PEER_SHARED_H
 #define PEER_SHARED_H 
 #include "common_defs.h"
-void peer_shared_init_list(peer_t *peers, int max_peers);
-int peer_shared_find_by_ip(peer_t *peers, int max_peers, const char *ip);
-int peer_shared_find_empty_slot(peer_t *peers, int max_peers);
+typedef struct {
+    peer_t peers[MAX_PEERS];
+} peer_manager_t;
+void peer_shared_init_list(peer_manager_t *manager);
+int peer_shared_find_by_ip(peer_manager_t *manager, const char *ip);
+int peer_shared_find_empty_slot(peer_manager_t *manager);
 void peer_shared_update_entry(peer_t *peer, const char *username);
-int peer_shared_add_or_update(peer_t *peers, int max_peers, const char *ip, const char *username);
-int peer_shared_prune_timed_out(peer_t *peers, int max_peers);
+int peer_shared_add_or_update(peer_manager_t *manager, const char *ip, const char *username);
+int peer_shared_prune_timed_out(peer_manager_t *manager);
 #endif


### PR DESCRIPTION
Introduced peer_manager_t struct in shared/peer_shared.h to hold the peer_t peers[MAX_PEERS] array.

Updated shared/peer_shared.c functions to operate on peer_manager_t*.

POSIX: Replaced peers array in app_state_t (posix/peer.h) with peer_manager_t. Updated posix/peer.c wrappers (add_peer, prune_peers) to use the manager while maintaining mutex locking. Updated peer data access in posix/ui_terminal.c and posix/messaging.c.

Classic Mac: Replaced global gPeerList (classic_mac/peer_mac.h/.c) with global gPeerManager. Updated Mac peer functions to call shared functions using gPeerManager. Updated peer data access in classic_mac/dialog_peerlist.c.

This centralizes peer data management, improving code sharing and consistency across platforms