### PR TITLE
Tcp fixing

### DIFF
--- a/classic_mac/dialog.c
+++ b/classic_mac/dialog.c
@@ -1,13 +1,13 @@
 #include "dialog.h"
 #include "logging.h"
-#include "network.h" // Includes YieldTimeToSystem, gMyUsername, gMyLocalIPStr
+#include "network.h"
 #include "protocol.h"
 #include "peer_mac.h"
 #include "common_defs.h"
 #include "dialog_messages.h"
 #include "dialog_input.h"
 #include "dialog_peerlist.h"
-#include "tcp.h"       // Includes TCP_SendTextMessageSync, GetTCPState, streamBusyErr
+#include "tcp.h"
 #include <MacTypes.h>
 #include <Dialogs.h>
 #include <TextEdit.h>
@@ -22,20 +22,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <Errors.h> // For standard error codes
-
+#include <Errors.h>
 DialogPtr gMainWindow = NULL;
 Boolean gDialogTEInitialized = false;
 Boolean gDialogListInitialized = false;
-// gMyUsername is extern from network.h
-// gLastSelectedCell is extern from dialog_peerlist.h
-
-// InitDialog remains unchanged
 Boolean InitDialog(void) {
     Boolean messagesOk = false;
     Boolean inputOk = false;
     Boolean listOk = false;
-
     log_message("Loading dialog resource ID %d...", kBaseResID);
     gMainWindow = GetNewDialog(kBaseResID, NULL, (WindowPtr)-1L);
     if (gMainWindow == NULL) {
@@ -43,60 +37,44 @@ Boolean InitDialog(void) {
         return false;
     }
     log_message("Dialog loaded successfully (gMainWindow: 0x%lX).", (unsigned long)gMainWindow);
-
     ShowWindow(gMainWindow);
     SelectWindow(gMainWindow);
     SetPort((GrafPtr)gMainWindow);
     log_message("Window shown, selected, port set.");
-
     messagesOk = InitMessagesTEAndScrollbar(gMainWindow);
     inputOk = InitInputTE(gMainWindow);
     listOk = InitPeerListControl(gMainWindow);
-
     gDialogTEInitialized = (messagesOk && inputOk);
     gDialogListInitialized = listOk;
-
     if (!gDialogTEInitialized || !gDialogListInitialized) {
         log_message("Error: One or more dialog components failed to initialize. Cleaning up.");
         CleanupDialog();
         return false;
     }
-
     UpdatePeerDisplayList(true);
-
     log_message("Setting focus to input field (item %d)...", kInputTextEdit);
     ActivateInputTE(true);
-
     log_message("InitDialog finished successfully.");
     return true;
 }
-
-// CleanupDialog remains unchanged
 void CleanupDialog(void) {
     log_message("Cleaning up Dialog...");
-
     CleanupPeerListControl();
     CleanupInputTE();
     CleanupMessagesTEAndScrollbar();
-
     if (gMainWindow != NULL) {
         log_message("Disposing dialog window...");
         DisposeDialog(gMainWindow);
         gMainWindow = NULL;
     }
-
     gDialogTEInitialized = false;
     gDialogListInitialized = false;
     log_message("Dialog cleanup complete.");
 }
-
-// HandleDialogClick remains unchanged
 void HandleDialogClick(DialogPtr dialog, short itemHit, EventRecord *theEvent) {
     if (dialog != gMainWindow) return;
     log_to_file_only("HandleDialogClick called for item %d (Potentially redundant).", itemHit);
 }
-
-// HandleSendButtonClick - UPDATED error handling
 void HandleSendButtonClick(void) {
     char inputCStr[256];
     ControlHandle checkboxHandle;
@@ -105,8 +83,7 @@ void HandleSendButtonClick(void) {
     Rect itemRect;
     Boolean isBroadcast;
     char displayMsg[BUFFER_SIZE + 100];
-    OSErr sendErr = noErr; // Initialize error status
-
+    OSErr sendErr = noErr;
     if (!GetInputText(inputCStr, sizeof(inputCStr))) {
         log_message("Error: Could not get text from input field.");
         SysBeep(10);
@@ -114,10 +91,8 @@ void HandleSendButtonClick(void) {
     }
     if (strlen(inputCStr) == 0) {
         log_message("Send Action: Input field is empty.");
-        return; // Don't send empty messages
+        return;
     }
-
-    // Get broadcast checkbox state
     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
     if (itemType == (ctrlItem + chkCtrl)) {
         checkboxHandle = (ControlHandle)itemHandle;
@@ -127,35 +102,27 @@ void HandleSendButtonClick(void) {
         log_message("Warning: Broadcast item %d is not a checkbox! Assuming not broadcast.", kBroadcastCheckbox);
         isBroadcast = false;
     }
-
     if (isBroadcast) {
         log_message("Broadcasting: '%s' (Broadcast send not implemented)", inputCStr);
         sprintf(displayMsg, "You (Broadcast): %s", inputCStr);
         AppendToMessagesTE(displayMsg);
         AppendToMessagesTE("\r");
-        // Add actual broadcast logic here if needed (e.g., UDP broadcast)
     } else {
         peer_t targetPeer;
         if (GetSelectedPeerInfo(&targetPeer)) {
             log_message("Attempting sync send to selected peer %s@%s: '%s'",
                          targetPeer.username, targetPeer.ip, inputCStr);
-
-            // Use the SYNC send function that now uses the single stream
             sendErr = TCP_SendTextMessageSync(targetPeer.ip, inputCStr, YieldTimeToSystem);
-
             if (sendErr == noErr) {
-                // Successfully SENT message
                 sprintf(displayMsg, "You (to %s): %s", targetPeer.username, inputCStr);
                 AppendToMessagesTE(displayMsg);
                 AppendToMessagesTE("\r");
                 log_message("Sync send completed successfully.");
             }
-            // *** ADDED: Handle stream busy error specifically ***
             else if (sendErr == streamBusyErr) {
                 log_message("Send failed: Stream is busy (receiving or sending). Please try again later.");
-                SysBeep(5); // Different beep? Or just log?
+                SysBeep(5);
             }
-            // Handle other errors
             else {
                 log_message("Error sending message to %s: %d", targetPeer.ip, sendErr);
                 SysBeep(10);
@@ -163,44 +130,32 @@ void HandleSendButtonClick(void) {
         } else {
              log_message("Error: Cannot send, no peer selected in the list or selection invalid.");
              SysBeep(10);
-             return; // Don't clear input if no peer selected
+             return;
         }
     }
-
-    // Clear input field only if broadcast or send succeeded (not if busy or error)
     if (isBroadcast || sendErr == noErr) {
         ClearInputText();
     }
-    // Ensure input field keeps focus
     ActivateInputTE(true);
 }
-
-// ActivateDialogTE remains unchanged
 void ActivateDialogTE(Boolean activating) {
     ActivateMessagesTEAndScrollbar(activating);
     ActivateInputTE(activating);
 }
-
-// UpdateDialogControls remains unchanged
 void UpdateDialogControls(void) {
     GrafPtr oldPort;
     GrafPtr windowPort = GetWindowPort(gMainWindow);
-
     if (windowPort == NULL) {
         log_message("UpdateDialogControls Error: Window port is NULL!");
         return;
     }
-
     GetPort(&oldPort);
     SetPort(windowPort);
-
     HandleMessagesTEUpdate(gMainWindow);
     HandleInputTEUpdate(gMainWindow);
     HandlePeerListUpdate(gMainWindow);
-
     if (gMessagesScrollBar != NULL) {
         Draw1Control(gMessagesScrollBar);
     }
-
     SetPort(oldPort);
 }

--- a/classic_mac/discovery.c
+++ b/classic_mac/discovery.c
@@ -1,176 +1,255 @@
+//====================================
+// FILE: ./classic_mac/discovery.c
+//====================================
+
 #include "discovery.h"
 #include "logging.h"
 #include "protocol.h"
 #include "../shared/discovery_logic.h"
 #include "peer_mac.h"
-#include "network.h"
-#include "dialog.h"
-#include "dialog_peerlist.h"
+#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, AddrToStr
+#include "dialog.h"  // For gMainWindow
+#include "dialog_peerlist.h" // For gPeerListHandle, UpdatePeerDisplayList
 #include <Devices.h>
 #include <Errors.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <Memory.h>
-#include <stddef.h>
+#include <stddef.h> // For offsetof if needed, though not directly used
 #include <MacTCP.h>
-#include <AddressXlation.h>
-extern OSErr AddrToStr(unsigned long addr, char *addrStr);
+// AddrToStr is declared in network.h, but if it were from DNR.c directly:
+// extern OSErr AddrToStr(unsigned long addr, char *addrStr);
+
+
 StreamPtr gUDPStream = NULL;
 Ptr gUDPRecvBuffer = NULL;
-UDPiopb gUDPReadPB;
-UDPiopb gUDPBfrReturnPB;
+UDPiopb gUDPReadPB;          // Parameter block for async UDPRead (polling)
+UDPiopb gUDPBfrReturnPB;     // Parameter block for async UDPBfrReturn (polling)
 Boolean gUDPReadPending = false;
 Boolean gUDPBfrReturnPending = false;
-unsigned long gLastBroadcastTimeTicks = 0;
+unsigned long gLastBroadcastTimeTicks = 0; // For periodic discovery
+
+// Static buffers for sync send operations to avoid heap fragmentation in tight loops
 static char gBroadcastBuffer[BUFFER_SIZE];
 static struct wdsEntry gBroadcastWDS[2];
+
 static char gResponseBuffer[BUFFER_SIZE];
 static struct wdsEntry gResponseWDS[2];
+
+
+// --- Platform-specific Callbacks for Shared Discovery Logic ---
 static void mac_send_discovery_response(uint32_t dest_ip_addr_host, uint16_t dest_port_host, void* platform_context) {
-    (void)platform_context;
-    ip_addr dest_ip_net = (ip_addr)dest_ip_addr_host;
-    udp_port dest_port_mac = dest_port_host;
+    (void)platform_context; // Unused
+    ip_addr dest_ip_net = (ip_addr)dest_ip_addr_host; // MacTCP uses network byte order for ip_addr
+    udp_port dest_port_mac = dest_port_host;         // MacTCP uses host byte order for udp_port
+
     OSErr sendErr = SendDiscoveryResponseSync(gMacTCPRefNum, gMyUsername, gMyLocalIPStr, dest_ip_net, dest_port_mac);
     if (sendErr != noErr) {
         log_message("Error sending sync discovery response: %d", sendErr);
     } else {
          char tempIPStr[INET_ADDRSTRLEN];
-         AddrToStr(dest_ip_net, tempIPStr);
+         AddrToStr(dest_ip_net, tempIPStr); // Convert network order IP for logging
          log_to_file_only("Sent DISCOVERY_RESPONSE to %s:%u", tempIPStr, dest_port_mac);
     }
 }
+
 static int mac_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused
     return AddOrUpdatePeer(ip, username);
 }
+
 static void mac_notify_peer_list_updated(void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused
     if (gMainWindow != NULL && gPeerListHandle != NULL) {
-        UpdatePeerDisplayList(true);
+        UpdatePeerDisplayList(true); // Force redraw
     }
 }
+
+
 OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     OSErr err;
     UDPiopb pbCreate;
-    const unsigned short specificPort = PORT_UDP;
+    const unsigned short specificPort = PORT_UDP; // Host byte order
+
     log_message("Initializing UDP Discovery Endpoint (Async Read Poll / Sync Write)...");
-    if (macTCPRefNum == 0) { return paramErr; }
+
+    if (macTCPRefNum == 0) {
+        log_message("Error (InitUDP): macTCPRefNum is 0.");
+        return paramErr;
+    }
+
+    // Initialize globals
     gUDPStream = NULL;
     gUDPRecvBuffer = NULL;
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
-    gLastBroadcastTimeTicks = 0;
+    gLastBroadcastTimeTicks = 0; // Initialize for CheckSendBroadcast
+
+    // Allocate receive buffer
     gUDPRecvBuffer = NewPtrClear(kMinUDPBufSize);
     if (gUDPRecvBuffer == NULL) {
         log_message("Fatal Error: Could not allocate UDP receive buffer (%ld bytes).", (long)kMinUDPBufSize);
         return memFullErr;
     }
     log_message("Allocated %ld bytes for UDP receive buffer at 0x%lX.", (long)kMinUDPBufSize, (unsigned long)gUDPRecvBuffer);
+
+    // Prepare UDPCreate parameter block
     memset(&pbCreate, 0, sizeof(UDPiopb));
-    pbCreate.ioCompletion = nil;
+    pbCreate.ioCompletion = nil; // Synchronous call
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = UDPCreate;
-    pbCreate.udpStream = 0L;
+    pbCreate.udpStream = 0L; // Will be filled by MacTCP
     pbCreate.csParam.create.rcvBuff = gUDPRecvBuffer;
     pbCreate.csParam.create.rcvBuffLen = kMinUDPBufSize;
-    pbCreate.csParam.create.notifyProc = nil;
-    pbCreate.csParam.create.localPort = specificPort;
+    pbCreate.csParam.create.notifyProc = nil; // No ASR for this stream
+    pbCreate.csParam.create.localPort = specificPort; // Request specific port
+
     log_message("Calling PBControlSync (UDPCreate) for port %u...", specificPort);
     err = PBControlSync((ParmBlkPtr)&pbCreate);
+
+    // Capture results before potential early exit
     StreamPtr returnedStreamPtr = pbCreate.udpStream;
     unsigned short assignedPort = pbCreate.csParam.create.localPort;
+
     log_message("DEBUG: After PBControlSync(UDPCreate): err=%d, StreamPtr=0x%lX, AssignedPort=%u",
         err, (unsigned long)returnedStreamPtr, assignedPort);
+
     if (err != noErr) {
+        log_message("Error (InitUDP): UDPCreate failed (Error: %d).", err);
         DisposePtr(gUDPRecvBuffer); gUDPRecvBuffer = NULL;
         return err;
     }
     if (returnedStreamPtr == NULL) {
-        log_message("Error: UDPCreate succeeded but returned NULL stream pointer.");
+        log_message("Error (InitUDP): UDPCreate succeeded but returned NULL stream pointer.");
         DisposePtr(gUDPRecvBuffer); gUDPRecvBuffer = NULL;
-        return ioErr;
+        return ioErr; // Treat as an IO error
     }
-     if (assignedPort != specificPort) {
-         log_message("Warning: UDPCreate assigned port %u instead of requested %u.", assignedPort, specificPort);
+     if (assignedPort != specificPort && specificPort != 0) { // Only warn if a specific non-zero port was requested
+         log_message("Warning (InitUDP): UDPCreate assigned port %u instead of requested %u.", assignedPort, specificPort);
      }
+
     gUDPStream = returnedStreamPtr;
     log_message("UDP Endpoint created successfully (StreamPtr: 0x%lX) on assigned port %u.", (unsigned long)gUDPStream, assignedPort);
+
+    // Reset pending flags (should be redundant if Init is called once, but good practice)
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
-    gLastBroadcastTimeTicks = 0;
+    gLastBroadcastTimeTicks = 0; // Reset for CheckSendBroadcast
+
+    // Start the first asynchronous read (for polling)
     err = StartAsyncUDPRead();
-    if (err != noErr && err != 1) {
+    if (err != noErr && err != 1 /*pending*/) { // Check for immediate error from StartAsyncUDPRead
         log_message("Error (InitUDP): Failed to start initial async UDP read (polling). Error: %d", err);
-        CleanupUDPDiscoveryEndpoint(macTCPRefNum);
+        CleanupUDPDiscoveryEndpoint(macTCPRefNum); // Full cleanup on error
         return err;
     } else {
+        // If err == 1 (pending), it's fine. If err == noErr (completed sync, unlikely for async setup), also fine.
         log_message("Initial asynchronous UDP read (polling) STARTING.");
     }
+
     return noErr;
 }
+
 void CleanupUDPDiscoveryEndpoint(short macTCPRefNum) {
     UDPiopb pbRelease;
     OSErr err;
+
     log_message("Cleaning up UDP Discovery Endpoint (Async)...");
+
     if (gUDPStream != NULL) {
         log_message("UDP Stream 0x%lX was open. Attempting synchronous release...", (unsigned long)gUDPStream);
-        if (gUDPReadPending) { PBKillIO((ParmBlkPtr)&gUDPReadPB, false); gUDPReadPending = false; }
-        if (gUDPBfrReturnPending) { PBKillIO((ParmBlkPtr)&gUDPBfrReturnPB, false); gUDPBfrReturnPending = false; }
+
+        // *** PBKillIO calls REMOVED based on Q&A PLAT04 ***
+        // UDPRelease is documented to terminate outstanding commands.
+        // if (gUDPReadPending) { PBKillIO((ParmBlkPtr)&gUDPReadPB, false); } // REMOVED
+        // if (gUDPBfrReturnPending) { PBKillIO((ParmBlkPtr)&gUDPBfrReturnPB, false); } // REMOVED
+
+        // UDPRelease will terminate pending UDPRead/UDPBfrReturn.
+        // Set flags to false to prevent PollUDPListener from acting on old PBs after release.
+        gUDPReadPending = false;
+        gUDPBfrReturnPending = false;
+
         memset(&pbRelease, 0, sizeof(UDPiopb));
-        pbRelease.ioCompletion = nil;
+        pbRelease.ioCompletion = nil; // Synchronous call
         pbRelease.ioCRefNum = macTCPRefNum;
         pbRelease.csCode = UDPRelease;
         pbRelease.udpStream = gUDPStream;
-        pbRelease.csParam.create.rcvBuff = gUDPRecvBuffer;
-        pbRelease.csParam.create.rcvBuffLen = kMinUDPBufSize;
+        // The rcvBuff and rcvBuffLen in csParam.create for UDPRelease are ignored by MacTCP
+        // but some docs show them being filled; clear for safety.
+        pbRelease.csParam.create.rcvBuff = NULL;
+        pbRelease.csParam.create.rcvBuffLen = 0;
+
         err = PBControlSync((ParmBlkPtr)&pbRelease);
         if (err != noErr) {
             log_message("Warning: Synchronous UDPRelease failed during cleanup (Error: %d).", err);
         } else {
             log_message("Synchronous UDPRelease succeeded.");
         }
-        gUDPStream = NULL;
+        gUDPStream = NULL; // Mark stream as closed
     } else {
         log_message("UDP Stream was not open or already cleaned up.");
     }
+
     if (gUDPRecvBuffer != NULL) {
          log_message("Disposing UDP receive buffer at 0x%lX.", (unsigned long)gUDPRecvBuffer);
          DisposePtr(gUDPRecvBuffer);
          gUDPRecvBuffer = NULL;
     }
+
+    // Ensure flags are reset even if stream was already NULL
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
     gLastBroadcastTimeTicks = 0;
+
     log_message("UDP Discovery Endpoint cleanup finished.");
 }
+
+
 OSErr StartAsyncUDPRead(void) {
     OSErr err;
+
     if (gUDPStream == NULL) return invalidStreamPtr;
-    if (gUDPReadPending) return 1;
-    if (gUDPBfrReturnPending) {
-        log_to_file_only("StartAsyncUDPRead: Cannot start read, buffer return is pending.");
-        return 1;
+    if (gUDPReadPending) {
+        log_to_file_only("StartAsyncUDPRead: UDPRead already pending.");
+        return 1; // Still pending, not an error
     }
-    if (gUDPRecvBuffer == NULL) return invalidBufPtr;
+    if (gUDPBfrReturnPending) {
+        // This is a valid state; we might be waiting for a buffer to be returned
+        // before we can issue a new read. PollUDPListener should handle this.
+        log_to_file_only("StartAsyncUDPRead: Cannot start read, buffer return is pending.");
+        return 1; // Indicate an operation is in progress that prevents new read
+    }
+    if (gUDPRecvBuffer == NULL) { // Should have been allocated in Init
+        log_message("Error (StartAsyncUDPRead): gUDPRecvBuffer is NULL.");
+        return invalidBufPtr;
+    }
+
     memset(&gUDPReadPB, 0, sizeof(UDPiopb));
-    gUDPReadPB.ioCompletion = nil;
+    gUDPReadPB.ioCompletion = nil; // We are polling ioResult
     gUDPReadPB.ioCRefNum = gMacTCPRefNum;
     gUDPReadPB.csCode = UDPRead;
     gUDPReadPB.udpStream = gUDPStream;
     gUDPReadPB.csParam.receive.rcvBuff = gUDPRecvBuffer;
     gUDPReadPB.csParam.receive.rcvBuffLen = kMinUDPBufSize;
-    gUDPReadPB.csParam.receive.timeOut = 0;
-    gUDPReadPending = true;
+    gUDPReadPB.csParam.receive.timeOut = 0; // Infinite timeout for async read (we poll)
+    // remoteHost and remotePort are filled in by MacTCP on receive
+
+    gUDPReadPending = true; // Set before calling async
+    gUDPReadPB.ioResult = 1; // Mark as pending for polling logic
+
     err = PBControlAsync((ParmBlkPtr)&gUDPReadPB);
     if (err != noErr) {
         log_message("Error (StartAsyncUDPRead): PBControlAsync(UDPRead - polling) failed immediately. Error: %d", err);
-        gUDPReadPending = false;
+        gUDPReadPending = false; // Reset flag on immediate failure
         return err;
     }
+
     log_to_file_only("StartAsyncUDPRead: Async UDPRead initiated for polling.");
-    return 1;
+    return 1; // Indicates operation is pending
 }
+
+// Internal helper for sending UDP packets synchronously
 static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr,
                            const char *msgType, const char *content,
                            ip_addr destIP, udp_port destPort,
@@ -179,28 +258,38 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     OSErr err;
     int formatted_len;
     UDPiopb pbSync;
-    if (gUDPStream == NULL) return invalidStreamPtr;
+
+    if (gUDPStream == NULL) return invalidStreamPtr; // Check if UDP endpoint is initialized
     if (macTCPRefNum == 0) return paramErr;
-    if (myUsername == NULL || myLocalIPStr == NULL) return paramErr;
+    if (myUsername == NULL || myLocalIPStr == NULL) return paramErr; // Basic validation
+
+    // Format the message into the provided static buffer
     formatted_len = format_message(staticBuffer, BUFFER_SIZE, msgType, myUsername, myLocalIPStr, content);
     if (formatted_len <= 0) {
         log_message("Error (SendUDPSyncInternal): format_message failed for '%s'.", msgType);
-        return paramErr;
+        return paramErr; // Or a more specific error
     }
-    staticWDS[0].length = formatted_len - 1;
+
+    // Prepare WDS (Write Data Structure)
+    // format_message includes the null terminator in its length. UDP sends binary data.
+    // Send length should be actual data length, not including C-string null terminator.
+    staticWDS[0].length = formatted_len -1; // Exclude null terminator for UDP payload
     staticWDS[0].ptr = staticBuffer;
-    staticWDS[1].length = 0;
+    staticWDS[1].length = 0; // End of WDS list
     staticWDS[1].ptr = nil;
+
+    // Prepare UDPWrite parameter block
     memset(&pbSync, 0, sizeof(UDPiopb));
-    pbSync.ioCompletion = nil;
+    pbSync.ioCompletion = nil; // Synchronous call
     pbSync.ioCRefNum = macTCPRefNum;
     pbSync.csCode = UDPWrite;
     pbSync.udpStream = gUDPStream;
     pbSync.csParam.send.remoteHost = destIP;
     pbSync.csParam.send.remotePort = destPort;
     pbSync.csParam.send.wdsPtr = (Ptr)staticWDS;
-    pbSync.csParam.send.checkSum = true;
-    pbSync.csParam.send.sendLength = 0;
+    pbSync.csParam.send.checkSum = true; // Let MacTCP calculate checksum
+    pbSync.csParam.send.sendLength = 0;  // Ignored when WDS is used
+
     err = PBControlSync((ParmBlkPtr)&pbSync);
     if (err != noErr) {
         log_message("Error (SendUDPSync): PBControlSync(UDPWrite) for '%s' failed. Error: %d", msgType, err);
@@ -209,62 +298,86 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     log_to_file_only("SendUDPSyncInternal: Sent '%s' to IP %lu:%u.", msgType, (unsigned long)destIP, destPort);
     return noErr;
 }
+
+
 OSErr SendDiscoveryBroadcastSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr) {
     log_to_file_only("Sending Discovery Broadcast...");
     return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
-                                MSG_DISCOVERY, "",
+                                MSG_DISCOVERY, "", // Empty content for discovery
                                 BROADCAST_IP, PORT_UDP,
                                 gBroadcastBuffer, gBroadcastWDS);
 }
+
 OSErr SendDiscoveryResponseSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr, ip_addr destIP, udp_port destPort) {
      log_to_file_only("Sending Discovery Response to IP %lu:%u...", (unsigned long)destIP, destPort);
      return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
-                                MSG_DISCOVERY_RESPONSE, "",
+                                MSG_DISCOVERY_RESPONSE, "", // Empty content for response
                                 destIP, destPort,
                                 gResponseBuffer, gResponseWDS);
 }
+
+
 OSErr ReturnUDPBufferAsync(Ptr dataPtr, unsigned short bufferSize) {
     OSErr err;
+
     if (gUDPStream == NULL) return invalidStreamPtr;
     if (gUDPBfrReturnPending) {
          log_to_file_only("ReturnUDPBufferAsync: Buffer return already pending.");
-         return 1;
+         return 1; // Still pending
     }
-    if (dataPtr == NULL) return invalidBufPtr;
+    if (dataPtr == NULL) { // Should be gUDPRecvBuffer
+        log_message("Error (ReturnUDPBufferAsync): dataPtr is NULL.");
+        return invalidBufPtr;
+    }
+
     memset(&gUDPBfrReturnPB, 0, sizeof(UDPiopb));
-    gUDPBfrReturnPB.ioCompletion = nil;
+    gUDPBfrReturnPB.ioCompletion = nil; // We are polling ioResult
     gUDPBfrReturnPB.ioCRefNum = gMacTCPRefNum;
     gUDPBfrReturnPB.csCode = UDPBfrReturn;
     gUDPBfrReturnPB.udpStream = gUDPStream;
-    gUDPBfrReturnPB.csParam.receive.rcvBuff = dataPtr;
-    gUDPBfrReturnPB.csParam.receive.rcvBuffLen = bufferSize;
-    gUDPBfrReturnPending = true;
+    gUDPBfrReturnPB.csParam.receive.rcvBuff = dataPtr; // The buffer to return
+    gUDPBfrReturnPB.csParam.receive.rcvBuffLen = bufferSize; // Its original size
+
+    gUDPBfrReturnPending = true; // Set before calling async
+    gUDPBfrReturnPB.ioResult = 1; // Mark as pending for polling logic
+
     err = PBControlAsync((ParmBlkPtr)&gUDPBfrReturnPB);
     if (err != noErr) {
         log_message("CRITICAL Error (ReturnUDPBufferAsync): PBControlAsync(UDPBfrReturn - polling) failed immediately. Error: %d.", err);
-        gUDPBfrReturnPending = false;
+        gUDPBfrReturnPending = false; // Reset flag on immediate failure
         return err;
     }
+
     log_to_file_only("ReturnUDPBufferAsync: Async UDPBfrReturn initiated for buffer 0x%lX.", (unsigned long)dataPtr);
-    return 1;
+    return 1; // Indicates operation is pending
 }
+
+
 void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr) {
     unsigned long currentTimeTicks = TickCount();
-    const unsigned long intervalTicks = (unsigned long)DISCOVERY_INTERVAL * 60;
-    if (gUDPStream == NULL || macTCPRefNum == 0) return;
-    if (currentTimeTicks < gLastBroadcastTimeTicks) {
-        gLastBroadcastTimeTicks = currentTimeTicks;
+    // DISCOVERY_INTERVAL is in seconds, TickCount is 1/60th sec
+    const unsigned long intervalTicks = (unsigned long)DISCOVERY_INTERVAL * 60UL;
+
+    if (gUDPStream == NULL || macTCPRefNum == 0) return; // Not initialized
+
+    // Handle TickCount wrap-around for gLastBroadcastTimeTicks
+    if (currentTimeTicks < gLastBroadcastTimeTicks) { // Timer wrapped
+        gLastBroadcastTimeTicks = currentTimeTicks; // Reset base to current time
     }
+
     if (gLastBroadcastTimeTicks == 0 || (currentTimeTicks - gLastBroadcastTimeTicks) >= intervalTicks) {
         log_to_file_only("CheckSendBroadcast: Interval elapsed. Sending broadcast.");
         OSErr sendErr = SendDiscoveryBroadcastSync(macTCPRefNum, myUsername, myLocalIPStr);
         if (sendErr == noErr) {
-            gLastBroadcastTimeTicks = currentTimeTicks;
+            gLastBroadcastTimeTicks = currentTimeTicks; // Update time only on successful send
         } else {
             log_message("Sync broadcast initiation failed (Error: %d)", sendErr);
+            // Consider if gLastBroadcastTimeTicks should be updated even on failure to prevent rapid retries
+            // For now, only update on success.
         }
     }
 }
+
 void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP) {
     OSErr ioResult;
     static discovery_platform_callbacks_t mac_callbacks = {
@@ -272,63 +385,91 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP) {
         .add_or_update_peer_callback = mac_add_or_update_peer,
         .notify_peer_list_updated_callback = mac_notify_peer_list_updated
     };
+
+    // Check for completed UDPRead
     if (gUDPReadPending) {
-        ioResult = gUDPReadPB.ioResult;
-        if (ioResult <= 0) {
-            gUDPReadPending = false;
+        ioResult = gUDPReadPB.ioResult; // Check result from async call
+        if (ioResult <= 0) { // Operation completed (successfully or with error)
+            gUDPReadPending = false; // Clear flag
+
             if (ioResult == noErr) {
                 ip_addr senderIPNet = gUDPReadPB.csParam.receive.remoteHost;
                 udp_port senderPortHost = gUDPReadPB.csParam.receive.remotePort;
                 unsigned short dataLength = gUDPReadPB.csParam.receive.rcvBuffLen;
-                Ptr dataPtr = gUDPReadPB.csParam.receive.rcvBuff;
+                Ptr dataPtr = gUDPReadPB.csParam.receive.rcvBuff; // This is gUDPRecvBuffer
+
                 if (dataLength > 0) {
-                    if (senderIPNet != myLocalIP) {
+                    if (senderIPNet != myLocalIP) { // Don't process our own broadcasts
                         char senderIPStr[INET_ADDRSTRLEN];
                         OSErr addrErr = AddrToStr(senderIPNet, senderIPStr);
                         if (addrErr != noErr) {
+                            // Fallback IP string formatting if AddrToStr fails
                             sprintf(senderIPStr, "%lu.%lu.%lu.%lu", (senderIPNet >> 24) & 0xFF, (senderIPNet >> 16) & 0xFF, (senderIPNet >> 8) & 0xFF, senderIPNet & 0xFF);
                             log_to_file_only("PollUDPListener: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.", addrErr, (unsigned long)senderIPNet, senderIPStr);
                         }
-                        uint32_t sender_ip_addr_host = (uint32_t)senderIPNet;
-                        discovery_logic_process_packet(dataPtr, dataLength,
-                                                       senderIPStr, sender_ip_addr_host, senderPortHost,
+
+                        // Convert sender_ip_net (network order) to host order for shared logic if it expects host order
+                        // However, discovery_logic_process_packet takes sender_ip_addr which is uint32_t,
+                        // and for MacTCP, ip_addr is already in network byte order.
+                        // The shared logic should be aware of this or convert if necessary.
+                        // For now, assume shared logic can handle network order IP or uses the string.
+                        uint32_t sender_ip_addr_host_order_for_shared = (uint32_t)senderIPNet; // Pass as is
+
+                        discovery_logic_process_packet((const char*)dataPtr, dataLength,
+                                                       senderIPStr, sender_ip_addr_host_order_for_shared, senderPortHost,
                                                        &mac_callbacks,
-                                                       NULL);
+                                                       NULL); // No specific platform context needed for these callbacks
                     } else {
+                        // Log ignored self-packet
                         char selfIPStr[INET_ADDRSTRLEN];
-                        AddrToStr(senderIPNet, selfIPStr);
+                        AddrToStr(senderIPNet, selfIPStr); // Should be gMyLocalIPStr
                         log_to_file_only("PollUDPListener: Ignored UDP packet from self (%s).", selfIPStr);
                     }
+
+                    // Return the buffer
                     OSErr returnErr = ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
-                    if (returnErr != noErr && returnErr != 1) {
+                    if (returnErr != noErr && returnErr != 1 /*pending*/) {
                         log_message("CRITICAL Error (PollUDPListener): Failed to initiate async UDPBfrReturn (polling) using pointer 0x%lX after processing. Error: %d.", (unsigned long)dataPtr, returnErr);
+                        // What to do here? Maybe try to StartAsyncUDPRead again later.
                     } else {
                          log_to_file_only("PollUDPListener: Initiated return for buffer 0x%lX.", (unsigned long)dataPtr);
                     }
-                } else {
+                } else { // dataLength == 0
                     log_to_file_only("DEBUG: Async UDPRead (polling) returned 0 bytes.");
-                    ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
+                    ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize); // Still need to return the buffer
                 }
-            } else {
+            } else { // ioResult < 0 (error)
                 log_message("Error (PollUDPListener): Polled async UDPRead completed with error: %d", ioResult);
+                // Still need to return the buffer even on error
                 ReturnUDPBufferAsync(gUDPReadPB.csParam.receive.rcvBuff, kMinUDPBufSize);
             }
         }
+        // If ioResult > 0, it's still pending. Do nothing.
     }
+
+    // Check for completed UDPBfrReturn
     if (gUDPBfrReturnPending) {
-        ioResult = gUDPBfrReturnPB.ioResult;
-        if (ioResult <= 0) {
-            gUDPBfrReturnPending = false;
+        ioResult = gUDPBfrReturnPB.ioResult; // Check result from async call
+        if (ioResult <= 0) { // Operation completed
+            gUDPBfrReturnPending = false; // Clear flag
+
             if (ioResult != noErr) {
                 log_message("CRITICAL Error (PollUDPListener): Polled async UDPBfrReturn completed with error: %d.", ioResult);
+                // If buffer return fails, we might be in trouble for future reads.
             } else {
                  log_to_file_only("PollUDPListener: Async UDPBfrReturn completed successfully.");
+                 // Now that buffer is returned, if a read isn't already pending, start one.
                  if (!gUDPReadPending) {
                      StartAsyncUDPRead();
                  }
             }
         }
+        // If ioResult > 0, it's still pending. Do nothing.
     }
+
+    // Fallback: If nothing is pending and stream is open, ensure a read is started.
+    // This handles cases where initial StartAsyncUDPRead might have failed and needs retry,
+    // or if both read and return completed in the same poll cycle.
     if (!gUDPReadPending && !gUDPBfrReturnPending && gUDPStream != NULL) {
         log_to_file_only("PollUDPListener: No UDP read or buffer return pending, starting new read.");
         StartAsyncUDPRead();

--- a/classic_mac/discovery.c
+++ b/classic_mac/discovery.c
@@ -1,120 +1,88 @@
-//====================================
-// FILE: ./classic_mac/discovery.c
-//====================================
-
 #include "discovery.h"
 #include "logging.h"
 #include "protocol.h"
 #include "../shared/discovery_logic.h"
 #include "peer_mac.h"
-#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, AddrToStr
-#include "dialog.h"  // For gMainWindow
-#include "dialog_peerlist.h" // For gPeerListHandle, UpdatePeerDisplayList
+#include "network.h"
+#include "dialog.h"
+#include "dialog_peerlist.h"
 #include <Devices.h>
 #include <Errors.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <Memory.h>
-#include <stddef.h> // For offsetof if needed, though not directly used
+#include <stddef.h>
 #include <MacTCP.h>
-// AddrToStr is declared in network.h, but if it were from DNR.c directly:
-// extern OSErr AddrToStr(unsigned long addr, char *addrStr);
-
-
 StreamPtr gUDPStream = NULL;
 Ptr gUDPRecvBuffer = NULL;
-UDPiopb gUDPReadPB;          // Parameter block for async UDPRead (polling)
-UDPiopb gUDPBfrReturnPB;     // Parameter block for async UDPBfrReturn (polling)
+UDPiopb gUDPReadPB;
+UDPiopb gUDPBfrReturnPB;
 Boolean gUDPReadPending = false;
 Boolean gUDPBfrReturnPending = false;
-unsigned long gLastBroadcastTimeTicks = 0; // For periodic discovery
-
-// Static buffers for sync send operations to avoid heap fragmentation in tight loops
+unsigned long gLastBroadcastTimeTicks = 0;
 static char gBroadcastBuffer[BUFFER_SIZE];
 static struct wdsEntry gBroadcastWDS[2];
-
 static char gResponseBuffer[BUFFER_SIZE];
 static struct wdsEntry gResponseWDS[2];
-
-
-// --- Platform-specific Callbacks for Shared Discovery Logic ---
 static void mac_send_discovery_response(uint32_t dest_ip_addr_host, uint16_t dest_port_host, void* platform_context) {
-    (void)platform_context; // Unused
-    ip_addr dest_ip_net = (ip_addr)dest_ip_addr_host; // MacTCP uses network byte order for ip_addr
-    udp_port dest_port_mac = dest_port_host;         // MacTCP uses host byte order for udp_port
-
+    (void)platform_context;
+    ip_addr dest_ip_net = (ip_addr)dest_ip_addr_host;
+    udp_port dest_port_mac = dest_port_host;
     OSErr sendErr = SendDiscoveryResponseSync(gMacTCPRefNum, gMyUsername, gMyLocalIPStr, dest_ip_net, dest_port_mac);
     if (sendErr != noErr) {
         log_message("Error sending sync discovery response: %d", sendErr);
     } else {
          char tempIPStr[INET_ADDRSTRLEN];
-         AddrToStr(dest_ip_net, tempIPStr); // Convert network order IP for logging
+         AddrToStr(dest_ip_net, tempIPStr);
          log_to_file_only("Sent DISCOVERY_RESPONSE to %s:%u", tempIPStr, dest_port_mac);
     }
 }
-
 static int mac_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context; // Unused
+    (void)platform_context;
     return AddOrUpdatePeer(ip, username);
 }
-
 static void mac_notify_peer_list_updated(void* platform_context) {
-    (void)platform_context; // Unused
+    (void)platform_context;
     if (gMainWindow != NULL && gPeerListHandle != NULL) {
-        UpdatePeerDisplayList(true); // Force redraw
+        UpdatePeerDisplayList(true);
     }
 }
-
-
 OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     OSErr err;
     UDPiopb pbCreate;
-    const unsigned short specificPort = PORT_UDP; // Host byte order
-
+    const unsigned short specificPort = PORT_UDP;
     log_message("Initializing UDP Discovery Endpoint (Async Read Poll / Sync Write)...");
-
     if (macTCPRefNum == 0) {
         log_message("Error (InitUDP): macTCPRefNum is 0.");
         return paramErr;
     }
-
-    // Initialize globals
     gUDPStream = NULL;
     gUDPRecvBuffer = NULL;
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
-    gLastBroadcastTimeTicks = 0; // Initialize for CheckSendBroadcast
-
-    // Allocate receive buffer
+    gLastBroadcastTimeTicks = 0;
     gUDPRecvBuffer = NewPtrClear(kMinUDPBufSize);
     if (gUDPRecvBuffer == NULL) {
         log_message("Fatal Error: Could not allocate UDP receive buffer (%ld bytes).", (long)kMinUDPBufSize);
         return memFullErr;
     }
     log_message("Allocated %ld bytes for UDP receive buffer at 0x%lX.", (long)kMinUDPBufSize, (unsigned long)gUDPRecvBuffer);
-
-    // Prepare UDPCreate parameter block
     memset(&pbCreate, 0, sizeof(UDPiopb));
-    pbCreate.ioCompletion = nil; // Synchronous call
+    pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = UDPCreate;
-    pbCreate.udpStream = 0L; // Will be filled by MacTCP
+    pbCreate.udpStream = 0L;
     pbCreate.csParam.create.rcvBuff = gUDPRecvBuffer;
     pbCreate.csParam.create.rcvBuffLen = kMinUDPBufSize;
-    pbCreate.csParam.create.notifyProc = nil; // No ASR for this stream
-    pbCreate.csParam.create.localPort = specificPort; // Request specific port
-
+    pbCreate.csParam.create.notifyProc = nil;
+    pbCreate.csParam.create.localPort = specificPort;
     log_message("Calling PBControlSync (UDPCreate) for port %u...", specificPort);
     err = PBControlSync((ParmBlkPtr)&pbCreate);
-
-    // Capture results before potential early exit
     StreamPtr returnedStreamPtr = pbCreate.udpStream;
     unsigned short assignedPort = pbCreate.csParam.create.localPort;
-
     log_message("DEBUG: After PBControlSync(UDPCreate): err=%d, StreamPtr=0x%lX, AssignedPort=%u",
         err, (unsigned long)returnedStreamPtr, assignedPort);
-
     if (err != noErr) {
         log_message("Error (InitUDP): UDPCreate failed (Error: %d).", err);
         DisposePtr(gUDPRecvBuffer); gUDPRecvBuffer = NULL;
@@ -123,133 +91,95 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum) {
     if (returnedStreamPtr == NULL) {
         log_message("Error (InitUDP): UDPCreate succeeded but returned NULL stream pointer.");
         DisposePtr(gUDPRecvBuffer); gUDPRecvBuffer = NULL;
-        return ioErr; // Treat as an IO error
+        return ioErr;
     }
-     if (assignedPort != specificPort && specificPort != 0) { // Only warn if a specific non-zero port was requested
+     if (assignedPort != specificPort && specificPort != 0) {
          log_message("Warning (InitUDP): UDPCreate assigned port %u instead of requested %u.", assignedPort, specificPort);
      }
-
     gUDPStream = returnedStreamPtr;
     log_message("UDP Endpoint created successfully (StreamPtr: 0x%lX) on assigned port %u.", (unsigned long)gUDPStream, assignedPort);
-
-    // Reset pending flags (should be redundant if Init is called once, but good practice)
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
-    gLastBroadcastTimeTicks = 0; // Reset for CheckSendBroadcast
-
-    // Start the first asynchronous read (for polling)
+    gLastBroadcastTimeTicks = 0;
     err = StartAsyncUDPRead();
-    if (err != noErr && err != 1 /*pending*/) { // Check for immediate error from StartAsyncUDPRead
+    if (err != noErr && err != 1 ) {
         log_message("Error (InitUDP): Failed to start initial async UDP read (polling). Error: %d", err);
-        CleanupUDPDiscoveryEndpoint(macTCPRefNum); // Full cleanup on error
+        CleanupUDPDiscoveryEndpoint(macTCPRefNum);
         return err;
     } else {
-        // If err == 1 (pending), it's fine. If err == noErr (completed sync, unlikely for async setup), also fine.
         log_message("Initial asynchronous UDP read (polling) STARTING.");
     }
-
     return noErr;
 }
-
 void CleanupUDPDiscoveryEndpoint(short macTCPRefNum) {
     UDPiopb pbRelease;
     OSErr err;
-
     log_message("Cleaning up UDP Discovery Endpoint (Async)...");
-
     if (gUDPStream != NULL) {
         log_message("UDP Stream 0x%lX was open. Attempting synchronous release...", (unsigned long)gUDPStream);
-
-        // *** PBKillIO calls REMOVED based on Q&A PLAT04 ***
-        // UDPRelease is documented to terminate outstanding commands.
-        // if (gUDPReadPending) { PBKillIO((ParmBlkPtr)&gUDPReadPB, false); } // REMOVED
-        // if (gUDPBfrReturnPending) { PBKillIO((ParmBlkPtr)&gUDPBfrReturnPB, false); } // REMOVED
-
-        // UDPRelease will terminate pending UDPRead/UDPBfrReturn.
-        // Set flags to false to prevent PollUDPListener from acting on old PBs after release.
         gUDPReadPending = false;
         gUDPBfrReturnPending = false;
-
         memset(&pbRelease, 0, sizeof(UDPiopb));
-        pbRelease.ioCompletion = nil; // Synchronous call
+        pbRelease.ioCompletion = nil;
         pbRelease.ioCRefNum = macTCPRefNum;
         pbRelease.csCode = UDPRelease;
         pbRelease.udpStream = gUDPStream;
-        // The rcvBuff and rcvBuffLen in csParam.create for UDPRelease are ignored by MacTCP
-        // but some docs show them being filled; clear for safety.
         pbRelease.csParam.create.rcvBuff = NULL;
         pbRelease.csParam.create.rcvBuffLen = 0;
-
         err = PBControlSync((ParmBlkPtr)&pbRelease);
         if (err != noErr) {
             log_message("Warning: Synchronous UDPRelease failed during cleanup (Error: %d).", err);
         } else {
             log_message("Synchronous UDPRelease succeeded.");
         }
-        gUDPStream = NULL; // Mark stream as closed
+        gUDPStream = NULL;
     } else {
         log_message("UDP Stream was not open or already cleaned up.");
     }
-
     if (gUDPRecvBuffer != NULL) {
          log_message("Disposing UDP receive buffer at 0x%lX.", (unsigned long)gUDPRecvBuffer);
          DisposePtr(gUDPRecvBuffer);
          gUDPRecvBuffer = NULL;
     }
-
-    // Ensure flags are reset even if stream was already NULL
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
     gLastBroadcastTimeTicks = 0;
-
     log_message("UDP Discovery Endpoint cleanup finished.");
 }
-
-
 OSErr StartAsyncUDPRead(void) {
     OSErr err;
-
     if (gUDPStream == NULL) return invalidStreamPtr;
     if (gUDPReadPending) {
         log_to_file_only("StartAsyncUDPRead: UDPRead already pending.");
-        return 1; // Still pending, not an error
+        return 1;
     }
     if (gUDPBfrReturnPending) {
-        // This is a valid state; we might be waiting for a buffer to be returned
-        // before we can issue a new read. PollUDPListener should handle this.
         log_to_file_only("StartAsyncUDPRead: Cannot start read, buffer return is pending.");
-        return 1; // Indicate an operation is in progress that prevents new read
+        return 1;
     }
-    if (gUDPRecvBuffer == NULL) { // Should have been allocated in Init
+    if (gUDPRecvBuffer == NULL) {
         log_message("Error (StartAsyncUDPRead): gUDPRecvBuffer is NULL.");
         return invalidBufPtr;
     }
-
     memset(&gUDPReadPB, 0, sizeof(UDPiopb));
-    gUDPReadPB.ioCompletion = nil; // We are polling ioResult
+    gUDPReadPB.ioCompletion = nil;
     gUDPReadPB.ioCRefNum = gMacTCPRefNum;
     gUDPReadPB.csCode = UDPRead;
     gUDPReadPB.udpStream = gUDPStream;
     gUDPReadPB.csParam.receive.rcvBuff = gUDPRecvBuffer;
     gUDPReadPB.csParam.receive.rcvBuffLen = kMinUDPBufSize;
-    gUDPReadPB.csParam.receive.timeOut = 0; // Infinite timeout for async read (we poll)
-    // remoteHost and remotePort are filled in by MacTCP on receive
-
-    gUDPReadPending = true; // Set before calling async
-    gUDPReadPB.ioResult = 1; // Mark as pending for polling logic
-
+    gUDPReadPB.csParam.receive.timeOut = 0;
+    gUDPReadPending = true;
+    gUDPReadPB.ioResult = 1;
     err = PBControlAsync((ParmBlkPtr)&gUDPReadPB);
     if (err != noErr) {
         log_message("Error (StartAsyncUDPRead): PBControlAsync(UDPRead - polling) failed immediately. Error: %d", err);
-        gUDPReadPending = false; // Reset flag on immediate failure
+        gUDPReadPending = false;
         return err;
     }
-
     log_to_file_only("StartAsyncUDPRead: Async UDPRead initiated for polling.");
-    return 1; // Indicates operation is pending
+    return 1;
 }
-
-// Internal helper for sending UDP packets synchronously
 static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr,
                            const char *msgType, const char *content,
                            ip_addr destIP, udp_port destPort,
@@ -258,38 +188,28 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     OSErr err;
     int formatted_len;
     UDPiopb pbSync;
-
-    if (gUDPStream == NULL) return invalidStreamPtr; // Check if UDP endpoint is initialized
+    if (gUDPStream == NULL) return invalidStreamPtr;
     if (macTCPRefNum == 0) return paramErr;
-    if (myUsername == NULL || myLocalIPStr == NULL) return paramErr; // Basic validation
-
-    // Format the message into the provided static buffer
+    if (myUsername == NULL || myLocalIPStr == NULL) return paramErr;
     formatted_len = format_message(staticBuffer, BUFFER_SIZE, msgType, myUsername, myLocalIPStr, content);
     if (formatted_len <= 0) {
         log_message("Error (SendUDPSyncInternal): format_message failed for '%s'.", msgType);
-        return paramErr; // Or a more specific error
+        return paramErr;
     }
-
-    // Prepare WDS (Write Data Structure)
-    // format_message includes the null terminator in its length. UDP sends binary data.
-    // Send length should be actual data length, not including C-string null terminator.
-    staticWDS[0].length = formatted_len -1; // Exclude null terminator for UDP payload
+    staticWDS[0].length = formatted_len -1;
     staticWDS[0].ptr = staticBuffer;
-    staticWDS[1].length = 0; // End of WDS list
+    staticWDS[1].length = 0;
     staticWDS[1].ptr = nil;
-
-    // Prepare UDPWrite parameter block
     memset(&pbSync, 0, sizeof(UDPiopb));
-    pbSync.ioCompletion = nil; // Synchronous call
+    pbSync.ioCompletion = nil;
     pbSync.ioCRefNum = macTCPRefNum;
     pbSync.csCode = UDPWrite;
     pbSync.udpStream = gUDPStream;
     pbSync.csParam.send.remoteHost = destIP;
     pbSync.csParam.send.remotePort = destPort;
     pbSync.csParam.send.wdsPtr = (Ptr)staticWDS;
-    pbSync.csParam.send.checkSum = true; // Let MacTCP calculate checksum
-    pbSync.csParam.send.sendLength = 0;  // Ignored when WDS is used
-
+    pbSync.csParam.send.checkSum = true;
+    pbSync.csParam.send.sendLength = 0;
     err = PBControlSync((ParmBlkPtr)&pbSync);
     if (err != noErr) {
         log_message("Error (SendUDPSync): PBControlSync(UDPWrite) for '%s' failed. Error: %d", msgType, err);
@@ -298,86 +218,66 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     log_to_file_only("SendUDPSyncInternal: Sent '%s' to IP %lu:%u.", msgType, (unsigned long)destIP, destPort);
     return noErr;
 }
-
-
 OSErr SendDiscoveryBroadcastSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr) {
     log_to_file_only("Sending Discovery Broadcast...");
     return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
-                                MSG_DISCOVERY, "", // Empty content for discovery
+                                MSG_DISCOVERY, "",
                                 BROADCAST_IP, PORT_UDP,
                                 gBroadcastBuffer, gBroadcastWDS);
 }
-
 OSErr SendDiscoveryResponseSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr, ip_addr destIP, udp_port destPort) {
      log_to_file_only("Sending Discovery Response to IP %lu:%u...", (unsigned long)destIP, destPort);
      return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
-                                MSG_DISCOVERY_RESPONSE, "", // Empty content for response
+                                MSG_DISCOVERY_RESPONSE, "",
                                 destIP, destPort,
                                 gResponseBuffer, gResponseWDS);
 }
-
-
 OSErr ReturnUDPBufferAsync(Ptr dataPtr, unsigned short bufferSize) {
     OSErr err;
-
     if (gUDPStream == NULL) return invalidStreamPtr;
     if (gUDPBfrReturnPending) {
          log_to_file_only("ReturnUDPBufferAsync: Buffer return already pending.");
-         return 1; // Still pending
+         return 1;
     }
-    if (dataPtr == NULL) { // Should be gUDPRecvBuffer
+    if (dataPtr == NULL) {
         log_message("Error (ReturnUDPBufferAsync): dataPtr is NULL.");
         return invalidBufPtr;
     }
-
     memset(&gUDPBfrReturnPB, 0, sizeof(UDPiopb));
-    gUDPBfrReturnPB.ioCompletion = nil; // We are polling ioResult
+    gUDPBfrReturnPB.ioCompletion = nil;
     gUDPBfrReturnPB.ioCRefNum = gMacTCPRefNum;
     gUDPBfrReturnPB.csCode = UDPBfrReturn;
     gUDPBfrReturnPB.udpStream = gUDPStream;
-    gUDPBfrReturnPB.csParam.receive.rcvBuff = dataPtr; // The buffer to return
-    gUDPBfrReturnPB.csParam.receive.rcvBuffLen = bufferSize; // Its original size
-
-    gUDPBfrReturnPending = true; // Set before calling async
-    gUDPBfrReturnPB.ioResult = 1; // Mark as pending for polling logic
-
+    gUDPBfrReturnPB.csParam.receive.rcvBuff = dataPtr;
+    gUDPBfrReturnPB.csParam.receive.rcvBuffLen = bufferSize;
+    gUDPBfrReturnPending = true;
+    gUDPBfrReturnPB.ioResult = 1;
     err = PBControlAsync((ParmBlkPtr)&gUDPBfrReturnPB);
     if (err != noErr) {
         log_message("CRITICAL Error (ReturnUDPBufferAsync): PBControlAsync(UDPBfrReturn - polling) failed immediately. Error: %d.", err);
-        gUDPBfrReturnPending = false; // Reset flag on immediate failure
+        gUDPBfrReturnPending = false;
         return err;
     }
-
     log_to_file_only("ReturnUDPBufferAsync: Async UDPBfrReturn initiated for buffer 0x%lX.", (unsigned long)dataPtr);
-    return 1; // Indicates operation is pending
+    return 1;
 }
-
-
 void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr) {
     unsigned long currentTimeTicks = TickCount();
-    // DISCOVERY_INTERVAL is in seconds, TickCount is 1/60th sec
     const unsigned long intervalTicks = (unsigned long)DISCOVERY_INTERVAL * 60UL;
-
-    if (gUDPStream == NULL || macTCPRefNum == 0) return; // Not initialized
-
-    // Handle TickCount wrap-around for gLastBroadcastTimeTicks
-    if (currentTimeTicks < gLastBroadcastTimeTicks) { // Timer wrapped
-        gLastBroadcastTimeTicks = currentTimeTicks; // Reset base to current time
+    if (gUDPStream == NULL || macTCPRefNum == 0) return;
+    if (currentTimeTicks < gLastBroadcastTimeTicks) {
+        gLastBroadcastTimeTicks = currentTimeTicks;
     }
-
     if (gLastBroadcastTimeTicks == 0 || (currentTimeTicks - gLastBroadcastTimeTicks) >= intervalTicks) {
         log_to_file_only("CheckSendBroadcast: Interval elapsed. Sending broadcast.");
         OSErr sendErr = SendDiscoveryBroadcastSync(macTCPRefNum, myUsername, myLocalIPStr);
         if (sendErr == noErr) {
-            gLastBroadcastTimeTicks = currentTimeTicks; // Update time only on successful send
+            gLastBroadcastTimeTicks = currentTimeTicks;
         } else {
             log_message("Sync broadcast initiation failed (Error: %d)", sendErr);
-            // Consider if gLastBroadcastTimeTicks should be updated even on failure to prevent rapid retries
-            // For now, only update on success.
         }
     }
 }
-
 void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP) {
     OSErr ioResult;
     static discovery_platform_callbacks_t mac_callbacks = {
@@ -385,91 +285,63 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP) {
         .add_or_update_peer_callback = mac_add_or_update_peer,
         .notify_peer_list_updated_callback = mac_notify_peer_list_updated
     };
-
-    // Check for completed UDPRead
     if (gUDPReadPending) {
-        ioResult = gUDPReadPB.ioResult; // Check result from async call
-        if (ioResult <= 0) { // Operation completed (successfully or with error)
-            gUDPReadPending = false; // Clear flag
-
+        ioResult = gUDPReadPB.ioResult;
+        if (ioResult <= 0) {
+            gUDPReadPending = false;
             if (ioResult == noErr) {
                 ip_addr senderIPNet = gUDPReadPB.csParam.receive.remoteHost;
                 udp_port senderPortHost = gUDPReadPB.csParam.receive.remotePort;
                 unsigned short dataLength = gUDPReadPB.csParam.receive.rcvBuffLen;
-                Ptr dataPtr = gUDPReadPB.csParam.receive.rcvBuff; // This is gUDPRecvBuffer
-
+                Ptr dataPtr = gUDPReadPB.csParam.receive.rcvBuff;
                 if (dataLength > 0) {
-                    if (senderIPNet != myLocalIP) { // Don't process our own broadcasts
+                    if (senderIPNet != myLocalIP) {
                         char senderIPStr[INET_ADDRSTRLEN];
                         OSErr addrErr = AddrToStr(senderIPNet, senderIPStr);
                         if (addrErr != noErr) {
-                            // Fallback IP string formatting if AddrToStr fails
                             sprintf(senderIPStr, "%lu.%lu.%lu.%lu", (senderIPNet >> 24) & 0xFF, (senderIPNet >> 16) & 0xFF, (senderIPNet >> 8) & 0xFF, senderIPNet & 0xFF);
                             log_to_file_only("PollUDPListener: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.", addrErr, (unsigned long)senderIPNet, senderIPStr);
                         }
-
-                        // Convert sender_ip_net (network order) to host order for shared logic if it expects host order
-                        // However, discovery_logic_process_packet takes sender_ip_addr which is uint32_t,
-                        // and for MacTCP, ip_addr is already in network byte order.
-                        // The shared logic should be aware of this or convert if necessary.
-                        // For now, assume shared logic can handle network order IP or uses the string.
-                        uint32_t sender_ip_addr_host_order_for_shared = (uint32_t)senderIPNet; // Pass as is
-
+                        uint32_t sender_ip_addr_host_order_for_shared = (uint32_t)senderIPNet;
                         discovery_logic_process_packet((const char*)dataPtr, dataLength,
                                                        senderIPStr, sender_ip_addr_host_order_for_shared, senderPortHost,
                                                        &mac_callbacks,
-                                                       NULL); // No specific platform context needed for these callbacks
+                                                       NULL);
                     } else {
-                        // Log ignored self-packet
                         char selfIPStr[INET_ADDRSTRLEN];
-                        AddrToStr(senderIPNet, selfIPStr); // Should be gMyLocalIPStr
+                        AddrToStr(senderIPNet, selfIPStr);
                         log_to_file_only("PollUDPListener: Ignored UDP packet from self (%s).", selfIPStr);
                     }
-
-                    // Return the buffer
                     OSErr returnErr = ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
-                    if (returnErr != noErr && returnErr != 1 /*pending*/) {
+                    if (returnErr != noErr && returnErr != 1 ) {
                         log_message("CRITICAL Error (PollUDPListener): Failed to initiate async UDPBfrReturn (polling) using pointer 0x%lX after processing. Error: %d.", (unsigned long)dataPtr, returnErr);
-                        // What to do here? Maybe try to StartAsyncUDPRead again later.
                     } else {
                          log_to_file_only("PollUDPListener: Initiated return for buffer 0x%lX.", (unsigned long)dataPtr);
                     }
-                } else { // dataLength == 0
+                } else {
                     log_to_file_only("DEBUG: Async UDPRead (polling) returned 0 bytes.");
-                    ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize); // Still need to return the buffer
+                    ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
                 }
-            } else { // ioResult < 0 (error)
+            } else {
                 log_message("Error (PollUDPListener): Polled async UDPRead completed with error: %d", ioResult);
-                // Still need to return the buffer even on error
                 ReturnUDPBufferAsync(gUDPReadPB.csParam.receive.rcvBuff, kMinUDPBufSize);
             }
         }
-        // If ioResult > 0, it's still pending. Do nothing.
     }
-
-    // Check for completed UDPBfrReturn
     if (gUDPBfrReturnPending) {
-        ioResult = gUDPBfrReturnPB.ioResult; // Check result from async call
-        if (ioResult <= 0) { // Operation completed
-            gUDPBfrReturnPending = false; // Clear flag
-
+        ioResult = gUDPBfrReturnPB.ioResult;
+        if (ioResult <= 0) {
+            gUDPBfrReturnPending = false;
             if (ioResult != noErr) {
                 log_message("CRITICAL Error (PollUDPListener): Polled async UDPBfrReturn completed with error: %d.", ioResult);
-                // If buffer return fails, we might be in trouble for future reads.
             } else {
                  log_to_file_only("PollUDPListener: Async UDPBfrReturn completed successfully.");
-                 // Now that buffer is returned, if a read isn't already pending, start one.
                  if (!gUDPReadPending) {
                      StartAsyncUDPRead();
                  }
             }
         }
-        // If ioResult > 0, it's still pending. Do nothing.
     }
-
-    // Fallback: If nothing is pending and stream is open, ensure a read is started.
-    // This handles cases where initial StartAsyncUDPRead might have failed and needs retry,
-    // or if both read and return completed in the same poll cycle.
     if (!gUDPReadPending && !gUDPBfrReturnPending && gUDPStream != NULL) {
         log_to_file_only("PollUDPListener: No UDP read or buffer return pending, starting new read.");
         StartAsyncUDPRead();

--- a/classic_mac/logging.c
+++ b/classic_mac/logging.c
@@ -20,7 +20,7 @@ void InitLogFile(void) {
         fclose(gLogFile);
         gLogFile = NULL;
     }
-    gLogFile = fopen(kLogFileName, "w");
+    gLogFile = fopen(kLogFileName, "a");
     if (gLogFile == NULL) {
         SysBeep(10);
     } else {
@@ -31,6 +31,7 @@ void InitLogFile(void) {
 void CloseLogFile(void) {
     if (gLogFile != NULL) {
         fprintf(gLogFile, "--- Log Ended ---\n");
+        fflush(gLogFile);
         fclose(gLogFile);
         gLogFile = NULL;
     }

--- a/classic_mac/main.c
+++ b/classic_mac/main.c
@@ -1,3 +1,7 @@
+//====================================
+// FILE: ./classic_mac/main.c
+//====================================
+
 #include <MacTypes.h>
 #include <Quickdraw.h>
 #include <Fonts.h>
@@ -11,12 +15,14 @@
 #include <Controls.h>
 #include <stdlib.h>
 #include "logging.h"
-#include "network.h"
-#include "dialog.h"
+#include "network.h" // Includes gMacTCPRefNum, gMyLocalIP, gMyLocalIPStr, YieldTimeToSystem
+#include "dialog.h"  // Includes HandleSendButtonClick declaration
 #include "peer_mac.h"
 #include "dialog_peerlist.h"
-#include "tcp.h"
-#include "discovery.h"
+#include "tcp.h"       // Includes PollTCPListener declaration, GetTCPStreamState
+#include "discovery.h" // Includes PollUDPListener declaration
+#include <Sound.h>     // Include for SysBeep
+
 #ifndef inThumb
 #define inThumb 129
 #endif
@@ -32,31 +38,42 @@
 #ifndef inPageDown
 #define inPageDown 23
 #endif
+
 Boolean gDone = false;
 unsigned long gLastPeerListUpdateTime = 0;
-const unsigned long kPeerListUpdateIntervalTicks = 5 * 60;
+const unsigned long kPeerListUpdateIntervalTicks = 5 * 60; // Update peer list every 5 seconds
+
+// Forward declarations
 void InitializeToolbox(void);
 void MainEventLoop(void);
 void HandleEvent(EventRecord *event);
 void HandleMouseDownInContent(WindowPtr whichWindow, EventRecord *event);
 void HandleIdleTasks(void);
+// HandleSendButtonClick is now declared in dialog.h and defined in dialog.c
+
 int main(void) {
     OSErr networkErr;
     Boolean dialogOk;
+
     InitLogFile();
-    log_message("Starting application (Async Read Poll / Sync Write)...");
+    log_message("Starting application (Async Poll / Async Send Attempt)..."); // Updated log message
+
     MaxApplZone();
     log_message("MaxApplZone called.");
+
     InitializeToolbox();
     log_message("Toolbox Initialized.");
+
     networkErr = InitializeNetworking();
     if (networkErr != noErr) {
         log_message("Fatal: Network initialization failed (%d). Exiting.", networkErr);
         CloseLogFile();
         return 1;
     }
+
     InitPeerList();
     log_message("Peer list initialized.");
+
     dialogOk = InitDialog();
     if (!dialogOk) {
         log_message("Fatal: Dialog initialization failed. Exiting.");
@@ -64,21 +81,27 @@ int main(void) {
         CloseLogFile();
         return 1;
     }
+
     log_message("Entering main event loop...");
     MainEventLoop();
     log_message("Exited main event loop.");
+
     log_message("Initiating shutdown sequence...");
+    // Use the potentially blocking sync function for shutdown
     OSErr quitErr = TCP_SendQuitMessagesSync(YieldTimeToSystem);
-    if (quitErr != noErr && quitErr != insufficientResources) {
+    if (quitErr != noErr) {
+        // Log specific errors like timeout or stream busy if needed
         log_message("Warning: TCP_SendQuitMessagesSync reported last error: %d.", quitErr);
-    } else if (quitErr == noErr) {
-        log_message("Finished sending shutdown notifications.");
+    } else {
+        log_message("Finished sending shutdown notifications (or no peers).");
     }
+
     CleanupDialog();
     CleanupNetworking();
     CloseLogFile();
     return 0;
 }
+
 void InitializeToolbox(void) {
     InitGraf(&qd.thePort);
     InitFonts();
@@ -88,17 +111,28 @@ void InitializeToolbox(void) {
     InitDialogs(NULL);
     InitCursor();
 }
+
 void MainEventLoop(void) {
     EventRecord event;
     Boolean gotEvent;
-    long sleepTime = 5L;
+    long sleepTime = 1L; // Use 1 tick sleep for better responsiveness
+
     while (!gDone) {
+        // Idle TextEdit fields
         if (gMessagesTE != NULL) TEIdle(gMessagesTE);
         if (gInputTE != NULL) TEIdle(gInputTE);
+
+        // Handle background network tasks and peer list pruning
         HandleIdleTasks();
+
+        // Wait for events, yielding time
         gotEvent = WaitNextEvent(everyEvent, &event, sleepTime, NULL);
+
         if (gotEvent) {
             Boolean eventHandled = false;
+
+            // --- Special handling for scrollbar clicks BEFORE DialogSelect ---
+            // This ensures TrackControl works correctly for continuous scrolling.
             if (event.what == mouseDown) {
                 WindowPtr whichWindow;
                 short windowPart = FindWindow(event.where, &whichWindow);
@@ -110,56 +144,80 @@ void MainEventLoop(void) {
                     GetPort(&oldPort);
                     SetPort(GetWindowPort(gMainWindow));
                     GlobalToLocal(&localPt);
+                    // FindControl checks if the click hit *any* part of the control
                     foundControlPart = FindControl(localPt, whichWindow, &foundControl);
                     SetPort(oldPort);
-                    if (foundControl == gMessagesScrollBar && foundControlPart != 0 && foundControlPart != inThumb) {
-                        log_to_file_only("MainEventLoop: Handling mouseDown on Messages Scrollbar (part %d) BEFORE DialogSelect.", foundControlPart);
-                        short hiliteState = (**foundControl).contrlHilite;
-                        if (hiliteState == 0) {
+
+                    // Only handle clicks in the up/down arrows or page regions here
+                    if (foundControl == gMessagesScrollBar &&
+                        (foundControlPart == inUpButton || foundControlPart == inDownButton ||
+                         foundControlPart == inPageUp || foundControlPart == inPageDown))
+                    {
+                        log_to_file_only("MainEventLoop: Handling mouseDown on Messages Scrollbar arrows/page (part %d) BEFORE DialogSelect.", foundControlPart);
+                        // Check if control is active before tracking
+                        if ((**foundControl).contrlHilite == 0) {
+                            // TrackControl handles repeated actions while mouse is down
                             TrackControl(foundControl, localPt, &MyScrollAction);
                         } else {
                             log_to_file_only("MainEventLoop: Messages scrollbar clicked but inactive.");
                         }
-                        eventHandled = true;
+                        eventHandled = true; // Mark event as handled
                     }
                 }
-            }
+            } // End scrollbar pre-handling
+
+            // --- Standard Event Handling ---
             if (!eventHandled) {
+                // Let DialogSelect handle clicks on buttons, checkboxes, TE fields, list selection, scrollbar thumb
                 if (IsDialogEvent(&event)) {
                     DialogPtr whichDialog;
                     short itemHit;
+                    // DialogSelect returns true if it handled the event AND itemHit is > 0
                     if (DialogSelect(&event, &whichDialog, &itemHit)) {
                         if (whichDialog == gMainWindow && itemHit > 0) {
                              log_to_file_only("DialogSelect returned TRUE for item %d.", itemHit);
                              switch (itemHit) {
                                  case kSendButton:
-                                     HandleSendButtonClick();
+                                     HandleSendButtonClick(); // Defined in dialog.c
                                      break;
                                  case kBroadcastCheckbox:
                                      log_to_file_only("Broadcast checkbox state changed by DialogSelect.");
+                                     // Add logic if needed
                                      break;
                                  case kMessagesScrollbar:
+                                      // DialogSelect handles thumb tracking automatically
                                       log_to_file_only("DialogSelect handled event for Messages Scrollbar (item %d). Assumed thumb drag.", itemHit);
-                                      short oldValue = GetControlValue(gMessagesScrollBar);
+                                      // Update TE scroll based on new control value after thumb drag
+                                      // short oldValue = GetControlValue(gMessagesScrollBar); // Might not be needed
                                       short newValue = GetControlValue(gMessagesScrollBar);
-                                      if (newValue != oldValue && gMessagesTE != NULL) {
+                                      if (gMessagesTE != NULL) {
                                             SignedByte teState = HGetState((Handle)gMessagesTE); HLock((Handle)gMessagesTE);
                                             if (*gMessagesTE != NULL) {
                                                 short lineHeight = (**gMessagesTE).lineHeight;
                                                 if (lineHeight > 0) {
-                                                    short currentActualTopLine = -(**gMessagesTE).destRect.top / lineHeight;
-                                                    short scrollDeltaPixels = (currentActualTopLine - newValue) * lineHeight;
-                                                    ScrollMessagesTE(scrollDeltaPixels);
+                                                    // Calculate desired top line based on scrollbar value
+                                                    short desiredTopPixel = -newValue * lineHeight;
+                                                    short currentTopPixel = (**gMessagesTE).destRect.top;
+                                                    short scrollDeltaPixels = desiredTopPixel - currentTopPixel;
+                                                    if (scrollDeltaPixels != 0) {
+                                                        ScrollMessagesTE(scrollDeltaPixels);
+                                                    }
                                                 }
                                             } HSetState((Handle)gMessagesTE, teState);
                                       }
                                      break;
-                                 case kInputTextEdit:
-                                 case kMessagesTextEdit:
-                                 case kPeerListUserItem:
-                                     log_to_file_only("DialogSelect handled event in item %d (TE/List).", itemHit);
-                                     if (itemHit == kPeerListUserItem) {
-                                         HandlePeerListClick(gMainWindow, &event);
+                                 case kInputTextEdit: // DialogSelect handles TE activation/clicks
+                                 case kMessagesTextEdit: // Read-only, but DS might handle clicks
+                                     log_to_file_only("DialogSelect handled event in item %d (TE).", itemHit);
+                                     break;
+                                 case kPeerListUserItem: // DialogSelect handles list clicks via LClick
+                                     log_to_file_only("DialogSelect handled event in item %d (List).", itemHit);
+                                     // Update selection state if needed (LClick should handle it)
+                                     Cell tempCell = {0,-1};
+                                     if (LGetSelect(true, &tempCell, gPeerListHandle)) {
+                                         gLastSelectedCell = tempCell;
+                                     } else {
+                                         SetPt(&gLastSelectedCell, 0, -1);
                                      }
                                      break;
                                   default:
@@ -167,46 +225,59 @@ void MainEventLoop(void) {
                                      break;
                              }
                         }
-                        eventHandled = true;
+                        eventHandled = true; // DialogSelect handled it
                     }
-                }
+                } // End IsDialogEvent
+
+                // If not handled by DialogSelect or special cases, use standard handler
                 if (!eventHandled) {
                      HandleEvent(&event);
                 }
-            }
-        }
-    }
+            } // End standard handling
+        } // End gotEvent
+    } // End while !gDone
 }
+
 void HandleIdleTasks(void) {
     unsigned long currentTimeTicks = TickCount();
-    PollUDPListener(gMacTCPRefNum, gMyLocalIP);
-    PollTCPListener(gMacTCPRefNum, gMyLocalIP);
+
+    // Poll network listeners/state machines
+    PollUDPListener(gMacTCPRefNum, gMyLocalIP); // UDP needs local IP to ignore self
+    PollTCPListener(gMacTCPRefNum);             // TCP state machine manages itself
+
+    // Send periodic discovery broadcast
     CheckSendBroadcast(gMacTCPRefNum, gMyUsername, gMyLocalIPStr);
+
+    // Prune and update peer list display periodically
     if (gLastPeerListUpdateTime == 0 ||
-        (currentTimeTicks < gLastPeerListUpdateTime) ||
+        (currentTimeTicks < gLastPeerListUpdateTime) || // Handle TickCount rollover
         (currentTimeTicks - gLastPeerListUpdateTime) >= kPeerListUpdateIntervalTicks)
     {
         if (gPeerListHandle != NULL) {
-            UpdatePeerDisplayList(false);
+            UpdatePeerDisplayList(false); // false = don't force redraw if count hasn't changed
         }
         gLastPeerListUpdateTime = currentTimeTicks;
     }
 }
+
 void HandleEvent(EventRecord *event) {
     short windowPart;
     WindowPtr whichWindow;
     char theChar;
+
     switch (event->what) {
         case mouseDown:
             windowPart = FindWindow(event->where, &whichWindow);
             switch (windowPart) {
                 case inMenuBar:
+                    // HandleMenuClick(MenuSelect(event->where)); // Add menu handling if needed
                     break;
                 case inSysWindow:
                     SystemClick(event, whichWindow);
                     break;
                 case inDrag:
                     if (whichWindow == (WindowPtr)gMainWindow) {
+                        // Use screen bounds, adjusted for menu bar height if necessary
                         DragWindow(whichWindow, event->where, &qd.screenBits.bounds);
                     }
                     break;
@@ -214,74 +285,95 @@ void HandleEvent(EventRecord *event) {
                     if (whichWindow == (WindowPtr)gMainWindow) {
                          if (TrackGoAway(whichWindow, event->where)) {
                               log_message("Close box clicked. Setting gDone = true.");
-                              gDone = true;
+                              gDone = true; // Signal main loop to exit
                          }
                     }
                     break;
                 case inContent:
+                     // Clicks in content not handled by DialogSelect or scrollbar pre-handler
                      if (whichWindow == (WindowPtr)gMainWindow) {
-                         HandleMouseDownInContent(whichWindow, event);
+                         // HandleMouseDownInContent(whichWindow, event); // Might be needed for custom items
+                         log_to_file_only("HandleEvent: Click in content not handled by DS.");
                      } else {
+                         // Click in non-front window brings it to front
                          SelectWindow(whichWindow);
                      }
+                    break;
+                 case inZoomIn: // Handle zoom box if present
+                 case inZoomOut:
+                    // if (whichWindow == (WindowPtr)gMainWindow) {
+                    //     if (TrackBox(whichWindow, event->where, windowPart)) {
+                    //         ZoomWindow(whichWindow, windowPart, true); // Or false based on context
+                    //     }
+                    // }
                     break;
                 default:
                     break;
             }
             break;
+
         case keyDown:
         case autoKey:
              theChar = event->message & charCodeMask;
              if ((event->modifiers & cmdKey) != 0) {
+                 // Handle Command keys if menus are added
+                 // HandleMenuClick(MenuKey(theChar));
              } else {
+                 // Key events are generally handled by DialogSelect/TEKey for active TE fields
+                 // No specific handling needed here unless overriding TE behavior
              }
             break;
+
         case updateEvt:
             whichWindow = (WindowPtr)event->message;
              BeginUpdate(whichWindow);
+             // EraseRgn(whichWindow->visRgn); // Optional: Erase region first
              if (whichWindow == (WindowPtr)gMainWindow) {
-                 DrawDialog(whichWindow);
-                 UpdateDialogControls();
+                 DrawDialog(whichWindow); // Redraw standard dialog items
+                 UpdateDialogControls(); // Redraw custom items (TE, List, Scrollbar)
              }
+             // DrawGrowIcon(whichWindow); // Draw grow icon if window is resizable
              EndUpdate(whichWindow);
             break;
+
         case activateEvt:
             whichWindow = (WindowPtr)event->message;
             if (whichWindow == (WindowPtr)gMainWindow) {
                 Boolean becomingActive = ((event->modifiers & activeFlag) != 0);
                 log_to_file_only("HandleEvent: ActivateEvt for gMainWindow -> BecomingActive=%d", becomingActive);
-                ActivateDialogTE(becomingActive);
+                // Activate/Deactivate custom controls
+                ActivateDialogTE(becomingActive); // Handles both TEs
                 ActivatePeerList(becomingActive);
-                ActivateMessagesTEAndScrollbar(becomingActive);
+                ActivateMessagesTEAndScrollbar(becomingActive); // Handles scrollbar hilite
+                // DrawGrowIcon(whichWindow); // Redraw grow icon based on active state
             }
             break;
+
+        // Handle other events if needed (diskEvt, osEvt, etc.)
+        // case diskEvt:
+        //     if (HiWord(event->message) != noErr) {
+        //         // Handle disk errors
+        //     }
+        //     break;
+
         default:
             break;
     }
 }
+
+// Handles clicks in content area NOT handled by DialogSelect
+// (e.g., clicks outside any active control/item)
 void HandleMouseDownInContent(WindowPtr whichWindow, EventRecord *event) {
+    // Currently unused as DialogSelect handles TE/List clicks,
+    // and scrollbar arrows are pre-handled.
+    // If you add other custom clickable areas, handle them here.
     Point localPt = event->where;
     GrafPtr oldPort;
-    if (whichWindow != FrontWindow()) {
-        SelectWindow(whichWindow);
-        return;
-    }
     GetPort(&oldPort);
     SetPort(GetWindowPort(whichWindow));
     GlobalToLocal(&localPt);
     log_to_file_only("HandleMouseDownInContent: Processing click at local (%d, %d)", localPt.v, localPt.h);
-    SignedByte listState = HGetState((Handle)gPeerListHandle); HLock((Handle)gPeerListHandle);
-    Boolean inListView = false;
-    if (*gPeerListHandle != NULL) {
-        inListView = PtInRect(localPt, &(**gPeerListHandle).rView);
-    }
-    HSetState((Handle)gPeerListHandle, listState);
-    if (inListView) {
-        log_to_file_only("HandleMouseDownInContent: Click in Peer List view rect.");
-        Boolean handledByLClick = HandlePeerListClick(gMainWindow, event);
-        log_to_file_only("HandleMouseDownInContent: HandlePeerListClick returned %d", handledByLClick);
-    } else {
-        log_to_file_only("HandleMouseDownInContent: Click in content area not handled (outside List).");
-    }
+    // Example: Check if click hit a custom drawing area
+    // if (PtInRect(localPt, &gMyCustomRect)) { ... }
     SetPort(oldPort);
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,23 +1,40 @@
+//====================================
+// FILE: ./classic_mac/network.c
+//====================================
+
 #include "network.h"
 #include "logging.h"
-#include "discovery.h"
-#include "tcp.h"
-#include <Devices.h>
+#include "discovery.h" // For Init/Cleanup UDP
+#include "tcp.h"       // For Init/Cleanup TCP Listener
+#include <Devices.h>   // For PBOpenSync, PBCloseSync, PBControlSync
 #include <Errors.h>
-#include <string.h>
-#include <stdlib.h>
-#include <Memory.h>
+#include <string.h>    // For memset, strcpy, strncpy, strtok_r
+#include <stdlib.h>    // For strtoul
+#include <Memory.h>    // For NewPtrClear, DisposePtr
+#include <Events.h>    // For WaitNextEvent
+
+// DNR Function Prototypes (assuming DNR.c provides these)
+extern OSErr OpenResolver(char *fileName);
+extern OSErr CloseResolver(void);
+extern OSErr AddrToStr(unsigned long addr, char *addrStr);
+// StrToAddr might be needed if ParseIPv4 is insufficient, but let's use ParseIPv4 for now.
+// extern OSErr StrToAddr(char *hostName, struct hostInfo *rtnStruct, long resultproc, char *userDataPtr);
+
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser";
+char gMyUsername[32] = "MacUser"; // Default username
+
 OSErr InitializeNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
     CntrlParam cntrlPB;
+
     log_message("Initializing Networking...");
+
+    // 1. Open MacTCP Driver
     pb.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
-    pb.ioParam.ioPermssn = fsCurPerm;
+    pb.ioParam.ioPermssn = fsCurPerm; // Read/write permission
     log_message("Attempting PBOpenSync for .IPP driver...");
     err = PBOpenSync(&pb);
     if (err != noErr) {
@@ -27,6 +44,8 @@ OSErr InitializeNetworking(void) {
     }
     gMacTCPRefNum = pb.ioParam.ioRefNum;
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
+
+    // 2. Get Local IP Address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
     cntrlPB.csCode = ipctlGetAddr;
@@ -34,33 +53,46 @@ OSErr InitializeNetworking(void) {
     err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        PBCloseSync(&pb);
+        PBCloseSync(&pb); // Close driver on error
         gMacTCPRefNum = 0;
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
+    // Extract the IP address from the control parameter block
     gMyLocalIP = *((ip_addr *)(&cntrlPB.csParam[0]));
+
+    // 3. Initialize DNR (Domain Name Resolver)
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL);
+    err = OpenResolver(NULL); // Pass NULL for default resolver configuration
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        PBCloseSync(&pb);
+        PBCloseSync(&pb); // Close driver on error
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
+
+    // 4. Convert Local IP to String using DNR
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
+         // Log warning but don't necessarily fail; maybe IP is 0.0.0.0 initially
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
+         // Fallback if IP is 0 or string conversion failed badly
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
-             log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1.");
+             log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
+             // Optionally, try parsing 127.0.0.1 back to gMyLocalIP if gMyLocalIP was 0
+             if (gMyLocalIP == 0) {
+                ParseIPv4("127.0.0.1", &gMyLocalIP);
+             }
          }
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
+
+    // 5. Initialize UDP Discovery Endpoint
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
@@ -69,24 +101,35 @@ OSErr InitializeNetworking(void) {
         gMacTCPRefNum = 0;
         return err;
     }
+
+    // 6. Initialize TCP Listener Stream
     err = InitTCPListener(gMacTCPRefNum);
     if (err != noErr) {
         log_message("Fatal: TCP Listener initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Clean up UDP if TCP fails
         CloseResolver();
         PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
+
     log_message("Networking initialization complete.");
     return noErr;
 }
+
 void CleanupNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
-    log_message("Cleaning up Networking...");
+
+    log_message("Cleaning up Networking (Streams, DNR, Driver)...");
+
+    // 1. Cleanup TCP Listener (handles its own stream release)
     CleanupTCPListener(gMacTCPRefNum);
+
+    // 2. Cleanup UDP Endpoint (handles its own stream release)
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+
+    // 3. Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -94,18 +137,75 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
+
+    // 4. Close MacTCP Driver
     if (gMacTCPRefNum != 0) {
          log_message("Closing MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
          pb.ioParam.ioRefNum = gMacTCPRefNum;
          err = PBCloseSync(&pb);
          if (err != noErr) {
+             // This error (-24, fcbNotFound) is common if streams weren't released properly,
+             // but we attempted release in the cleanup functions. Log it but continue.
              log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d", err);
          } else {
              log_message("MacTCP driver closed.");
          }
-        gMacTCPRefNum = 0;
+        gMacTCPRefNum = 0; // Mark as closed regardless of error
     } else {
         log_message("MacTCP driver was not open.");
     }
+
     log_message("Networking cleanup complete.");
+}
+
+// Basic yield function for cooperative multitasking
+void YieldTimeToSystem(void) {
+    EventRecord event; // Dummy event record
+    // WaitNextEvent with minimal sleep allows other processes (including MacTCP background tasks) to run.
+    // Using 0 for sleep can starve other processes on some systems, 1 is safer.
+    WaitNextEvent(0, &event, 1L, NULL);
+}
+
+// Helper to parse IPv4 string "a.b.c.d" into network byte order ip_addr
+OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
+    unsigned long parts[4];
+    int i = 0;
+    char *token;
+    char *rest;
+    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
+
+    if (ip_str == NULL || out_addr == NULL) {
+        return paramErr;
+    }
+
+    // Copy to a temporary buffer because strtok_r modifies the string
+    strncpy(buffer, ip_str, INET_ADDRSTRLEN);
+    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
+
+    rest = buffer; // Initialize rest for strtok_r
+
+    // Parse up to 4 parts separated by '.'
+    while ((token = strtok_r(rest, ".", &rest)) != NULL && i < 4) {
+        char *endptr;
+        parts[i] = strtoul(token, &endptr, 10); // Base 10 conversion
+
+        // Check for conversion errors or out-of-range values
+        if (*endptr != '\0' || parts[i] > 255) {
+            log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
+            *out_addr = 0;
+            return paramErr; // Return error code
+        }
+        i++;
+    }
+
+    // Check if exactly 4 parts were found
+    if (i != 4) {
+        log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
+        *out_addr = 0;
+        return paramErr; // Return error code
+    }
+
+    // Combine parts into a 32-bit ip_addr (network byte order assumed by MacTCP)
+    *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
+    return noErr; // Success
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,7 +1,3 @@
-//====================================
-// FILE: ./classic_mac/network.c
-//====================================
-
 #include "network.h"
 #include "logging.h"
 #include "discovery.h"
@@ -12,123 +8,88 @@
 #include <stdlib.h>
 #include <Memory.h>
 #include <Events.h>
-
-// External DNR function prototypes (from DNR.c or similar)
 extern OSErr OpenResolver(char *fileName);
 extern OSErr CloseResolver(void);
 extern OSErr AddrToStr(unsigned long addr, char *addrStr);
-
-// Globals
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser"; // Default username
-
-
+char gMyUsername[32] = "MacUser";
 OSErr InitializeNetworking(void) {
     OSErr err;
-    ParamBlockRec pbOpen; // For PBOpen of the driver
-    CntrlParam cntrlPB;   // For ipctlGetAddr
-    
+    ParamBlockRec pbOpen;
+    CntrlParam cntrlPB;
     log_message("Initializing Networking...");
-
-    // Initialize the ParamBlockRec for PBOpen
     memset(&pbOpen, 0, sizeof(ParamBlockRec));
-    pbOpen.ioParam.ioNamePtr = (StringPtr)kTCPDriverName; // MacTCP driver name: ".IPP"
-    pbOpen.ioParam.ioPermssn = fsCurPerm; // Read/write permission (standard for drivers)
-
+    pbOpen.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
+    pbOpen.ioParam.ioPermssn = fsCurPerm;
     log_message("Attempting PBOpenSync for .IPP driver...");
-    err = PBOpenSync(&pbOpen); // Synchronously open the MacTCP driver
+    err = PBOpenSync(&pbOpen);
     if (err != noErr) {
         log_message("Error: PBOpenSync for MacTCP driver failed. Error: %d", err);
         gMacTCPRefNum = 0;
         return err;
     }
-    gMacTCPRefNum = pbOpen.ioParam.ioRefNum; // Store the driver reference number
+    gMacTCPRefNum = pbOpen.ioParam.ioRefNum;
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
-
-    // Get local IP address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
-    cntrlPB.csCode = ipctlGetAddr; // Control call to get IP address
+    cntrlPB.csCode = ipctlGetAddr;
     log_message("Attempting PBControlSync for ipctlGetAddr...");
-    err = PBControlSync((ParmBlkPtr)&cntrlPB); // Synchronously get IP
+    err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        // Note: Driver is open, but we failed to get IP. 
-        // For robust cleanup, one might consider closing the driver here,
-        // but since we plan to quit if this fails, system restart will handle it.
-        gMacTCPRefNum = 0; // Invalidate refnum as networking is not fully up
+        gMacTCPRefNum = 0;
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
-    BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr)); // Copy IP address
-
-    // Initialize DNR (Domain Name Resolver)
+    BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr));
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL); // Use default "Hosts" file
+    err = OpenResolver(NULL);
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        // No need to explicitly close driver here on failure if app exits
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
-
-    // Convert local IP to string
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
-         // Fallback if AddrToStr fails or returns an unusable IP
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
              log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
-             if (gMyLocalIP == 0) { // If gMyLocalIP was also 0, parse the fallback
-                ParseIPv4("127.0.0.1", &gMyLocalIP); 
+             if (gMyLocalIP == 0) {
+                ParseIPv4("127.0.0.1", &gMyLocalIP);
              }
          }
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
-
-    // Initialize UDP Discovery
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
         CloseResolver();
-        // No driver close here
         gMacTCPRefNum = 0;
         return err;
     }
-
-    // Initialize TCP
     err = InitTCP(gMacTCPRefNum);
     if (err != noErr) {
         log_message("Fatal: TCP initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Cleanup what was initialized
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
         CloseResolver();
-        // No driver close here
         gMacTCPRefNum = 0;
         return err;
     }
-
     log_message("Networking initialization complete.");
     return noErr;
 }
-
 void CleanupNetworking(void) {
     OSErr err;
-    // ParamBlockRec pbCloseDriver; // No longer needed for closing the driver
-
     log_message("Cleaning up Networking (Streams, DNR, Driver)...");
-
-    // Cleanup TCP and UDP streams first
     CleanupTCP(gMacTCPRefNum);
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
-
-    // Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -136,82 +97,45 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
-
-    // Do NOT close the MacTCP driver itself. It's a shared system resource.
-    // The PBOpen call only gets a reference to it.
     if (gMacTCPRefNum != 0) {
          log_message("MacTCP driver (RefNum: %d) was opened by this application. It will remain open for the system.", gMacTCPRefNum);
-        // memset(&pbCloseDriver, 0, sizeof(ParamBlockRec));
-        // pbCloseDriver.ioParam.ioRefNum = gMacTCPRefNum;
-        // log_message("Attempting PBCloseSync for MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
-        // err = PBCloseSync(&pbCloseDriver); // THIS IS THE LINE TO REMOVE / COMMENT OUT
-        // if (err != noErr) {
-        //     log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d. This is problematic.", err);
-        // } else {
-        //     log_message("MacTCP driver (RefNum: %d) closed via PBCloseSync.", gMacTCPRefNum);
-        // }
-        gMacTCPRefNum = 0; // Invalidate our reference
+        gMacTCPRefNum = 0;
     } else {
         log_message("MacTCP driver was not opened by this application or already cleaned up.");
     }
-    
     log_message("Networking cleanup complete.");
 }
-
-// YieldTimeToSystem: Gives time back to the OS, allowing other processes
-// (including MacTCP background tasks) to run.
 void YieldTimeToSystem(void) {
-    EventRecord event; // Dummy event record
-    // Minimal wait to cede time. The 1L is a short duration.
-    // We're not actually interested in the event, just yielding.
-    WaitNextEvent(0, &event, 1L, NULL); 
+    EventRecord event;
+    WaitNextEvent(0, &event, 1L, NULL);
 }
-
-
-// ParseIPv4: Converts a dotted-decimal IP string to a 32-bit MacTCP ip_addr.
-// Note: MacTCP ip_addr is typically network byte order, but since we get it
-// from MacTCP calls and pass it back to MacTCP calls, we generally don't
-// need to swap bytes for MacTCP's own use. However, if displaying parts
-// or comparing with standard host order numbers, be mindful.
-// This function produces a host-order equivalent from the string for internal logic,
-// which is then implicitly treated as network order by MacTCP functions.
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
     unsigned long parts[4];
     int i = 0;
     char *token;
-    char *rest_of_string; // Renamed to avoid conflict with standard 'rest'
-    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
-
+    char *rest_of_string;
+    char buffer[INET_ADDRSTRLEN + 1];
     if (ip_str == NULL || out_addr == NULL) {
         return paramErr;
     }
-
-    // Make a writable copy of the IP string for strtok_r
     strncpy(buffer, ip_str, INET_ADDRSTRLEN);
-    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
-
+    buffer[INET_ADDRSTRLEN] = '\0';
     rest_of_string = buffer;
     while ((token = strtok_r(rest_of_string, ".", &rest_of_string)) != NULL && i < 4) {
         char *endptr;
-        parts[i] = strtoul(token, &endptr, 10); // Base 10
-        
-        // Check for conversion errors or out-of-range values
+        parts[i] = strtoul(token, &endptr, 10);
         if (*endptr != '\0' || parts[i] > 255) {
             log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
-            *out_addr = 0; // Indicate error
-            return paramErr; 
+            *out_addr = 0;
+            return paramErr;
         }
         i++;
     }
-
     if (i != 4) {
         log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
-        *out_addr = 0; // Indicate error
+        *out_addr = 0;
         return paramErr;
     }
-
-    // Assemble the ip_addr in network byte order (big-endian)
-    // which is MacTCP's native format for ip_addr.
     *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
     return noErr;
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,34 +1,27 @@
 #include "network.h"
 #include "logging.h"
-#include "discovery.h" // For Init/Cleanup UDP
-#include "tcp.h"       // For InitTCP, CleanupTCP
-#include <Devices.h>   // For PBOpenSync, PBCloseSync, PBControlSync
+#include "discovery.h"
+#include "tcp.h"
+#include <Devices.h>
 #include <Errors.h>
-#include <string.h>    // For memset, strcpy, strncpy, strtok_r
-#include <stdlib.h>    // For strtoul
-#include <Memory.h>    // For NewPtrClear, DisposePtr
-#include <Events.h>    // For WaitNextEvent
-
-// DNR Function Prototypes (assuming DNR.c provides these)
+#include <string.h>
+#include <stdlib.h>
+#include <Memory.h>
+#include <Events.h>
 extern OSErr OpenResolver(char *fileName);
 extern OSErr CloseResolver(void);
 extern OSErr AddrToStr(unsigned long addr, char *addrStr);
-
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser"; // Default username
-
+char gMyUsername[32] = "MacUser";
 OSErr InitializeNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
     CntrlParam cntrlPB;
-
     log_message("Initializing Networking...");
-
-    // 1. Open MacTCP Driver
     pb.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
-    pb.ioParam.ioPermssn = fsCurPerm; // Read/write permission
+    pb.ioParam.ioPermssn = fsCurPerm;
     log_message("Attempting PBOpenSync for .IPP driver...");
     err = PBOpenSync(&pb);
     if (err != noErr) {
@@ -38,8 +31,6 @@ OSErr InitializeNetworking(void) {
     }
     gMacTCPRefNum = pb.ioParam.ioRefNum;
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
-
-    // 2. Get Local IP Address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
     cntrlPB.csCode = ipctlGetAddr;
@@ -47,40 +38,29 @@ OSErr InitializeNetworking(void) {
     err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        PBCloseSync(&pb); // Close driver on error
+        PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
-    // Extract the IP address from the control parameter block
-    // Ensure alignment: Use BlockMoveData for safety
-    // gMyLocalIP = *((ip_addr *)(&cntrlPB.csParam[0])); // Potential alignment issue
     BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr));
-
-
-    // 3. Initialize DNR (Domain Name Resolver)
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL); // Pass NULL for default resolver configuration
+    err = OpenResolver(NULL);
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        PBCloseSync(&pb); // Close driver on error
+        PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
-
-    // 4. Convert Local IP to String using DNR
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
-         // Log warning but don't necessarily fail; maybe IP is 0.0.0.0 initially
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
-         // Fallback if IP is 0 or string conversion failed badly
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
              log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
-             // Optionally, try parsing 127.0.0.1 back to gMyLocalIP if gMyLocalIP was 0
              if (gMyLocalIP == 0) {
                 ParseIPv4("127.0.0.1", &gMyLocalIP);
              }
@@ -88,8 +68,6 @@ OSErr InitializeNetworking(void) {
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
-
-    // 5. Initialize UDP Discovery Endpoint
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
@@ -98,35 +76,24 @@ OSErr InitializeNetworking(void) {
         gMacTCPRefNum = 0;
         return err;
     }
-
-    // 6. Initialize TCP Listener and Sender Streams (Now just the single stream)
-    err = InitTCP(gMacTCPRefNum); // Call the refactored InitTCP
+    err = InitTCP(gMacTCPRefNum);
     if (err != noErr) {
         log_message("Fatal: TCP initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Clean up UDP if TCP fails
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
         CloseResolver();
         PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
-
     log_message("Networking initialization complete.");
     return noErr;
 }
-
 void CleanupNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
-
     log_message("Cleaning up Networking (Streams, DNR, Driver)...");
-
-    // 1. Cleanup TCP Listener and Sender Streams (Now just the single stream)
-    CleanupTCP(gMacTCPRefNum); // Call the refactored CleanupTCP
-
-    // 2. Cleanup UDP Endpoint (handles its own stream release)
+    CleanupTCP(gMacTCPRefNum);
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
-
-    // 3. Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -134,75 +101,52 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
-
-    // 4. Close MacTCP Driver
     if (gMacTCPRefNum != 0) {
          log_message("Closing MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
          pb.ioParam.ioRefNum = gMacTCPRefNum;
          err = PBCloseSync(&pb);
          if (err != noErr) {
-             // This error (-24, fcbNotFound) is common if streams weren't released properly,
-             // but we attempted release in the cleanup functions. Log it but continue.
              log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d", err);
          } else {
              log_message("MacTCP driver closed.");
          }
-        gMacTCPRefNum = 0; // Mark as closed regardless of error
+        gMacTCPRefNum = 0;
     } else {
         log_message("MacTCP driver was not open.");
     }
-
     log_message("Networking cleanup complete.");
 }
-
-// Basic yield function for cooperative multitasking
 void YieldTimeToSystem(void) {
-    EventRecord event; // Dummy event record
-    // WaitNextEvent with minimal sleep allows other processes (including MacTCP background tasks) to run.
-    // Using 0 for sleep can starve other processes on some systems, 1 is safer.
+    EventRecord event;
     WaitNextEvent(0, &event, 1L, NULL);
 }
-
-// Helper to parse IPv4 string "a.b.c.d" into network byte order ip_addr
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
     unsigned long parts[4];
     int i = 0;
     char *token;
     char *rest;
-    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
-
+    char buffer[INET_ADDRSTRLEN + 1];
     if (ip_str == NULL || out_addr == NULL) {
         return paramErr;
     }
-
-    // Copy to a temporary buffer because strtok_r modifies the string
     strncpy(buffer, ip_str, INET_ADDRSTRLEN);
-    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
-
-    rest = buffer; // Initialize rest for strtok_r
-
-    // Parse up to 4 parts separated by '.'
+    buffer[INET_ADDRSTRLEN] = '\0';
+    rest = buffer;
     while ((token = strtok_r(rest, ".", &rest)) != NULL && i < 4) {
         char *endptr;
-        parts[i] = strtoul(token, &endptr, 10); // Base 10 conversion
-
-        // Check for conversion errors or out-of-range values
+        parts[i] = strtoul(token, &endptr, 10);
         if (*endptr != '\0' || parts[i] > 255) {
             log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
             *out_addr = 0;
-            return paramErr; // Return error code
+            return paramErr;
         }
         i++;
     }
-
-    // Check if exactly 4 parts were found
     if (i != 4) {
         log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
         *out_addr = 0;
-        return paramErr; // Return error code
+        return paramErr;
     }
-
-    // Combine parts into a 32-bit ip_addr (network byte order assumed by MacTCP)
     *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
-    return noErr; // Success
+    return noErr;
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,27 +1,38 @@
+//====================================
+// FILE: ./classic_mac/network.c
+//====================================
+
 #include "network.h"
 #include "logging.h"
-#include "discovery.h"
-#include "tcp.h"
-#include <Devices.h>
+#include "discovery.h" // For Init/Cleanup UDP
+#include "tcp.h"       // For InitTCP, CleanupTCP
+#include <Devices.h>   // For PBOpenSync, PBCloseSync, PBControlSync
 #include <Errors.h>
-#include <string.h>
-#include <stdlib.h>
-#include <Memory.h>
-#include <Events.h>
+#include <string.h>    // For memset, strcpy, strncpy, strtok_r
+#include <stdlib.h>    // For strtoul
+#include <Memory.h>    // For NewPtrClear, DisposePtr
+#include <Events.h>    // For WaitNextEvent
+
+// DNR Function Prototypes (assuming DNR.c provides these)
 extern OSErr OpenResolver(char *fileName);
 extern OSErr CloseResolver(void);
 extern OSErr AddrToStr(unsigned long addr, char *addrStr);
+
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser";
+char gMyUsername[32] = "MacUser"; // Default username
+
 OSErr InitializeNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
     CntrlParam cntrlPB;
+
     log_message("Initializing Networking...");
+
+    // 1. Open MacTCP Driver
     pb.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
-    pb.ioParam.ioPermssn = fsCurPerm;
+    pb.ioParam.ioPermssn = fsCurPerm; // Read/write permission
     log_message("Attempting PBOpenSync for .IPP driver...");
     err = PBOpenSync(&pb);
     if (err != noErr) {
@@ -31,6 +42,8 @@ OSErr InitializeNetworking(void) {
     }
     gMacTCPRefNum = pb.ioParam.ioRefNum;
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
+
+    // 2. Get Local IP Address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
     cntrlPB.csCode = ipctlGetAddr;
@@ -38,29 +51,37 @@ OSErr InitializeNetworking(void) {
     err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        PBCloseSync(&pb);
+        PBCloseSync(&pb); // Close driver on error
         gMacTCPRefNum = 0;
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
+    // Extract the IP address from the control parameter block
     gMyLocalIP = *((ip_addr *)(&cntrlPB.csParam[0]));
+
+    // 3. Initialize DNR (Domain Name Resolver)
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL);
+    err = OpenResolver(NULL); // Pass NULL for default resolver configuration
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        PBCloseSync(&pb);
+        PBCloseSync(&pb); // Close driver on error
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
+
+    // 4. Convert Local IP to String using DNR
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
+         // Log warning but don't necessarily fail; maybe IP is 0.0.0.0 initially
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
+         // Fallback if IP is 0 or string conversion failed badly
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
              log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
+             // Optionally, try parsing 127.0.0.1 back to gMyLocalIP if gMyLocalIP was 0
              if (gMyLocalIP == 0) {
                 ParseIPv4("127.0.0.1", &gMyLocalIP);
              }
@@ -68,6 +89,8 @@ OSErr InitializeNetworking(void) {
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
+
+    // 5. Initialize UDP Discovery Endpoint
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
@@ -76,24 +99,35 @@ OSErr InitializeNetworking(void) {
         gMacTCPRefNum = 0;
         return err;
     }
-    err = InitTCPListener(gMacTCPRefNum);
+
+    // 6. Initialize TCP Listener and Sender Streams
+    err = InitTCP(gMacTCPRefNum); // <<< UPDATED CALL
     if (err != noErr) {
-        log_message("Fatal: TCP Listener initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+        log_message("Fatal: TCP initialization failed (%d). Cleaning up.", err);
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Clean up UDP if TCP fails
         CloseResolver();
         PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
+
     log_message("Networking initialization complete.");
     return noErr;
 }
+
 void CleanupNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
+
     log_message("Cleaning up Networking (Streams, DNR, Driver)...");
-    CleanupTCPListener(gMacTCPRefNum);
+
+    // 1. Cleanup TCP Listener and Sender Streams
+    CleanupTCP(gMacTCPRefNum); // <<< UPDATED CALL
+
+    // 2. Cleanup UDP Endpoint (handles its own stream release)
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+
+    // 3. Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -101,52 +135,75 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
+
+    // 4. Close MacTCP Driver
     if (gMacTCPRefNum != 0) {
          log_message("Closing MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
          pb.ioParam.ioRefNum = gMacTCPRefNum;
          err = PBCloseSync(&pb);
          if (err != noErr) {
+             // This error (-24, fcbNotFound) is common if streams weren't released properly,
+             // but we attempted release in the cleanup functions. Log it but continue.
              log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d", err);
          } else {
              log_message("MacTCP driver closed.");
          }
-        gMacTCPRefNum = 0;
+        gMacTCPRefNum = 0; // Mark as closed regardless of error
     } else {
         log_message("MacTCP driver was not open.");
     }
+
     log_message("Networking cleanup complete.");
 }
+
+// Basic yield function for cooperative multitasking
 void YieldTimeToSystem(void) {
-    EventRecord event;
+    EventRecord event; // Dummy event record
+    // WaitNextEvent with minimal sleep allows other processes (including MacTCP background tasks) to run.
+    // Using 0 for sleep can starve other processes on some systems, 1 is safer.
     WaitNextEvent(0, &event, 1L, NULL);
 }
+
+// Helper to parse IPv4 string "a.b.c.d" into network byte order ip_addr
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
     unsigned long parts[4];
     int i = 0;
     char *token;
     char *rest;
-    char buffer[INET_ADDRSTRLEN + 1];
+    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
+
     if (ip_str == NULL || out_addr == NULL) {
         return paramErr;
     }
+
+    // Copy to a temporary buffer because strtok_r modifies the string
     strncpy(buffer, ip_str, INET_ADDRSTRLEN);
-    buffer[INET_ADDRSTRLEN] = '\0';
-    rest = buffer;
+    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
+
+    rest = buffer; // Initialize rest for strtok_r
+
+    // Parse up to 4 parts separated by '.'
     while ((token = strtok_r(rest, ".", &rest)) != NULL && i < 4) {
         char *endptr;
-        parts[i] = strtoul(token, &endptr, 10);
+        parts[i] = strtoul(token, &endptr, 10); // Base 10 conversion
+
+        // Check for conversion errors or out-of-range values
         if (*endptr != '\0' || parts[i] > 255) {
             log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
             *out_addr = 0;
-            return paramErr;
+            return paramErr; // Return error code
         }
         i++;
     }
+
+    // Check if exactly 4 parts were found
     if (i != 4) {
         log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
         *out_addr = 0;
-        return paramErr;
+        return paramErr; // Return error code
     }
+
+    // Combine parts into a 32-bit ip_addr (network byte order assumed by MacTCP)
     *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
-    return noErr;
+    return noErr; // Success
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,3 +1,7 @@
+//====================================
+// FILE: ./classic_mac/network.c
+//====================================
+
 #include "network.h"
 #include "logging.h"
 #include "discovery.h"
@@ -8,92 +12,123 @@
 #include <stdlib.h>
 #include <Memory.h>
 #include <Events.h>
+
+// External DNR function prototypes (from DNR.c or similar)
 extern OSErr OpenResolver(char *fileName);
 extern OSErr CloseResolver(void);
 extern OSErr AddrToStr(unsigned long addr, char *addrStr);
+
+// Globals
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser";
+char gMyUsername[32] = "MacUser"; // Default username
+
+
 OSErr InitializeNetworking(void) {
     OSErr err;
-    ParamBlockRec pb;
-    CntrlParam cntrlPB;
+    ParamBlockRec pbOpen; // For PBOpen of the driver
+    CntrlParam cntrlPB;   // For ipctlGetAddr
+    
     log_message("Initializing Networking...");
-    pb.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
-    pb.ioParam.ioPermssn = fsCurPerm;
+
+    // Initialize the ParamBlockRec for PBOpen
+    memset(&pbOpen, 0, sizeof(ParamBlockRec));
+    pbOpen.ioParam.ioNamePtr = (StringPtr)kTCPDriverName; // MacTCP driver name: ".IPP"
+    pbOpen.ioParam.ioPermssn = fsCurPerm; // Read/write permission (standard for drivers)
+
     log_message("Attempting PBOpenSync for .IPP driver...");
-    err = PBOpenSync(&pb);
+    err = PBOpenSync(&pbOpen); // Synchronously open the MacTCP driver
     if (err != noErr) {
-        log_message("Error: PBOpenSync failed. Error: %d", err);
+        log_message("Error: PBOpenSync for MacTCP driver failed. Error: %d", err);
         gMacTCPRefNum = 0;
         return err;
     }
-    gMacTCPRefNum = pb.ioParam.ioRefNum;
+    gMacTCPRefNum = pbOpen.ioParam.ioRefNum; // Store the driver reference number
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
+
+    // Get local IP address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
-    cntrlPB.csCode = ipctlGetAddr;
+    cntrlPB.csCode = ipctlGetAddr; // Control call to get IP address
     log_message("Attempting PBControlSync for ipctlGetAddr...");
-    err = PBControlSync((ParmBlkPtr)&cntrlPB);
+    err = PBControlSync((ParmBlkPtr)&cntrlPB); // Synchronously get IP
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        PBCloseSync(&pb);
-        gMacTCPRefNum = 0;
+        // Note: Driver is open, but we failed to get IP. 
+        // For robust cleanup, one might consider closing the driver here,
+        // but since we plan to quit if this fails, system restart will handle it.
+        gMacTCPRefNum = 0; // Invalidate refnum as networking is not fully up
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
-    BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr));
+    BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr)); // Copy IP address
+
+    // Initialize DNR (Domain Name Resolver)
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL);
+    err = OpenResolver(NULL); // Use default "Hosts" file
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        PBCloseSync(&pb);
+        // No need to explicitly close driver here on failure if app exits
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
+
+    // Convert local IP to string
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
+         // Fallback if AddrToStr fails or returns an unusable IP
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
              log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
-             if (gMyLocalIP == 0) {
-                ParseIPv4("127.0.0.1", &gMyLocalIP);
+             if (gMyLocalIP == 0) { // If gMyLocalIP was also 0, parse the fallback
+                ParseIPv4("127.0.0.1", &gMyLocalIP); 
              }
          }
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
+
+    // Initialize UDP Discovery
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
         CloseResolver();
-        PBCloseSync(&pb);
+        // No driver close here
         gMacTCPRefNum = 0;
         return err;
     }
+
+    // Initialize TCP
     err = InitTCP(gMacTCPRefNum);
     if (err != noErr) {
         log_message("Fatal: TCP initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Cleanup what was initialized
         CloseResolver();
-        PBCloseSync(&pb);
+        // No driver close here
         gMacTCPRefNum = 0;
         return err;
     }
+
     log_message("Networking initialization complete.");
     return noErr;
 }
+
 void CleanupNetworking(void) {
     OSErr err;
-    ParamBlockRec pb;
+    // ParamBlockRec pbCloseDriver; // No longer needed for closing the driver
+
     log_message("Cleaning up Networking (Streams, DNR, Driver)...");
+
+    // Cleanup TCP and UDP streams first
     CleanupTCP(gMacTCPRefNum);
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
+
+    // Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -101,52 +136,82 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
+
+    // Do NOT close the MacTCP driver itself. It's a shared system resource.
+    // The PBOpen call only gets a reference to it.
     if (gMacTCPRefNum != 0) {
-         log_message("Closing MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
-         pb.ioParam.ioRefNum = gMacTCPRefNum;
-         err = PBCloseSync(&pb);
-         if (err != noErr) {
-             log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d", err);
-         } else {
-             log_message("MacTCP driver closed.");
-         }
-        gMacTCPRefNum = 0;
+         log_message("MacTCP driver (RefNum: %d) was opened by this application. It will remain open for the system.", gMacTCPRefNum);
+        // memset(&pbCloseDriver, 0, sizeof(ParamBlockRec));
+        // pbCloseDriver.ioParam.ioRefNum = gMacTCPRefNum;
+        // log_message("Attempting PBCloseSync for MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
+        // err = PBCloseSync(&pbCloseDriver); // THIS IS THE LINE TO REMOVE / COMMENT OUT
+        // if (err != noErr) {
+        //     log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d. This is problematic.", err);
+        // } else {
+        //     log_message("MacTCP driver (RefNum: %d) closed via PBCloseSync.", gMacTCPRefNum);
+        // }
+        gMacTCPRefNum = 0; // Invalidate our reference
     } else {
-        log_message("MacTCP driver was not open.");
+        log_message("MacTCP driver was not opened by this application or already cleaned up.");
     }
+    
     log_message("Networking cleanup complete.");
 }
+
+// YieldTimeToSystem: Gives time back to the OS, allowing other processes
+// (including MacTCP background tasks) to run.
 void YieldTimeToSystem(void) {
-    EventRecord event;
-    WaitNextEvent(0, &event, 1L, NULL);
+    EventRecord event; // Dummy event record
+    // Minimal wait to cede time. The 1L is a short duration.
+    // We're not actually interested in the event, just yielding.
+    WaitNextEvent(0, &event, 1L, NULL); 
 }
+
+
+// ParseIPv4: Converts a dotted-decimal IP string to a 32-bit MacTCP ip_addr.
+// Note: MacTCP ip_addr is typically network byte order, but since we get it
+// from MacTCP calls and pass it back to MacTCP calls, we generally don't
+// need to swap bytes for MacTCP's own use. However, if displaying parts
+// or comparing with standard host order numbers, be mindful.
+// This function produces a host-order equivalent from the string for internal logic,
+// which is then implicitly treated as network order by MacTCP functions.
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
     unsigned long parts[4];
     int i = 0;
     char *token;
-    char *rest;
-    char buffer[INET_ADDRSTRLEN + 1];
+    char *rest_of_string; // Renamed to avoid conflict with standard 'rest'
+    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
+
     if (ip_str == NULL || out_addr == NULL) {
         return paramErr;
     }
+
+    // Make a writable copy of the IP string for strtok_r
     strncpy(buffer, ip_str, INET_ADDRSTRLEN);
-    buffer[INET_ADDRSTRLEN] = '\0';
-    rest = buffer;
-    while ((token = strtok_r(rest, ".", &rest)) != NULL && i < 4) {
+    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
+
+    rest_of_string = buffer;
+    while ((token = strtok_r(rest_of_string, ".", &rest_of_string)) != NULL && i < 4) {
         char *endptr;
-        parts[i] = strtoul(token, &endptr, 10);
+        parts[i] = strtoul(token, &endptr, 10); // Base 10
+        
+        // Check for conversion errors or out-of-range values
         if (*endptr != '\0' || parts[i] > 255) {
             log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
-            *out_addr = 0;
-            return paramErr;
+            *out_addr = 0; // Indicate error
+            return paramErr; 
         }
         i++;
     }
+
     if (i != 4) {
         log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
-        *out_addr = 0;
+        *out_addr = 0; // Indicate error
         return paramErr;
     }
+
+    // Assemble the ip_addr in network byte order (big-endian)
+    // which is MacTCP's native format for ip_addr.
     *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
     return noErr;
 }

--- a/classic_mac/network.c
+++ b/classic_mac/network.c
@@ -1,40 +1,27 @@
-//====================================
-// FILE: ./classic_mac/network.c
-//====================================
-
 #include "network.h"
 #include "logging.h"
-#include "discovery.h" // For Init/Cleanup UDP
-#include "tcp.h"       // For Init/Cleanup TCP Listener
-#include <Devices.h>   // For PBOpenSync, PBCloseSync, PBControlSync
+#include "discovery.h"
+#include "tcp.h"
+#include <Devices.h>
 #include <Errors.h>
-#include <string.h>    // For memset, strcpy, strncpy, strtok_r
-#include <stdlib.h>    // For strtoul
-#include <Memory.h>    // For NewPtrClear, DisposePtr
-#include <Events.h>    // For WaitNextEvent
-
-// DNR Function Prototypes (assuming DNR.c provides these)
+#include <string.h>
+#include <stdlib.h>
+#include <Memory.h>
+#include <Events.h>
 extern OSErr OpenResolver(char *fileName);
 extern OSErr CloseResolver(void);
 extern OSErr AddrToStr(unsigned long addr, char *addrStr);
-// StrToAddr might be needed if ParseIPv4 is insufficient, but let's use ParseIPv4 for now.
-// extern OSErr StrToAddr(char *hostName, struct hostInfo *rtnStruct, long resultproc, char *userDataPtr);
-
 short gMacTCPRefNum = 0;
 ip_addr gMyLocalIP = 0;
 char gMyLocalIPStr[INET_ADDRSTRLEN] = "0.0.0.0";
-char gMyUsername[32] = "MacUser"; // Default username
-
+char gMyUsername[32] = "MacUser";
 OSErr InitializeNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
     CntrlParam cntrlPB;
-
     log_message("Initializing Networking...");
-
-    // 1. Open MacTCP Driver
     pb.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
-    pb.ioParam.ioPermssn = fsCurPerm; // Read/write permission
+    pb.ioParam.ioPermssn = fsCurPerm;
     log_message("Attempting PBOpenSync for .IPP driver...");
     err = PBOpenSync(&pb);
     if (err != noErr) {
@@ -44,8 +31,6 @@ OSErr InitializeNetworking(void) {
     }
     gMacTCPRefNum = pb.ioParam.ioRefNum;
     log_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
-
-    // 2. Get Local IP Address
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
     cntrlPB.csCode = ipctlGetAddr;
@@ -53,37 +38,29 @@ OSErr InitializeNetworking(void) {
     err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
         log_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
-        PBCloseSync(&pb); // Close driver on error
+        PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
     log_message("PBControlSync(ipctlGetAddr) succeeded.");
-    // Extract the IP address from the control parameter block
     gMyLocalIP = *((ip_addr *)(&cntrlPB.csParam[0]));
-
-    // 3. Initialize DNR (Domain Name Resolver)
     log_message("Attempting OpenResolver...");
-    err = OpenResolver(NULL); // Pass NULL for default resolver configuration
+    err = OpenResolver(NULL);
     if (err != noErr) {
         log_message("Error: OpenResolver failed. Error: %d", err);
-        PBCloseSync(&pb); // Close driver on error
+        PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     } else {
         log_message("OpenResolver succeeded.");
     }
-
-    // 4. Convert Local IP to String using DNR
     log_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
-         // Log warning but don't necessarily fail; maybe IP is 0.0.0.0 initially
          log_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
-         // Fallback if IP is 0 or string conversion failed badly
          if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
              log_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
              strcpy(gMyLocalIPStr, "127.0.0.1");
-             // Optionally, try parsing 127.0.0.1 back to gMyLocalIP if gMyLocalIP was 0
              if (gMyLocalIP == 0) {
                 ParseIPv4("127.0.0.1", &gMyLocalIP);
              }
@@ -91,8 +68,6 @@ OSErr InitializeNetworking(void) {
     } else {
         log_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
-
-    // 5. Initialize UDP Discovery Endpoint
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
      if (err != noErr) {
         log_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
@@ -101,35 +76,24 @@ OSErr InitializeNetworking(void) {
         gMacTCPRefNum = 0;
         return err;
     }
-
-    // 6. Initialize TCP Listener Stream
     err = InitTCPListener(gMacTCPRefNum);
     if (err != noErr) {
         log_message("Fatal: TCP Listener initialization failed (%d). Cleaning up.", err);
-        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum); // Clean up UDP if TCP fails
+        CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
         CloseResolver();
         PBCloseSync(&pb);
         gMacTCPRefNum = 0;
         return err;
     }
-
     log_message("Networking initialization complete.");
     return noErr;
 }
-
 void CleanupNetworking(void) {
     OSErr err;
     ParamBlockRec pb;
-
     log_message("Cleaning up Networking (Streams, DNR, Driver)...");
-
-    // 1. Cleanup TCP Listener (handles its own stream release)
     CleanupTCPListener(gMacTCPRefNum);
-
-    // 2. Cleanup UDP Endpoint (handles its own stream release)
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
-
-    // 3. Close DNR
     log_message("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
@@ -137,75 +101,52 @@ void CleanupNetworking(void) {
     } else {
         log_message("CloseResolver succeeded.");
     }
-
-    // 4. Close MacTCP Driver
     if (gMacTCPRefNum != 0) {
          log_message("Closing MacTCP driver (RefNum: %d)...", gMacTCPRefNum);
          pb.ioParam.ioRefNum = gMacTCPRefNum;
          err = PBCloseSync(&pb);
          if (err != noErr) {
-             // This error (-24, fcbNotFound) is common if streams weren't released properly,
-             // but we attempted release in the cleanup functions. Log it but continue.
              log_message("Warning: PBCloseSync failed for MacTCP driver. Error: %d", err);
          } else {
              log_message("MacTCP driver closed.");
          }
-        gMacTCPRefNum = 0; // Mark as closed regardless of error
+        gMacTCPRefNum = 0;
     } else {
         log_message("MacTCP driver was not open.");
     }
-
     log_message("Networking cleanup complete.");
 }
-
-// Basic yield function for cooperative multitasking
 void YieldTimeToSystem(void) {
-    EventRecord event; // Dummy event record
-    // WaitNextEvent with minimal sleep allows other processes (including MacTCP background tasks) to run.
-    // Using 0 for sleep can starve other processes on some systems, 1 is safer.
+    EventRecord event;
     WaitNextEvent(0, &event, 1L, NULL);
 }
-
-// Helper to parse IPv4 string "a.b.c.d" into network byte order ip_addr
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr) {
     unsigned long parts[4];
     int i = 0;
     char *token;
     char *rest;
-    char buffer[INET_ADDRSTRLEN + 1]; // +1 for null terminator
-
+    char buffer[INET_ADDRSTRLEN + 1];
     if (ip_str == NULL || out_addr == NULL) {
         return paramErr;
     }
-
-    // Copy to a temporary buffer because strtok_r modifies the string
     strncpy(buffer, ip_str, INET_ADDRSTRLEN);
-    buffer[INET_ADDRSTRLEN] = '\0'; // Ensure null termination
-
-    rest = buffer; // Initialize rest for strtok_r
-
-    // Parse up to 4 parts separated by '.'
+    buffer[INET_ADDRSTRLEN] = '\0';
+    rest = buffer;
     while ((token = strtok_r(rest, ".", &rest)) != NULL && i < 4) {
         char *endptr;
-        parts[i] = strtoul(token, &endptr, 10); // Base 10 conversion
-
-        // Check for conversion errors or out-of-range values
+        parts[i] = strtoul(token, &endptr, 10);
         if (*endptr != '\0' || parts[i] > 255) {
             log_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
             *out_addr = 0;
-            return paramErr; // Return error code
+            return paramErr;
         }
         i++;
     }
-
-    // Check if exactly 4 parts were found
     if (i != 4) {
         log_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
         *out_addr = 0;
-        return paramErr; // Return error code
+        return paramErr;
     }
-
-    // Combine parts into a 32-bit ip_addr (network byte order assumed by MacTCP)
     *out_addr = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
-    return noErr; // Success
+    return noErr;
 }

--- a/classic_mac/network.h
+++ b/classic_mac/network.h
@@ -1,17 +1,37 @@
+//====================================
+// FILE: ./classic_mac/network.h
+//====================================
+
 #ifndef NETWORK_H
-#define NETWORK_H 
+#define NETWORK_H
+
 #include <MacTypes.h>
-#include "discovery.h"
-#define __MACTCPCOMMONTYPES__ 
-#include <AddressXlation.h>
+#include "discovery.h" // Keep for OSErr definition if not elsewhere
+#define __MACTCPCOMMONTYPES__ // Define before including MacTCP.h if needed by other headers
+#include <AddressXlation.h> // For AddrToStr, StrToAddr if used directly
+#include <MacTCP.h>         // For ip_addr, tcp_port etc.
 #include "common_defs.h"
-#include "tcp.h"
+
 #define kTCPDriverName "\p.IPP"
-#define ipctlGetAddr 15
-extern short gMacTCPRefNum;
-extern ip_addr gMyLocalIP;
-extern char gMyLocalIPStr[INET_ADDRSTRLEN];
-extern char gMyUsername[32];
+#define ipctlGetAddr 15 // Control code to get local IP address
+
+extern short gMacTCPRefNum; // Reference number for the MacTCP driver
+extern ip_addr gMyLocalIP;  // Local IP address in network byte order
+extern char gMyLocalIPStr[INET_ADDRSTRLEN]; // Local IP address as a C-string
+extern char gMyUsername[32]; // User's chosen name
+
+// Initializes MacTCP driver, DNR, UDP, and TCP listener.
+// Returns noErr on success, or an OSErr otherwise.
 OSErr InitializeNetworking(void);
+
+// Cleans up TCP listener, UDP endpoint, DNR, and closes MacTCP driver.
 void CleanupNetworking(void);
-#endif
+
+// Basic yield function for cooperative multitasking during sync network calls.
+void YieldTimeToSystem(void);
+
+// Helper to convert IP address string to network byte order ip_addr.
+// Returns noErr on success, paramErr on failure.
+OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr);
+
+#endif // NETWORK_H

--- a/classic_mac/network.h
+++ b/classic_mac/network.h
@@ -1,37 +1,19 @@
-//====================================
-// FILE: ./classic_mac/network.h
-//====================================
-
 #ifndef NETWORK_H
-#define NETWORK_H
-
+#define NETWORK_H 
 #include <MacTypes.h>
-#include "discovery.h" // Keep for OSErr definition if not elsewhere
-#define __MACTCPCOMMONTYPES__ // Define before including MacTCP.h if needed by other headers
-#include <AddressXlation.h> // For AddrToStr, StrToAddr if used directly
-#include <MacTCP.h>         // For ip_addr, tcp_port etc.
+#include "discovery.h"
+#define __MACTCPCOMMONTYPES__ 
+#include <AddressXlation.h>
+#include <MacTCP.h>
 #include "common_defs.h"
-
 #define kTCPDriverName "\p.IPP"
-#define ipctlGetAddr 15 // Control code to get local IP address
-
-extern short gMacTCPRefNum; // Reference number for the MacTCP driver
-extern ip_addr gMyLocalIP;  // Local IP address in network byte order
-extern char gMyLocalIPStr[INET_ADDRSTRLEN]; // Local IP address as a C-string
-extern char gMyUsername[32]; // User's chosen name
-
-// Initializes MacTCP driver, DNR, UDP, and TCP listener.
-// Returns noErr on success, or an OSErr otherwise.
+#define ipctlGetAddr 15
+extern short gMacTCPRefNum;
+extern ip_addr gMyLocalIP;
+extern char gMyLocalIPStr[INET_ADDRSTRLEN];
+extern char gMyUsername[32];
 OSErr InitializeNetworking(void);
-
-// Cleans up TCP listener, UDP endpoint, DNR, and closes MacTCP driver.
 void CleanupNetworking(void);
-
-// Basic yield function for cooperative multitasking during sync network calls.
 void YieldTimeToSystem(void);
-
-// Helper to convert IP address string to network byte order ip_addr.
-// Returns noErr on success, paramErr on failure.
 OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr);
-
-#endif // NETWORK_H
+#endif

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,16 +1,11 @@
-//====================================
-// FILE: ./classic_mac/tcp.c
-//====================================
-
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
 #include "dialog.h"
 #include "dialog_peerlist.h"
-#include "network.h" // For gMacTCPRefNum, gMyLocalIPStr, gMyUsername, ParseIPv4
-#include "../shared/messaging_logic.h" // For handle_received_tcp_message
-
+#include "network.h"
+#include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
 #include <MacTypes.h>
@@ -18,46 +13,35 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <Events.h>  // For Delay
-#include <OSUtils.h> // For TickCount if needed, though Delay takes dummy timer
-
-// MacTCP Constants (ensure these are defined or use MacTCP headers if available)
+#include <Events.h>
+#include <OSUtils.h>
 #define kTCPRecvBufferSize 8192
-#define kTCPInternalBufferSize 8192 // For TCPCreate's rcvBuff
-
-// Timeouts, chosen empirically or from documentation recommendations
-#define kTCPPassiveOpenULPTimeoutSeconds 2 // ULP timeout for passive open (TCP default)
-#define kTCPListenPollTimeoutTicks 150      // How long OUR app polls a single PassiveOpen call
-#define kTCPRecvPollTimeoutTicks 1        // How long OUR app polls a single Rcv Call
-#define kTCPStatusPollTimeoutTicks 1      // How long OUR app polls a single Status call
-
-#define kConnectTimeoutTicks 300    // Approx 5 seconds for ActiveOpen ULP Timeout
-#define kSendTimeoutTicks 180       // Approx 3 seconds for Send ULP Timeout
-#define kAbortTimeoutTicks 60      // Approx 1 second for Abort ULP timeout
-#define kQuitLoopDelayTicks 120    // Approx 2 seconds delay between sending QUIT to peers
-#define kErrorRetryDelayTicks 120   // Approx 2 seconds delay after certain recoverable errors
-
-// MacTCP Error Codes (from MacTCPCommontypes.h or equivalent documentation)
-#define kMacTCPTimeoutErr (-23016)  // commandTimeout
-#define kDuplicateSocketErr (-23017) // duplicateSocket
-#define kConnectionExistsErr (-23007) // connectionExists
-#define kConnectionClosingErr (-23005) // connectionClosing
-#define kConnectionDoesntExistErr (-23008) // connectionDoesntExist
-#define kInvalidStreamPtrErr (-23010) // invalidStreamPtr
-#define kInvalidWDSErr (-23014)       // Use for invalidWDS checks
-#define kInvalidBufPtrErr (-23013)    // Use for invalidBufPtr checks
-#define AbortTrue 1 // For ULP Timeout Action
-
-// --- TCP State Machine and Globals ---
-static StreamPtr gTCPStream = NULL;         // Our single TCP stream
-static Ptr gTCPInternalBuffer = NULL;   // Buffer for TCPCreate (manages connection state)
-static Ptr gTCPRecvBuffer = NULL;       // Our application buffer for TCPRcv
+#define kTCPInternalBufferSize 8192
+#define kTCPPassiveOpenULPTimeoutSeconds 2
+#define kTCPListenPollTimeoutTicks 150
+#define kTCPRecvPollTimeoutTicks 1
+#define kTCPStatusPollTimeoutTicks 1
+#define kConnectTimeoutTicks 300
+#define kSendTimeoutTicks 180
+#define kAbortTimeoutTicks 60
+#define kQuitLoopDelayTicks 120
+#define kErrorRetryDelayTicks 120
+#define kMacTCPTimeoutErr (-23016)
+#define kDuplicateSocketErr (-23017)
+#define kConnectionExistsErr (-23007)
+#define kConnectionClosingErr (-23005)
+#define kConnectionDoesntExistErr (-23008)
+#define kInvalidStreamPtrErr (-23010)
+#define kInvalidWDSErr (-23014)
+#define kInvalidBufPtrErr (-23013)
+#define AbortTrue 1
+static StreamPtr gTCPStream = NULL;
+static Ptr gTCPInternalBuffer = NULL;
+static Ptr gTCPRecvBuffer = NULL;
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static Boolean gIsSending = false;          // Simple mutex for send operations
-static ip_addr gPeerIP = 0;             // IP of the currently connected peer (for incoming)
-static tcp_port gPeerPort = 0;           // Port of the currently connected peer (for incoming)
-
-// Forward declarations for static helper functions
+static Boolean gIsSending = false;
+static ip_addr gPeerIP = 0;
+static tcp_port gPeerPort = 0;
 static void ProcessTCPReceive(unsigned short dataLength);
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
@@ -68,57 +52,46 @@ static OSErr LowTCPRcvSyncPoll(SInt8 pollTimeoutTicks, Ptr buffer, unsigned shor
 static OSErr LowTCPStatusSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
 static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicks, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
-
-
-// --- Platform Callbacks for Shared Messaging Logic ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context; // Unused
+    (void)platform_context;
     int addResult = AddOrUpdatePeer(ip, username);
-    if (addResult > 0) { // New peer added
+    if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
-    } else if (addResult < 0) { // List full or other error
+    } else if (addResult < 0) {
         log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
-
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context; // Unused
-    (void)ip; // IP is available if needed, but username is primary for display
+    (void)platform_context;
+    (void)ip;
     char displayMsg[BUFFER_SIZE + 100];
-
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
-        AppendToMessagesTE("\r"); // Newline for Mac TE
+        AppendToMessagesTE("\r");
         log_message("Message from %s@%s: %s", username, ip, message_content);
     } else {
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
-
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context; // Unused
+    (void)platform_context;
     if (!ip) return;
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     }
 }
-
-// --- TCP Initialization and Cleanup ---
 OSErr InitTCP(short macTCPRefNum) {
     OSErr err;
     log_message("Initializing Single TCP Stream (Sync Poll Strategy)...");
-
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
         log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
-        return streamAlreadyOpen; // -23011
+        return streamAlreadyOpen;
     }
-
-    // Allocate buffers
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
@@ -129,43 +102,35 @@ OSErr InitTCP(short macTCPRefNum) {
         return memFullErr;
     }
     log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
-
     log_message("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
         log_message("Error: Failed to create TCP Stream: %d", err);
-        CleanupTCP(macTCPRefNum); // Cleanup partial allocations
+        CleanupTCP(macTCPRefNum);
         return err;
     }
     log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
-
     gTCPState = TCP_STATE_IDLE;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
     log_message("TCP initialization complete. State: IDLE.");
     return noErr;
 }
-
 void CleanupTCP(short macTCPRefNum) {
     log_message("Cleaning up Single TCP Stream (Sync Poll Strategy)...");
-    StreamPtr streamToRelease = gTCPStream; // Cache before modifying globals
+    StreamPtr streamToRelease = gTCPStream;
     TCPState stateBeforeCleanup = gTCPState;
-
-    // Tentatively set state to prevent re-entry or further operations
-    gTCPState = TCP_STATE_RELEASING; 
-    gTCPStream = NULL; // Mark stream as unusable *before* trying to release
-
+    gTCPState = TCP_STATE_RELEASING;
+    gTCPStream = NULL;
     if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_LISTENING_POLL) {
          log_message("Cleanup: Attempting synchronous abort (best effort)...");
          if (streamToRelease != NULL) {
-             // Temporarily restore gTCPStream for LowTCPAbortSyncPoll
-             StreamPtr currentGlobalStream = gTCPStream; 
-             gTCPStream = streamToRelease; 
+             StreamPtr currentGlobalStream = gTCPStream;
+             gTCPStream = streamToRelease;
              LowTCPAbortSyncPoll(kAbortTimeoutTicks, YieldTimeToSystem);
-             gTCPStream = currentGlobalStream; // Restore (now NULL)
+             gTCPStream = currentGlobalStream;
          }
     }
-
     if (streamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
         OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
@@ -174,441 +139,333 @@ void CleanupTCP(short macTCPRefNum) {
     } else if (streamToRelease != NULL) {
         log_message("Warning: Cannot release stream, MacTCP refnum is 0 or stream already NULLed.");
     }
-
-    // Final state and resource cleanup
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
-
     if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; }
     if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; }
     log_message("TCP cleanup finished.");
 }
-
-
-// --- Main TCP Polling Logic ---
 void PollTCP(GiveTimePtr giveTime) {
     OSErr err;
     unsigned short amountUnread = 0;
-    Byte connectionState = 0; // MacTCP connection state (0=closed, 2=listen, 8=established, etc.)
-    unsigned long dummyTimer; // For Delay()
-
+    Byte connectionState = 0;
+    unsigned long dummyTimer;
     if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
-        return; // Not in a pollable state
+        return;
     }
-    if (gIsSending) { return; } // Don't interfere with an active send operation
-
+    if (gIsSending) { return; }
     switch (gTCPState) {
         case TCP_STATE_IDLE:
             log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll (ULP: %ds, AppPoll: %d ticks)...", kTCPPassiveOpenULPTimeoutSeconds, kTCPListenPollTimeoutTicks);
             err = LowTCPPassiveOpenSyncPoll(kTCPListenPollTimeoutTicks, giveTime);
             if (err == noErr) {
-                char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr); // gPeerIP set by LowTCPPassiveOpenSyncPoll
+                char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr);
                 log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
                 gTCPState = TCP_STATE_CONNECTED_IN;
-                goto CheckConnectedInData; // Immediately check this new connection for data
-            } else if (err == commandTimeout) { // -23016
+                goto CheckConnectedInData;
+            } else if (err == commandTimeout) {
                 log_to_file_only("PollTCP: Passive Open Poll window (%d ticks) timed out. No connection. Returning to IDLE.", kTCPListenPollTimeoutTicks);
-                gTCPState = TCP_STATE_IDLE; // Remain idle
-            } else if (err == kDuplicateSocketErr || err == kConnectionExistsErr) { // -23017 or -23007
+                gTCPState = TCP_STATE_IDLE;
+            } else if (err == kDuplicateSocketErr || err == kConnectionExistsErr) {
                 log_message("PollTCP: Passive Open Poll failed with %d. Attempting to Abort stream to reset.", err);
-                // ** NEW LOGIC FOR Issue 2 **
-                // Abort the stream to clear the problematic state before trying passive open again.
                 OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
                 if (abortErr == noErr) {
                     log_message("PollTCP: Abort successful after Passive Open failure. Will retry passive open.");
                 } else {
                     log_message("PollTCP: CRITICAL - Abort FAILED (%d) after Passive Open failure. TCP might be stuck.", abortErr);
-                    // Consider moving to TCP_STATE_ERROR if abort repeatedly fails.
                 }
-                gTCPState = TCP_STATE_IDLE; // Remain idle, will retry passive open next cycle
+                gTCPState = TCP_STATE_IDLE;
                 log_message("PollTCP: Delaying %d ticks due to error %d before retrying passive open.", kErrorRetryDelayTicks, err);
                 Delay(kErrorRetryDelayTicks, &dummyTimer);
             } else {
                 log_message("PollTCP: Passive Open Poll failed with other error: %d. Returning to IDLE.", err);
-                gTCPState = TCP_STATE_IDLE; // Remain idle
+                gTCPState = TCP_STATE_IDLE;
             }
             break;
-
         case TCP_STATE_CONNECTED_IN:
-CheckConnectedInData: // Label for goto from successful passive open
+CheckConnectedInData:
             log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
             err = LowTCPStatusSyncPoll(kTCPStatusPollTimeoutTicks, giveTime, &amountUnread, &connectionState);
             if (err != noErr) {
                 log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
-                LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Attempt to clean up
-                gTCPState = TCP_STATE_IDLE; // Reset state machine
+                LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                gTCPState = TCP_STATE_IDLE;
                 break;
             }
-
-            // MacTCP States: 8 (Established), 10 (FIN_WAIT_1), 12 (FIN_WAIT_2), 14 (CLOSE_WAIT)
-            // We are interested if it's NOT one of these active/closing states.
             if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
                  char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                  log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Assuming closed/aborted. Returning to IDLE.", connectionState, peerIPStr);
-                 gTCPState = TCP_STATE_IDLE; // Connection is no longer valid
+                 gTCPState = TCP_STATE_IDLE;
                  break;
             }
-            
             log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
             if (amountUnread > 0) {
-                unsigned short bytesToRead = kTCPRecvBufferSize; // Max to read in one go
+                unsigned short bytesToRead = kTCPRecvBufferSize;
                 Boolean markFlag = false, urgentFlag = false;
                 log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
                 err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
-                
                 if (err == noErr) {
                     log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                     ProcessTCPReceive(bytesToRead);
-                    // Remain in TCP_STATE_CONNECTED_IN to check for more data or state changes
-                } else if (err == kConnectionClosingErr) { // -23005 "all data on this connection has already been delivered"
+                } else if (err == kConnectionClosingErr) {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
-                    if (bytesToRead > 0) ProcessTCPReceive(bytesToRead); // Process any last bytes
-                    gTCPState = TCP_STATE_IDLE; // Connection is gracefully closing from peer end
-                } else if (err == commandTimeout) { // -23016
+                    if (bytesToRead > 0) ProcessTCPReceive(bytesToRead);
+                    gTCPState = TCP_STATE_IDLE;
+                } else if (err == commandTimeout) {
                      log_to_file_only("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
-                     // Remain in TCP_STATE_CONNECTED_IN
-                } else { // Other errors
+                } else {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
-                    LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Attempt to clean up
-                    gTCPState = TCP_STATE_IDLE; // Reset state machine
+                    LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                    gTCPState = TCP_STATE_IDLE;
                 }
-            } else { // No unread data
-                 if (connectionState == 14 ) { // CLOSE_WAIT: peer has closed, waiting for us to close
+            } else {
+                 if (connectionState == 14 ) {
                      char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                      log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Returning to IDLE.", peerIPStr);
-                     // MacTCP should transition out of this, or we might need to TCPClose then TCPAbort if it lingers.
-                     // For now, returning to IDLE will attempt a Passive Open, which might clear this state
-                     // or we might need a TCPClose here.
-                     // Let's try aborting our end to fully close it.
                      LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
                      gTCPState = TCP_STATE_IDLE;
                  }
-                 // If state is 8, 10, 12 and no data, just continue polling status.
             }
             break;
-
-        // Other states (LISTENING_POLL, ERROR, RELEASING, UNINITIALIZED) are handled by the initial checks or not directly polled here.
         default:
             log_message("PollTCP: In unexpected state %d.", gTCPState);
-            gTCPState = TCP_STATE_IDLE; // Attempt to recover
+            gTCPState = TCP_STATE_IDLE;
             break;
     }
 }
-
 TCPState GetTCPState(void) { return gTCPState; }
-
-// --- TCP Send Operations ---
 OSErr TCP_SendTextMessageSync(const char *peerIPStr, const char *message, GiveTimePtr giveTime) {
     OSErr err = noErr, finalErr = noErr;
     ip_addr targetIP = 0;
     char messageBuffer[BUFFER_SIZE];
     int formattedLen;
-    struct wdsEntry sendWDS[2]; // Simple WDS: one buffer for message, one terminator
-
+    struct wdsEntry sendWDS[2];
     log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIPStr);
-
     if (gMacTCPRefNum == 0) return notOpenErr;
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
     if (peerIPStr == NULL || message == NULL || giveTime == NULL) return paramErr;
-
-    if (gIsSending) { 
-        log_message("Warning (SendText): Send already in progress."); 
-        return streamBusyErr; // Or a specific "busy" error
+    if (gIsSending) {
+        log_message("Warning (SendText): Send already in progress.");
+        return streamBusyErr;
     }
-    if (gTCPState != TCP_STATE_IDLE) { 
-        log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState); 
-        return streamBusyErr; // Or a specific "state" error
+    if (gTCPState != TCP_STATE_IDLE) {
+        log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState);
+        return streamBusyErr;
     }
-
-    gIsSending = true; // Acquire "lock"
-
+    gIsSending = true;
     err = ParseIPv4(peerIPStr, &targetIP);
     if (err != noErr || targetIP == 0) {
         log_message("Error (SendText): Invalid peer IP '%s'.", peerIPStr);
         finalErr = paramErr;
         goto SendTextCleanup;
     }
-
     formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message);
     if (formattedLen <= 0) {
         log_message("Error (SendText): format_message failed.");
-        finalErr = paramErr; // Or a specific formatting error
+        finalErr = paramErr;
         goto SendTextCleanup;
     }
-
     log_to_file_only("SendText: Connecting to %s...", peerIPStr);
     err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
         log_to_file_only("SendText: Connected successfully to %s.", peerIPStr);
-        sendWDS[0].length = formattedLen; // MacTCP expects length of data, not including null terminator for strings
+        sendWDS[0].length = formattedLen;
         sendWDS[0].ptr = (Ptr)messageBuffer;
-        sendWDS[1].length = 0; // Terminator for WDS
+        sendWDS[1].length = 0;
         sendWDS[1].ptr = NULL;
-
         log_to_file_only("SendText: Sending data (%d bytes)...", formattedLen);
-        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true /*pushFlag*/, (Ptr)sendWDS, giveTime);
+        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true , (Ptr)sendWDS, giveTime);
         if (err != noErr) {
             log_message("Error (SendText): Send failed to %s: %d", peerIPStr, err);
             finalErr = err;
         } else {
             log_to_file_only("SendText: Send successful to %s.", peerIPStr);
         }
-
-        // Always abort after send for this simple client model
         log_to_file_only("SendText: Aborting connection to %s...", peerIPStr);
-        OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Use specific abort timeout
+        OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
         if (abortErr != noErr) {
             log_message("Warning (SendText): Abort failed for %s: %d", peerIPStr, abortErr);
-            if (finalErr == noErr) finalErr = abortErr; // Report abort error if send was okay
+            if (finalErr == noErr) finalErr = abortErr;
         }
     } else {
         log_message("Error (SendText): Connect to %s failed: %d", peerIPStr, err);
-        finalErr = err; // Store the connect error
+        finalErr = err;
     }
-
 SendTextCleanup:
-    gIsSending = false; // Release "lock"
-    gTCPState = TCP_STATE_IDLE; // Ensure state is reset to IDLE after send attempt
+    gIsSending = false;
+    gTCPState = TCP_STATE_IDLE;
     log_to_file_only("TCP_SendTextMessageSync to %s: Released send lock. Final Status: %d.", peerIPStr, finalErr);
     return finalErr;
 }
-
-
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
     int i;
     OSErr lastErr = noErr, currentErr = noErr;
     char quitMessageBuffer[BUFFER_SIZE];
     int formattedLen, activePeerCount = 0, sentCount = 0;
-    unsigned long dummyTimer; // For Delay()
+    unsigned long dummyTimer;
     struct wdsEntry sendWDS[2];
-
     log_message("TCP_SendQuitMessagesSync: Starting...");
-
     if (gMacTCPRefNum == 0) return notOpenErr;
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
     if (giveTime == NULL) return paramErr;
-
-    if (gIsSending) { 
-        log_message("Warning (SendQuit): Send already in progress."); 
-        return streamBusyErr; 
+    if (gIsSending) {
+        log_message("Warning (SendQuit): Send already in progress.");
+        return streamBusyErr;
     }
-    // Check if stream is IDLE. If not, it implies an incoming connection might be active,
-    // which means we shouldn't interfere.
     if (gTCPState != TCP_STATE_IDLE) {
         log_message("Warning (SendQuit): Stream not IDLE (state %d). Cannot send QUIT now. Peer might be connecting.", gTCPState);
         return streamBusyErr;
     }
-    
-    gIsSending = true; // Acquire "lock"
-
+    gIsSending = true;
     formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, "");
     if (formattedLen <= 0) {
         log_message("Error (SendQuit): format_message for QUIT failed.");
         lastErr = paramErr;
         goto SendQuitCleanup;
     }
-
     for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
     log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
     if (activePeerCount == 0) {
-        lastErr = noErr; // No peers to notify is not an error
+        lastErr = noErr;
         goto SendQuitCleanup;
     }
-
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
             ip_addr currentTargetIP = 0;
-            currentErr = noErr; // Reset for this peer
-
-            // Double check state before each peer, though gIsSending should protect this.
-            if (gTCPState != TCP_STATE_IDLE) { 
+            currentErr = noErr;
+            if (gTCPState != TCP_STATE_IDLE) {
                 log_message("CRITICAL (SendQuit): State became non-IDLE (%d) during QUIT loop for peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip);
-                if (lastErr == noErr) lastErr = ioErr; // Indicate a general I/O problem
-                break; 
+                if (lastErr == noErr) lastErr = ioErr;
+                break;
             }
-
             log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
             currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
             if (currentErr != noErr || currentTargetIP == 0) {
                 log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip);
                 if (lastErr == noErr) lastErr = currentErr;
-                goto NextPeerDelay; // Use goto for clarity to reach delay
+                goto NextPeerDelay;
             }
-
             log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip);
             currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
-            
             if (currentErr == noErr) {
                 log_to_file_only("SendQuit: Connected successfully to %s.", gPeerManager.peers[i].ip);
                 sendWDS[0].length = formattedLen;
                 sendWDS[0].ptr = (Ptr)quitMessageBuffer;
                 sendWDS[1].length = 0;
                 sendWDS[1].ptr = NULL;
-
                 log_to_file_only("SendQuit: Sending data to %s...", gPeerManager.peers[i].ip);
-                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true /*pushFlag*/, (Ptr)sendWDS, giveTime);
+                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true , (Ptr)sendWDS, giveTime);
                 if (currentErr == noErr) {
                     log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip);
                     sentCount++;
                 } else {
                     log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
-                    if (lastErr == noErr) lastErr = currentErr; // Capture first send error
+                    if (lastErr == noErr) lastErr = currentErr;
                 }
-                
                 log_to_file_only("SendQuit: Aborting connection to %s...", gPeerManager.peers[i].ip);
                 OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
                 if (abortErr != noErr) {
                     log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr);
-                    if (lastErr == noErr) lastErr = abortErr; // Capture first abort error
+                    if (lastErr == noErr) lastErr = abortErr;
                 }
-            } else { // ActiveOpen failed
+            } else {
                 log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
-                // **NEW LOGIC FOR Issue 4**
-                if (lastErr == noErr) lastErr = currentErr; // Capture the connect error
-                // Special handling for connectionExists during QUIT send
+                if (lastErr == noErr) lastErr = currentErr;
                 if (currentErr == kConnectionExistsErr) {
                      log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
-                     // Don't treat this specific error as a failure that prevents other QUITs necessarily,
-                     // but it should be reflected in lastErr if no other "harder" errors occurred.
                 }
             }
         NextPeerDelay:
             log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
-            giveTime(); // Yield first
-            Delay(kQuitLoopDelayTicks, &dummyTimer); // Then delay
+            giveTime();
+            Delay(kQuitLoopDelayTicks, &dummyTimer);
         }
     }
-
 SendQuitCleanup:
-    gIsSending = false; // Release "lock"
-    gTCPState = TCP_STATE_IDLE; // Ensure stream is IDLE after attempts
+    gIsSending = false;
+    gTCPState = TCP_STATE_IDLE;
     log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
     return lastErr;
 }
-
-
-// --- TCP Data Processing and Low-Level Wrappers ---
-
 static void ProcessTCPReceive(unsigned short dataLength) {
     char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN]; // Parsed from message
+    char senderIPStrFromPayload[INET_ADDRSTRLEN];
     char senderUsername[32];
     char msgType[32];
     char content[BUFFER_SIZE];
-
-    // Static struct for callbacks, initialized once
     static tcp_platform_callbacks_t mac_callbacks = {
         .add_or_update_peer = mac_tcp_add_or_update_peer,
         .display_text_message = mac_tcp_display_text_message,
         .mark_peer_inactive = mac_tcp_mark_peer_inactive
     };
-
     if (dataLength > 0 && gTCPRecvBuffer != NULL) {
-        // Get sender's IP from the connection parameters (gPeerIP is set by PassiveOpen)
         OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
-        if (addrErr != noErr) { // Fallback if AddrToStr fails
+        if (addrErr != noErr) {
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
             log_to_file_only("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
         }
-
-        // Ensure received data is null-terminated for string operations (parse_message)
-        // This is safe because gTCPRecvBuffer is kTCPRecvBufferSize.
         if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0';
-        else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; // Max case
-
+        else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0';
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
             log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
                              msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
-            // Use senderIPStrFromConnection (actual source IP of TCP segment) for identification
             handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL);
-
             if (strcmp(msgType, MSG_QUIT) == 0) {
                 log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
-                // The PollTCP state machine will see the connection state change (e.g. to CLOSE_WAIT)
-                // and should transition to IDLE.
             }
         } else {
             log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
         }
     } else if (dataLength == 0) {
         log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal or KeepAlive).");
-    } else { // Should not happen if dataLength > 0
+    } else {
         log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
     }
 }
-
-
-// LowLevelSyncPoll: Generic wrapper for making asynchronous MacTCP calls
-// and polling them to completion synchronously.
-// Takes a 'pollTimeoutTicks' for how long *this wrapper* will poll, not the ULP timeout.
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks) {
     OSErr err;
     unsigned long startTime = TickCount();
-
     if (pBlock == NULL || giveTime == NULL) return paramErr;
-
-    pBlock->ioCompletion = nil; // Synchronous polling
-    pBlock->ioCRefNum = gMacTCPRefNum; // Ensure this is always set
-    pBlock->tcpStream = gTCPStream;   // Ensure this is always set for stream operations
-    pBlock->ioResult = 1;       // Must be > 0 for async calls (InProgress equivalent for MacTCP)
-    pBlock->csCode = csCode;    // The specific TCP command
-
+    pBlock->ioCompletion = nil;
+    pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->tcpStream = gTCPStream;
+    pBlock->ioResult = 1;
+    pBlock->csCode = csCode;
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
         log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
         return err;
     }
-
-    // Poll for completion or app-defined timeout
-    // Note: appPollTimeoutTicks = 0 means poll indefinitely until ioResult changes
-    while (pBlock->ioResult > 0) { 
-        giveTime(); // Critical to allow MacTCP to process
+    while (pBlock->ioResult > 0) {
+        giveTime();
         if (appPollTimeoutTicks > 0 && (TickCount() - startTime) >= (unsigned long)appPollTimeoutTicks) {
-            // Application-level polling timeout detected.
-            // This is NOT a MacTCP ULP timeout. It means OUR polling loop timed out.
-            // We need to tell MacTCP to cancel THIS specific operation if possible, or just return a timeout.
-            // For many calls like Open/Send/Rcv, MacTCP has its own ULP timeout.
-            // This wrapper's timeout is more of a fallback for calls that might not have one
-            // or if we want to limit how long *we* wait for MacTCP's own timeout.
             log_to_file_only("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
-            // It's tricky to "cancel" a pending PBControlAsync without aborting the whole stream.
-            // For now, we assume MacTCP's internal ULP timeouts are the primary mechanism.
-            // This timeout here mostly protects OUR main loop from getting stuck if ioResult somehow
-            // never changes from 1 for a call that should eventually complete or error out.
-            // Let's return a generic timeout, MacTCP's ioResult might still be 1.
-            // In practice, for TCP calls, MacTCP's ULP timeouts (set in csParams) should trigger first.
-            return commandTimeout; // Indicate OUR polling loop timed out.
+            return commandTimeout;
         }
     }
-    return pBlock->ioResult; // Return MacTCP's final result code
+    return pBlock->ioResult;
 }
-
-
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr rcvBuff, unsigned long rcvBuffLen) {
     OSErr err;
     TCPiopb pbCreate;
-
     if (streamPtrOut == NULL || rcvBuff == NULL) return paramErr;
-
     memset(&pbCreate, 0, sizeof(TCPiopb));
-    pbCreate.ioCompletion = nil; // Synchronous
+    pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L; // Output from MacTCP
-
+    pbCreate.tcpStream = 0L;
     pbCreate.csParam.create.rcvBuff = rcvBuff;
-    pbCreate.csParam.create.rcvBuffLen = rcvBuffLen; // Typically kTCPInternalBufferSize
-    pbCreate.csParam.create.notifyProc = nil; // No ASR for this simple client
-
-    err = PBControlSync((ParmBlkPtr)&pbCreate); // TCPCreate is typically fast, direct sync is okay
+    pbCreate.csParam.create.rcvBuffLen = rcvBuffLen;
+    pbCreate.csParam.create.notifyProc = nil;
+    err = PBControlSync((ParmBlkPtr)&pbCreate);
     if (err == noErr) {
         *streamPtrOut = pbCreate.tcpStream;
         if (*streamPtrOut == NULL) {
             log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
-            err = ioErr; // General I/O error
+            err = ioErr;
         }
     } else {
         *streamPtrOut = NULL;
@@ -616,181 +473,119 @@ static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr r
     }
     return err;
 }
-
-// Listens for an incoming connection. Sets gPeerIP and gPeerPort on success.
 static OSErr LowTCPPassiveOpenSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime) {
     OSErr err;
     TCPiopb pbOpen;
-
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
-
     memset(&pbOpen, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-    
-    // ULP Timeout for the connection attempt itself (after first SYN)
-    pbOpen.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds; 
-    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue; // Abort if ULP timeout expires
-    // Command timeout for THIS PBControl call (waiting for initial SYN)
-    // MacTCP PassiveOpen uses commandTimeoutValue field for the "no SYN received" timeout.
-    // The docs for TCPPassiveOpen (page 41) say:
-    // "command timeout in seconds; 0 = infinity" -> This is pbOpen.csParam.open.commandTimeoutValue (offset 35)
-    // Let's make this explicit for MacTCP's internal timer.
-    pbOpen.csParam.open.commandTimeoutValue = 2; // Wait 2 seconds for an incoming SYN
-
-    pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction; // Indicate ULP timeout fields are valid
-
-    pbOpen.csParam.open.localPort = PORT_TCP; // Listen on our standard TCP port
-    pbOpen.csParam.open.localHost = 0L;       // Listen on all local interfaces (gMyLocalIP)
-    pbOpen.csParam.open.remoteHost = 0L;      // Accept from any remote host
-    pbOpen.csParam.open.remotePort = 0;       // Accept from any remote port
-    
-    // IP options (TOS, precedence, etc.) - use defaults
-    pbOpen.csParam.open.tosFlags = 0;    // Routine
-    pbOpen.csParam.open.precedence = 0;  // Routine
-    pbOpen.csParam.open.dontFrag = false;
-    pbOpen.csParam.open.timeToLive = 0;  // Default (usually 60-64)
-    pbOpen.csParam.open.security = 0;
-    pbOpen.csParam.open.optionCnt = 0;
-    // pbOpen.csParam.open.options would go here if optionCnt > 0
-
-    err = LowLevelSyncPoll(&pbOpen, giveTime, TCPPassiveOpen, appPollTimeoutTicks);
-    if (err == noErr) {
-        gPeerIP = pbOpen.csParam.open.remoteHost;   // Capture peer's IP
-        gPeerPort = pbOpen.csParam.open.remotePort; // Capture peer's port
-    } else {
-        gPeerIP = 0; gPeerPort = 0; // Clear if open failed
-    }
-    return err;
-}
-
-static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicksForCall, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
-    TCPiopb pbOpen;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
-
-    memset(&pbOpen, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-
-    pbOpen.csParam.open.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60); // Convert ticks to seconds for ULP timeout
-    if (pbOpen.csParam.open.ulpTimeoutValue == 0) pbOpen.csParam.open.ulpTimeoutValue = 1; // Minimum 1 second ULP
+    pbOpen.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
     pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
+    pbOpen.csParam.open.commandTimeoutValue = 2;
     pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    
-    pbOpen.csParam.open.commandTimeoutValue = 0; // Not used for ActiveOpen ULP timeout handles it
-
-    pbOpen.csParam.open.remoteHost = remoteHost;
-    pbOpen.csParam.open.remotePort = remotePort;
-    pbOpen.csParam.open.localPort = 0;  // Ephemeral local port
-    pbOpen.csParam.open.localHost = 0L; // OS chooses local IP
-
-    // Default IP options
+    pbOpen.csParam.open.localPort = PORT_TCP;
+    pbOpen.csParam.open.localHost = 0L;
+    pbOpen.csParam.open.remoteHost = 0L;
+    pbOpen.csParam.open.remotePort = 0;
     pbOpen.csParam.open.tosFlags = 0;
     pbOpen.csParam.open.precedence = 0;
     pbOpen.csParam.open.dontFrag = false;
-    pbOpen.csParam.open.timeToLive = 0; // Default
+    pbOpen.csParam.open.timeToLive = 0;
     pbOpen.csParam.open.security = 0;
     pbOpen.csParam.open.optionCnt = 0;
-
-    // The LowLevelSyncPoll's appPollTimeoutTicks should be longer than ULP timeout for this active open.
-    // Let ULP timeout be primary. Poll for slightly longer than ULP.
-    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60; // Poll for ULP + 1 second cushion
-
+    err = LowLevelSyncPoll(&pbOpen, giveTime, TCPPassiveOpen, appPollTimeoutTicks);
+    if (err == noErr) {
+        gPeerIP = pbOpen.csParam.open.remoteHost;
+        gPeerPort = pbOpen.csParam.open.remotePort;
+    } else {
+        gPeerIP = 0; gPeerPort = 0;
+    }
+    return err;
+}
+static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicksForCall, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
+    TCPiopb pbOpen;
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    memset(&pbOpen, 0, sizeof(TCPiopb));
+    pbOpen.csParam.open.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60);
+    if (pbOpen.csParam.open.ulpTimeoutValue == 0) pbOpen.csParam.open.ulpTimeoutValue = 1;
+    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
+    pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
+    pbOpen.csParam.open.commandTimeoutValue = 0;
+    pbOpen.csParam.open.remoteHost = remoteHost;
+    pbOpen.csParam.open.remotePort = remotePort;
+    pbOpen.csParam.open.localPort = 0;
+    pbOpen.csParam.open.localHost = 0L;
+    pbOpen.csParam.open.tosFlags = 0;
+    pbOpen.csParam.open.precedence = 0;
+    pbOpen.csParam.open.dontFrag = false;
+    pbOpen.csParam.open.timeToLive = 0;
+    pbOpen.csParam.open.security = 0;
+    pbOpen.csParam.open.optionCnt = 0;
+    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60;
     return LowLevelSyncPoll(&pbOpen, giveTime, TCPActiveOpen, appPollTimeout);
 }
-
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicksForCall, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) {
     TCPiopb pbSend;
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
-    if (wdsPtr == NULL) return kInvalidWDSErr; 
-
+    if (wdsPtr == NULL) return kInvalidWDSErr;
     memset(&pbSend, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-    
-    pbSend.csParam.send.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60); // Convert ULP timeout to seconds
-    if (pbSend.csParam.send.ulpTimeoutValue == 0) pbSend.csParam.send.ulpTimeoutValue = 1; // Min 1 sec
+    pbSend.csParam.send.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60);
+    if (pbSend.csParam.send.ulpTimeoutValue == 0) pbSend.csParam.send.ulpTimeoutValue = 1;
     pbSend.csParam.send.ulpTimeoutAction = AbortTrue;
     pbSend.csParam.send.validityFlags = timeoutValue | timeoutAction;
-    
     pbSend.csParam.send.pushFlag = push;
-    pbSend.csParam.send.urgentFlag = false; // Not using urgent data
+    pbSend.csParam.send.urgentFlag = false;
     pbSend.csParam.send.wdsPtr = wdsPtr;
-    // sendLength and sendFree are output params from TCPSend, not input.
-
-    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60; // Poll for ULP + 1 second cushion
+    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60;
     return LowLevelSyncPoll(&pbSend, giveTime, TCPSend, appPollTimeout);
 }
-
 static OSErr LowTCPRcvSyncPoll(SInt8 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) {
     OSErr err;
     TCPiopb pbRcv;
     unsigned short initialBufferLen;
-
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
     if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return kInvalidBufPtrErr;
     if (markFlag == NULL || urgentFlag == NULL) return paramErr;
-
-    initialBufferLen = *bufferLen; // Save original buffer length
+    initialBufferLen = *bufferLen;
     memset(&pbRcv, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-
-    // commandTimeoutValue for TCPRcv is how long TCP waits for data before completing the call.
-    // 0 = infinite. We use our appPollTimeoutTicks in the wrapper.
-    // Let's set a short MacTCP command timeout, and let our wrapper control overall poll.
-    pbRcv.csParam.receive.commandTimeoutValue = 1; // 1 second MacTCP command timeout for data arrival
+    pbRcv.csParam.receive.commandTimeoutValue = 1;
     pbRcv.csParam.receive.rcvBuff = buffer;
     pbRcv.csParam.receive.rcvBuffLen = initialBufferLen;
-    
     err = LowLevelSyncPoll(&pbRcv, giveTime, TCPRcv, appPollTimeoutTicks);
-    
-    *bufferLen = pbRcv.csParam.receive.rcvBuffLen; // Actual bytes received
+    *bufferLen = pbRcv.csParam.receive.rcvBuffLen;
     *markFlag = pbRcv.csParam.receive.markFlag;
     *urgentFlag = pbRcv.csParam.receive.urgentFlag;
     return err;
 }
-
 static OSErr LowTCPStatusSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) {
     OSErr err;
     TCPiopb pbStat;
-
     if (gTCPStream == NULL) return kInvalidStreamPtrErr;
     if (amtUnread == NULL || connState == NULL) return paramErr;
-
     memset(&pbStat, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-    
     err = LowLevelSyncPoll(&pbStat, giveTime, TCPStatus, appPollTimeoutTicks);
     if (err == noErr) {
         *amtUnread = pbStat.csParam.status.amtUnreadData;
         *connState = pbStat.csParam.status.connectionState;
     } else {
         *amtUnread = 0;
-        *connState = 0; // Indicate unknown/closed state on error
+        *connState = 0;
         log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
-        // If status fails with invalid stream, the connection is effectively gone.
-        if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr; // Map to more logical error for caller
+        if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr;
     }
     return err;
 }
-
 static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicksForAbort, GiveTimePtr giveTime) {
     OSErr err;
     TCPiopb pbAbort;
-
     if (gTCPStream == NULL) {
         log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
-        return noErr; // Or invalidStreamPtr, but for reset purposes, noErr if already gone is fine.
+        return noErr;
     }
-    
     memset(&pbAbort, 0, sizeof(TCPiopb));
-    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
-    // Abort does not strictly use ULP timeout in csParams, but we poll for completion.
-    // The ulpTimeoutTicksForAbort is for our polling loop.
-    
     err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, ulpTimeoutTicksForAbort);
-    
-    // **MODIFIED LOGIC** Treat "already gone" errors as a successful abort for state reset.
-    if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr) { // -23008 or -23010
+    if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr) {
         log_to_file_only("LowTCPAbortSyncPoll: Abort completed (connection doesn't exist or stream invalid). Result: %d. Considered OK for reset.", err);
-        err = noErr; // THIS IS THE KEY CHANGE: Map these to success for our state machine
+        err = noErr;
     } else if (err != noErr) {
         log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
     } else {
@@ -798,26 +593,21 @@ static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicksForAbort, GiveTimePtr give
     }
     return err;
 }
-
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease) {
     OSErr err;
     TCPiopb pbRelease;
-
     if (streamToRelease == NULL) return kInvalidStreamPtrErr;
-
     memset(&pbRelease, 0, sizeof(TCPiopb));
-    pbRelease.ioCompletion = nil; // Synchronous
+    pbRelease.ioCompletion = nil;
     pbRelease.ioCRefNum = macTCPRefNum;
     pbRelease.csCode = TCPRelease;
-    pbRelease.tcpStream = streamToRelease; // Specify the stream to release
-
+    pbRelease.tcpStream = streamToRelease;
     err = PBControlSync((ParmBlkPtr)&pbRelease);
-    // If stream is already invalid, MacTCP might return invalidStreamPtr. This is not a disaster.
     if (err != noErr && err != kInvalidStreamPtrErr) {
         log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
     } else if (err == kInvalidStreamPtrErr) {
         log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
-        err = noErr; // Treat as success for cleanup purposes
+        err = noErr;
     }
     return err;
 }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -6,30 +6,32 @@
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
-#include "dialog.h" // For updating UI if needed
+#include "dialog.h"
 #include "dialog_peerlist.h"
-#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem, AddrToStr
+#include "network.h"
 #include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
-#include <MacTypes.h> // Ensure Byte is available
-#include <Memory.h> // For NewPtrClear, DisposePtr, BlockMoveData
-#include <string.h> // For memset, strcmp, strlen
-#include <stdio.h>  // For sprintf
-#include <stdlib.h> // For size_t if needed
-#include <Events.h> // For TickCount, Delay
+#include <MacTypes.h>
+#include <Memory.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <Events.h>
 #include <OSUtils.h> // For Delay
 
 // --- Constants ---
 #define kTCPRecvBufferSize 8192
 #define kTCPInternalBufferSize 8192
-#define kConnectTimeoutTicks 300
-#define kSendTimeoutTicks 180
-#define kCloseTimeoutTicks 120
-#define kAbortTimeoutTicks 60
-#define kKillWaitTimeoutTicks 180
-#define kQuitLoopDelayTicks 120
-#define kErrorRetryDelayTicks 120
+// *** Aggressively tuned listen poll timeout for UI responsiveness ***
+#define kTCPListenPollTimeoutTicks 5      // Timeout for PassiveOpen poll (approx 1/12th sec)
+#define kTCPRecvPollTimeoutTicks 1        // Short timeout for sync Rcv poll
+#define kTCPStatusPollTimeoutTicks 1      // Short timeout for sync Status poll
+#define kConnectTimeoutTicks 300          // ULP Timeout for TCPActiveOpen (5 sec)
+#define kSendTimeoutTicks 180             // ULP Timeout for TCPSend (3 sec)
+#define kAbortTimeoutTicks 60             // Timeout for abort poll (1 sec)
+#define kQuitLoopDelayTicks 120           // Delay+Yield between QUIT sends (2 sec)
+#define kErrorRetryDelayTicks 120         // Delay after certain recoverable errors (2 sec)
 
 #define kMacTCPTimeoutErr (-23016)
 #define AbortTrue 1
@@ -39,29 +41,19 @@ static StreamPtr gTCPStream = NULL;
 static Ptr gTCPInternalBuffer = NULL;
 static Ptr gTCPRecvBuffer = NULL;
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static TCPiopb gListenPB;
-static TCPiopb gRecvPB;
-static TCPiopb gClosePB;
-static TCPiopb *gCurrentPendingPB = NULL;
-static Boolean gIsSending = false;
-volatile static Boolean gNeedToStartListen = false;
-volatile static Boolean gNeedToStartRecv = false;
-volatile static Boolean gNeedToProcessData = false;
-volatile static Boolean gNeedToCloseIncoming = false;
-volatile static unsigned short gRcvDataLength = 0;
-static ip_addr gPeerIP = 0;
-static tcp_port gPeerPort = 0;
+static Boolean gIsSending = false;        // Lock for outgoing send operations
+static ip_addr gPeerIP = 0;               // IP of current incoming connection
+static tcp_port gPeerPort = 0;             // Port of current incoming connection
 
 // --- Forward Declarations ---
 static void ProcessTCPReceive(unsigned short dataLength);
-static OSErr StartAsyncListen(void);
-static OSErr StartAsyncRecv(void);
-static OSErr StartAsyncCloseIncoming(void);
-static OSErr KillAsyncOperation(GiveTimePtr giveTime);
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
+static OSErr LowTCPPassiveOpenSyncPoll(SInt8 timeoutTicks, GiveTimePtr giveTime);
 static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
+static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
+static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
 static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
 
@@ -70,151 +62,339 @@ static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) { (void)platform_context; (void)ip; char displayMsg[BUFFER_SIZE + 100]; if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) { sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : ""); AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r"); log_message("Message from %s@%s: %s", username, ip, message_content); } else { log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready."); } }
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) { (void)platform_context; if (!ip) return; log_message("Peer %s has sent QUIT notification via TCP.", ip); if (MarkPeerInactive(ip)) { if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } }
 
-// --- Completion Routines (Pascal Convention) ---
-
-// ListenCompleteProc remains unchanged
-pascal void ListenCompleteProc(struct TCPiopb *iopb) {
-    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
-    if (ioResult == noErr) { gPeerIP = iopb->csParam.open.remoteHost; gPeerPort = iopb->csParam.open.remotePort; gTCPState = TCP_STATE_CONNECTED_IN; gNeedToStartRecv = true; }
-    else { const char *errMsg = "Unknown Error"; Boolean isReqAborted = (ioResult == reqAborted); if (isReqAborted) errMsg = "reqAborted (-23015)"; else if (ioResult == connectionExists) errMsg = "connectionExists (-23007)"; else if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)"; else if (ioResult == commandTimeout) errMsg = "commandTimeout (-23016)";
-        if (!isReqAborted) { log_message("ListenCompleteProc: Error: %d (%s)", ioResult, errMsg); } else { log_to_file_only("ListenCompleteProc: Request aborted (%d).", ioResult); }
-        gTCPState = TCP_STATE_IDLE; if (ioResult != invalidStreamPtr && !isReqAborted) { gNeedToStartListen = true; } else if (ioResult == invalidStreamPtr) { gTCPState = TCP_STATE_ERROR; log_message("ListenCompleteProc: CRITICAL - Stream invalid."); } }
-}
-
-// RecvCompleteProc remains unchanged
-pascal void RecvCompleteProc(struct TCPiopb *iopb) {
-    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
-    if (ioResult == noErr) { gRcvDataLength = iopb->csParam.receive.rcvBuffLen; gNeedToProcessData = true; }
-    else if (ioResult == connectionClosing) { gRcvDataLength = iopb->csParam.receive.rcvBuffLen; gNeedToProcessData = true; gNeedToCloseIncoming = false; }
-    else { gRcvDataLength = 0; const char *errMsg = "Unknown Error"; Boolean isReqAborted = (ioResult == reqAborted); if (isReqAborted) errMsg = "reqAborted (-23015)"; else if (ioResult == connectionTerminated) errMsg = "connectionTerminated (-23012)"; else if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)";
-        if (!isReqAborted) { log_message("RecvCompleteProc: Error: %d (%s)", ioResult, errMsg); } else { log_to_file_only("RecvCompleteProc: Request aborted (%d).", ioResult); }
-        if (ioResult == invalidStreamPtr) { gTCPState = TCP_STATE_ERROR; log_message("RecvCompleteProc: CRITICAL - Stream invalid."); } else if (!isReqAborted) { gNeedToCloseIncoming = true; } }
-}
-
-// CloseCompleteProc remains unchanged
-pascal void CloseCompleteProc(struct TCPiopb *iopb) {
-    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
-    if (ioResult != noErr) { log_message("CloseCompleteProc: Warning - Async close failed: %d", ioResult); } else { log_to_file_only("CloseCompleteProc: Async close completed."); }
-    gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true;
-}
-
-
 // --- Public Functions ---
+OSErr InitTCP(short macTCPRefNum) {
+    OSErr err;
+    log_message("Initializing Single TCP Stream (Sync Poll Strategy)...");
+    if (macTCPRefNum == 0) return paramErr;
+    if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
+        log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
+        return streamAlreadyOpen;
+    }
 
-// InitTCP remains unchanged
-OSErr InitTCP(short macTCPRefNum) { OSErr err; log_message("Initializing Single TCP Stream (Async Strategy)..."); if (macTCPRefNum == 0) return paramErr; if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) { log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState); return streamAlreadyOpen; }
-    gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize); gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize); if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) { log_message("Fatal Error: Could not allocate TCP buffers."); if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer); if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer); gTCPInternalBuffer = gTCPRecvBuffer = NULL; return memFullErr; } log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
-    log_message("Creating Single Stream..."); err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize); if (err != noErr || gTCPStream == NULL) { log_message("Error: Failed to create TCP Stream: %d", err); CleanupTCP(macTCPRefNum); return err; } log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
-    gTCPState = TCP_STATE_IDLE; gCurrentPendingPB = NULL; gIsSending = false; gNeedToStartListen = true; gNeedToStartRecv = false; gNeedToProcessData = false; gNeedToCloseIncoming = false; gPeerIP = 0; gPeerPort = 0; log_message("TCP initialization complete. State: IDLE. Will start listening on next poll."); return noErr; }
+    gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
+    gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
 
-// CleanupTCP remains unchanged
-void CleanupTCP(short macTCPRefNum) { log_message("Cleaning up Single TCP Stream (Async Strategy)..."); StreamPtr streamToRelease = gTCPStream; TCPState stateBeforeCleanup = gTCPState; gTCPStream = NULL; gTCPState = TCP_STATE_RELEASING;
-    if (gCurrentPendingPB != NULL && stateBeforeCleanup != TCP_STATE_IDLE) { log_message("Cleanup: Attempting async kill of pending operation (State: %d)...", stateBeforeCleanup); OSErr killErr = PBKillIO((ParmBlkPtr)gCurrentPendingPB, false); if (killErr != noErr) { log_message("Warning: PBKillIO failed immediately during cleanup: %d", killErr); } gCurrentPendingPB = NULL; }
-    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_RECEIVING) { log_message("Cleanup: Attempting synchronous abort (best effort)..."); LowTCPAbortSyncPoll(YieldTimeToSystem); }
-    if (streamToRelease != NULL && macTCPRefNum != 0) { log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease); OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease); if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr); else log_to_file_only("Sync release successful."); } else if (streamToRelease != NULL) { log_message("Warning: Cannot release stream, MacTCP refnum is 0."); }
-    gTCPState = TCP_STATE_UNINITIALIZED; gCurrentPendingPB = NULL; gIsSending = false; gNeedToStartListen = false; gNeedToStartRecv = false; gNeedToProcessData = false; gNeedToCloseIncoming = false; gPeerIP = 0; gPeerPort = 0;
-    if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; } if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; } log_message("TCP cleanup finished."); }
+    if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
+        log_message("Fatal Error: Could not allocate TCP buffers.");
+        if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer);
+        if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer);
+        gTCPInternalBuffer = gTCPRecvBuffer = NULL;
+        return memFullErr;
+    }
+    log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
 
-// PollTCP remains unchanged
-void PollTCP(void) { OSErr err; unsigned long dummyTimer; if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) return; if (gIsSending) return; if (gCurrentPendingPB != NULL) return;
-    if (gNeedToStartListen && gTCPState == TCP_STATE_IDLE) { gNeedToStartListen = false; log_to_file_only("PollTCP: Starting async listen..."); err = StartAsyncListen(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async listen: %d. Retrying later.", err); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; Delay(kErrorRetryDelayTicks, &dummyTimer); } return; }
-    if (gNeedToStartRecv && gTCPState == TCP_STATE_CONNECTED_IN) { gNeedToStartRecv = false; log_to_file_only("PollTCP: Starting async receive..."); err = StartAsyncRecv(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async receive: %d. Closing connection.", err); gTCPState = TCP_STATE_CONNECTED_IN; gNeedToCloseIncoming = true; } return; }
-    if (gNeedToProcessData) { gNeedToProcessData = false; log_to_file_only("PollTCP: Processing received data (%u bytes)...", gRcvDataLength); ProcessTCPReceive(gRcvDataLength); gRcvDataLength = 0;
-         if (gTCPState == TCP_STATE_RECEIVING) { log_to_file_only("PollTCP: Starting next async receive..."); err = StartAsyncRecv(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start next async receive: %d. Closing connection.", err); gTCPState = TCP_STATE_RECEIVING; gNeedToCloseIncoming = true; } }
-         else if (gTCPState == TCP_STATE_CONNECTED_IN) { char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr); log_message("PollTCP: Peer %s closed connection gracefully. Returning to IDLE.", peerIPStr); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; }
-         else { log_message("PollTCP: WARNING - Processed data but state is unexpected: %d", gTCPState); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } return; }
-    if (gNeedToCloseIncoming) { gNeedToCloseIncoming = false; if (gTCPState == TCP_STATE_RECEIVING || gTCPState == TCP_STATE_CONNECTED_IN) { log_message("PollTCP: Closing incoming connection gracefully..."); err = StartAsyncCloseIncoming(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async close: %d. Assuming closed, returning to IDLE.", err); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } }
-         else { log_message("PollTCP: WARNING - NeedToCloseIncoming flag set, but state is unexpected: %d. Returning to IDLE.", gTCPState); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } return; }
+    log_message("Creating Single Stream...");
+    err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
+    if (err != noErr || gTCPStream == NULL) {
+        log_message("Error: Failed to create TCP Stream: %d", err);
+        CleanupTCP(macTCPRefNum); // Call full cleanup
+        return err;
+    }
+    log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
+
+    gTCPState = TCP_STATE_IDLE;
+    gIsSending = false;
+    gPeerIP = 0; gPeerPort = 0;
+
+    log_message("TCP initialization complete. State: IDLE.");
+    return noErr;
 }
 
-// GetTCPState remains unchanged
-TCPState GetTCPState(void) { return gTCPState; }
+void CleanupTCP(short macTCPRefNum) {
+    log_message("Cleaning up Single TCP Stream (Sync Poll Strategy)...");
 
-// WaitForKillCompletion remains unchanged
-static OSErr WaitForKillCompletion(GiveTimePtr giveTime, const char* context) { unsigned long startTime = TickCount(); log_to_file_only("WaitForKillCompletion (%s): Waiting for state to return to IDLE...", context); while ((TickCount() - startTime) < kKillWaitTimeoutTicks) { if (gTCPState == TCP_STATE_IDLE && gCurrentPendingPB == NULL) { log_to_file_only("WaitForKillCompletion (%s): Kill completed (State IDLE).", context); return noErr; } giveTime(); } log_message("Error (%s): Timeout waiting for PBKillIO to complete. State: %d", context, gTCPState); return reqAborted; }
+    StreamPtr streamToRelease = gTCPStream; // Capture before nullifying
+    TCPState stateBeforeCleanup = gTCPState;
 
-// TCP_SendTextMessageSync remains unchanged
-OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) { OSErr err = noErr, finalErr = noErr; ip_addr targetIP = 0; char messageBuffer[BUFFER_SIZE]; int formattedLen; struct wdsEntry sendWDS[2];
-    log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIP); if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
-    if (gIsSending) { log_message("Warning (SendText): Send already in progress."); return streamBusyErr; } gIsSending = true; log_to_file_only("TCP_SendTextMessageSync: Acquired send lock.");
-    err = KillAsyncOperation(giveTime); if (err != noErr) { log_message("Error (SendText): Failed to kill pending async operation (%d). Cannot send.", err); finalErr = streamBusyErr; goto SendTextCleanup; } if (gTCPState != TCP_STATE_IDLE) { log_message("Error (SendText): State not IDLE (%d) after kill attempt. Cannot send.", gTCPState); finalErr = streamBusyErr; goto SendTextCleanup; }
-    err = ParseIPv4(peerIP, &targetIP); if (err != noErr || targetIP == 0) { log_message("Error (SendText): Could not parse peer IP '%s'.", peerIP); finalErr = paramErr; goto SendTextCleanup; }
-    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message); if (formattedLen <= 0) { log_message("Error (SendText): Failed to format TEXT message for %s.", peerIP); finalErr = paramErr; goto SendTextCleanup; }
-    log_to_file_only("SendText: Connecting..."); err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
-    if (err == noErr) { log_to_file_only("SendText: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL; log_to_file_only("SendText: Sending data..."); err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime); if (err == noErr) { log_to_file_only("SendText: Send successful."); } else { log_message("Error (SendText): Send failed: %d", err); finalErr = err; } log_to_file_only("SendText: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime); if (abortErr != noErr) { log_message("Warning (SendText): Abort failed: %d", abortErr); if (finalErr == noErr) finalErr = abortErr; } }
-    else { log_message("Error (SendText): Connect failed: %d", err); finalErr = err; }
-SendTextCleanup: gNeedToStartListen = true; gIsSending = false; log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr); return finalErr; }
+    gTCPStream = NULL; // Prevent further use by other functions
+    gTCPState = TCP_STATE_RELEASING;
 
-// TCP_SendQuitMessagesSync remains unchanged
-OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) { int i; OSErr lastErr = noErr, currentErr = noErr; char quitMessageBuffer[BUFFER_SIZE]; int formattedLen, activePeerCount = 0, sentCount = 0; unsigned long dummyTimer; struct wdsEntry sendWDS[2];
-    log_message("TCP_SendQuitMessagesSync: Starting..."); if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (giveTime == NULL) return paramErr;
-    if (gIsSending) { log_message("Warning (SendQuit): Send already in progress."); return streamBusyErr; } gIsSending = true; log_to_file_only("TCP_SendQuitMessagesSync: Acquired send lock.");
-    currentErr = KillAsyncOperation(giveTime); if (currentErr != noErr) { log_message("Error (SendQuit): Failed to kill pending async operation (%d). Cannot send.", currentErr); lastErr = streamBusyErr; goto SendQuitCleanup; } if (gTCPState != TCP_STATE_IDLE) { log_message("Error (SendQuit): State not IDLE (%d) after kill attempt. Cannot send.", gTCPState); lastErr = streamBusyErr; goto SendQuitCleanup; }
-    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, ""); if (formattedLen <= 0) { log_message("Error (SendQuit): Failed to format QUIT message."); lastErr = paramErr; goto SendQuitCleanup; }
-    for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++; log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount); if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
-    for (i = 0; i < MAX_PEERS; ++i) { if (gPeerManager.peers[i].active) { ip_addr currentTargetIP = 0; currentErr = noErr; if (gTCPState != TCP_STATE_IDLE) { log_message("CRITICAL (SendQuit): State not IDLE (%d) before processing peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip); lastErr = ioErr; break; } log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP); if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse peer IP '%s'. Skipping.", gPeerManager.peers[i].ip); lastErr = currentErr; goto NextPeerDelay; }
-            log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip); currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
-            if (currentErr == noErr) { log_to_file_only("SendQuit: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL; log_to_file_only("SendQuit: Sending data..."); currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime); if (currentErr == noErr) { log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip); sentCount++; } else { log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr); lastErr = currentErr; } log_to_file_only("SendQuit: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime); if (abortErr != noErr) { log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr); if (lastErr == noErr) lastErr = abortErr; } }
-            else { log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr); lastErr = currentErr; }
-        NextPeerDelay: log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip); giveTime(); Delay(kQuitLoopDelayTicks, &dummyTimer); } }
-SendQuitCleanup: log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr); gNeedToStartListen = true; gIsSending = false; log_to_file_only("TCP_SendQuitMessagesSync: Released send lock."); return lastErr; }
+    // Abort if connection might still exist (best effort sync poll)
+    // Check state *before* cleanup started. Only abort if it was connected.
+    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN) {
+         log_message("Cleanup: Attempting synchronous abort (best effort)...");
+         // Use the captured streamToRelease if gTCPStream was nulled for safety
+         // but LowTCPAbortSyncPoll uses the global gTCPStream.
+         // Temporarily restore gTCPStream for abort if it was nulled too early.
+         // This is tricky. The design of LowTCPAbortSyncPoll relies on gTCPStream.
+         // Let's ensure gTCPStream is valid for LowTCPAbortSyncPoll.
+         if (streamToRelease != NULL) { // Only if there was a stream to begin with
+             StreamPtr currentGlobalStream = gTCPStream; // Should be NULL now
+             gTCPStream = streamToRelease; // Temporarily restore for abort
+             LowTCPAbortSyncPoll(YieldTimeToSystem);
+             gTCPStream = currentGlobalStream; // Set back to NULL (or whatever it was)
+         }
+    }
 
+    // Release stream synchronously
+    if (streamToRelease != NULL && macTCPRefNum != 0) {
+        log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
+        OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease); // Use captured stream
+        if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr);
+        else log_to_file_only("Sync release successful.");
+    } else if (streamToRelease != NULL) {
+        log_message("Warning: Cannot release stream, MacTCP refnum is 0.");
+    }
+
+    gTCPState = TCP_STATE_UNINITIALIZED;
+    gIsSending = false;
+    gPeerIP = 0; gPeerPort = 0;
+
+    if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; }
+    if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; }
+
+    log_message("TCP cleanup finished.");
+}
+
+
+void PollTCP(GiveTimePtr giveTime) {
+    OSErr err;
+    unsigned short amountUnread = 0;
+    Byte connectionState = 0; // MacTypes.h Byte
+    unsigned long dummyTimer;
+
+    if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
+        return;
+    }
+    if (gIsSending) { // Don't interfere with outgoing send operations (which are synchronous)
+        return;
+    }
+
+    switch (gTCPState) {
+        case TCP_STATE_IDLE:
+            log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll...");
+            gTCPState = TCP_STATE_LISTENING_POLL; // Tentative state
+            err = LowTCPPassiveOpenSyncPoll(kTCPListenPollTimeoutTicks, giveTime);
+
+            if (err == noErr) {
+                char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr);
+                log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
+                gTCPState = TCP_STATE_CONNECTED_IN;
+                goto CheckConnectedInData; // Check for data in the same poll cycle
+            } else if (err == commandTimeout) {
+                log_to_file_only("PollTCP: Passive Open Poll timed out. Returning to IDLE.");
+                gTCPState = TCP_STATE_IDLE;
+            } else {
+                log_message("PollTCP: Passive Open Poll failed: %d. Returning to IDLE.", err);
+                gTCPState = TCP_STATE_IDLE;
+                if (err == duplicateSocket || err == connectionExists) { // -23007 or -23008
+                     log_message("PollTCP: Delaying %d ticks due to error %d.", kErrorRetryDelayTicks, err);
+                     Delay(kErrorRetryDelayTicks, &dummyTimer);
+                }
+            }
+            break;
+
+        case TCP_STATE_LISTENING_POLL: // Should not be reached if LowTCPPassiveOpenSyncPoll is truly synchronous
+             log_message("PollTCP: WARNING - Reached LISTENING_POLL state unexpectedly.");
+             gTCPState = TCP_STATE_IDLE;
+             break;
+
+        case TCP_STATE_CONNECTED_IN:
+CheckConnectedInData:
+            log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
+            err = LowTCPStatusSyncPoll(giveTime, &amountUnread, &connectionState);
+
+            if (err != noErr) {
+                log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
+                LowTCPAbortSyncPoll(giveTime); // Best effort abort
+                gTCPState = TCP_STATE_IDLE;
+                break;
+            }
+
+            // TCP connection states: 8=Established, 10=FIN_WAIT_1, 12=FIN_WAIT_2, 14=CLOSE_WAIT
+            if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
+                 char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+                 log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Assuming closed/aborted. Returning to IDLE.", connectionState, peerIPStr);
+                 gTCPState = TCP_STATE_IDLE;
+                 break;
+            }
+            log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
+
+            if (amountUnread > 0) {
+                unsigned short bytesToRead = kTCPRecvBufferSize;
+                Boolean markFlag = false, urgentFlag = false;
+                log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
+                err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
+
+                if (err == noErr) {
+                    log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
+                    ProcessTCPReceive(bytesToRead);
+                    // Stay in CONNECTED_IN state
+                } else if (err == connectionClosing) {
+                    char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+                    log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
+                    ProcessTCPReceive(bytesToRead); // Process final data
+                    gTCPState = TCP_STATE_IDLE;     // Return to idle
+                } else if (err == commandTimeout) {
+                     log_to_file_only("PollTCP: Rcv poll timed out despite status showing data?");
+                } else { // e.g., connectionTerminated
+                    char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+                    log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
+                    LowTCPAbortSyncPoll(giveTime);
+                    gTCPState = TCP_STATE_IDLE;
+                }
+            } else { // No data to read
+                 if (connectionState == 14 /*CloseWait*/) {
+                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+                     log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Returning to IDLE.", peerIPStr);
+                     gTCPState = TCP_STATE_IDLE;
+                 }
+            }
+            break;
+        default:
+            log_message("PollTCP: In unexpected state %d.", gTCPState);
+            gTCPState = TCP_STATE_IDLE; // Try to recover
+            break;
+    }
+}
+
+TCPState GetTCPState(void) {
+    return gTCPState;
+}
+
+OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
+    OSErr err = noErr, finalErr = noErr;
+    ip_addr targetIP = 0;
+    char messageBuffer[BUFFER_SIZE];
+    int formattedLen;
+    struct wdsEntry sendWDS[2];
+
+    log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIP);
+
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (gTCPStream == NULL) return invalidStreamPtr;
+    if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
+
+    if (gIsSending) { log_message("Warning (SendText): Send already in progress."); return streamBusyErr; }
+    if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
+    gIsSending = true;
+    // No gTCPState change here, send is a sequence of sync calls within this function.
+
+    err = ParseIPv4(peerIP, &targetIP);
+    if (err != noErr || targetIP == 0) { finalErr = paramErr; goto SendTextCleanup; }
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message);
+    if (formattedLen <= 0) { finalErr = paramErr; goto SendTextCleanup; }
+
+    log_to_file_only("SendText: Connecting...");
+    err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
+    if (err == noErr) {
+        log_to_file_only("SendText: Connected successfully.");
+        sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer;
+        sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
+        log_to_file_only("SendText: Sending data...");
+        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
+        if (err != noErr) { log_message("Error (SendText): Send failed: %d", err); finalErr = err; }
+        else { log_to_file_only("SendText: Send successful."); }
+        log_to_file_only("SendText: Aborting connection...");
+        OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
+        if (abortErr != noErr) { log_message("Warning (SendText): Abort failed: %d", abortErr); if (finalErr == noErr) finalErr = abortErr; }
+    } else { log_message("Error (SendText): Connect failed: %d", err); finalErr = err; }
+
+SendTextCleanup:
+    // gTCPState should remain IDLE or be forced to IDLE by abort.
+    gIsSending = false;
+    log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr);
+    return finalErr;
+}
+
+OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
+    int i;
+    OSErr lastErr = noErr, currentErr = noErr;
+    char quitMessageBuffer[BUFFER_SIZE];
+    int formattedLen, activePeerCount = 0, sentCount = 0;
+    unsigned long dummyTimer;
+    struct wdsEntry sendWDS[2];
+
+    log_message("TCP_SendQuitMessagesSync: Starting...");
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (gTCPStream == NULL) return invalidStreamPtr;
+    if (giveTime == NULL) return paramErr;
+
+    if (gIsSending) { log_message("Warning (SendQuit): Send already in progress."); return streamBusyErr; }
+    if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendQuit): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
+    gIsSending = true;
+
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, "");
+    if (formattedLen <= 0) { lastErr = paramErr; goto SendQuitCleanup; }
+
+    for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
+    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
+    if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
+
+    for (i = 0; i < MAX_PEERS; ++i) {
+        if (gPeerManager.peers[i].active) {
+            ip_addr currentTargetIP = 0;
+            currentErr = noErr;
+            if (gTCPState != TCP_STATE_IDLE) { log_message("CRITICAL (SendQuit): State not IDLE (%d) before peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip); lastErr = ioErr; break; }
+
+            log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
+            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
+            if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip); if (lastErr == noErr) lastErr = currentErr; goto NextPeerDelay; }
+
+            log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip);
+            currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
+
+            // *** MODIFIED: Handle -23007 gracefully ***
+            if (currentErr == connectionExists) { // -23007
+                log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
+                // Do not set lastErr here, allow other peers to be tried.
+            } else if (currentErr == noErr) {
+                log_to_file_only("SendQuit: Connected successfully.");
+                sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer;
+                sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
+                log_to_file_only("SendQuit: Sending data...");
+                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
+                if (currentErr == noErr) { log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip); sentCount++; }
+                else { log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr); if (lastErr == noErr) lastErr = currentErr; }
+                log_to_file_only("SendQuit: Aborting connection...");
+                OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
+                if (abortErr != noErr) { log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr); if (lastErr == noErr) lastErr = abortErr; }
+            } else {
+                log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
+                if (lastErr == noErr) lastErr = currentErr;
+            }
+        NextPeerDelay:
+            log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
+            giveTime(); Delay(kQuitLoopDelayTicks, &dummyTimer);
+        }
+    }
+SendQuitCleanup:
+    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
+    gIsSending = false;
+    return lastErr;
+}
 
 // --- Private Helpers ---
-
 // ProcessTCPReceive remains unchanged
 static void ProcessTCPReceive(unsigned short dataLength) { char senderIPStrFromConnection[INET_ADDRSTRLEN], senderIPStrFromPayload[INET_ADDRSTRLEN]; char senderUsername[32], msgType[32], content[BUFFER_SIZE]; static tcp_platform_callbacks_t mac_callbacks = { .add_or_update_peer = mac_tcp_add_or_update_peer, .display_text_message = mac_tcp_display_text_message, .mark_peer_inactive = mac_tcp_mark_peer_inactive }; if (dataLength > 0 && gTCPRecvBuffer != NULL) { OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection); if (addrErr != noErr) sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF); if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0'; else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) { log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection); handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL); if (strcmp(msgType, MSG_QUIT) == 0) log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection); } else log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength); } else if (dataLength == 0) log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal)."); else log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL?"); }
-
-// StartAsyncListen - *** UPDATED CAST ***
-static OSErr StartAsyncListen(void) {
-    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gCurrentPendingPB != NULL || gTCPState != TCP_STATE_IDLE) return inProgress;
-    memset(&gListenPB, 0, sizeof(TCPiopb));
-    // *** USE TCPIOCompletionProcPtr ***
-    gListenPB.ioCompletion = (TCPIOCompletionProcPtr)ListenCompleteProc;
-    gListenPB.ioCRefNum = gMacTCPRefNum; gListenPB.csCode = TCPPassiveOpen; gListenPB.tcpStream = gTCPStream;
-    gListenPB.csParam.open.validityFlags = 0; gListenPB.csParam.open.localPort = PORT_TCP; gListenPB.csParam.open.commandTimeoutValue = 0;
-    gTCPState = TCP_STATE_LISTENING; gCurrentPendingPB = &gListenPB; err = PBControlAsync((ParmBlkPtr)&gListenPB);
-    if (err != noErr) { log_message("Error (StartAsyncListen): PBControlAsync failed immediately: %d", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_IDLE; return err; } return 1;
-}
-
-// StartAsyncRecv - *** UPDATED CAST ***
-static OSErr StartAsyncRecv(void) {
-    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gTCPRecvBuffer == NULL) return invalidBufPtr; if (gCurrentPendingPB != NULL || gTCPState != TCP_STATE_CONNECTED_IN) return inProgress;
-    memset(&gRecvPB, 0, sizeof(TCPiopb));
-    // *** USE TCPIOCompletionProcPtr ***
-    gRecvPB.ioCompletion = (TCPIOCompletionProcPtr)RecvCompleteProc;
-    gRecvPB.ioCRefNum = gMacTCPRefNum; gRecvPB.csCode = TCPRcv; gRecvPB.tcpStream = gTCPStream;
-    gRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer; gRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize; gRecvPB.csParam.receive.commandTimeoutValue = 0;
-    gTCPState = TCP_STATE_RECEIVING; gCurrentPendingPB = &gRecvPB; err = PBControlAsync((ParmBlkPtr)&gRecvPB);
-    if (err != noErr) { log_message("Error (StartAsyncRecv): PBControlAsync failed immediately: %d", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_CONNECTED_IN; return err; } return 1;
-}
-
-// StartAsyncCloseIncoming - *** UPDATED CAST ***
-static OSErr StartAsyncCloseIncoming(void) {
-    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gCurrentPendingPB != NULL || (gTCPState != TCP_STATE_CONNECTED_IN && gTCPState != TCP_STATE_RECEIVING)) return inProgress;
-    memset(&gClosePB, 0, sizeof(TCPiopb));
-    // *** USE TCPIOCompletionProcPtr ***
-    gClosePB.ioCompletion = (TCPIOCompletionProcPtr)CloseCompleteProc;
-    gClosePB.ioCRefNum = gMacTCPRefNum; gClosePB.csCode = TCPClose; gClosePB.tcpStream = gTCPStream;
-    gClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction; gClosePB.csParam.close.ulpTimeoutValue = kCloseTimeoutTicks; gClosePB.csParam.close.ulpTimeoutAction = AbortTrue;
-    gTCPState = TCP_STATE_CLOSING_IN; gCurrentPendingPB = &gClosePB; err = PBControlAsync((ParmBlkPtr)&gClosePB);
-    if (err != noErr) { log_message("Error (StartAsyncCloseIncoming): PBControlAsync failed immediately: %d. Assuming closed.", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_IDLE; return noErr; } return 1;
-}
-
-// KillAsyncOperation remains unchanged
-static OSErr KillAsyncOperation(GiveTimePtr giveTime) { OSErr killErr = noErr; TCPiopb *pbToKill = gCurrentPendingPB; TCPState stateWhenKilled = gTCPState; if (pbToKill != NULL && stateWhenKilled != TCP_STATE_IDLE) { log_message("KillAsyncOperation: Attempting async kill of pending operation (State: %d)...", stateWhenKilled); killErr = PBKillIO((ParmBlkPtr)pbToKill, false); if (killErr == noErr) { killErr = WaitForKillCompletion(giveTime, "KillAsyncOperation"); if (killErr != noErr) { log_message("KillAsyncOperation: Failed waiting for kill completion."); return streamBusyErr; } return noErr; } else if (killErr == paramErr) { log_message("CRITICAL (KillAsyncOperation): PBKillIO failed with paramErr (%d)! Cannot interrupt async op (State: %d).", killErr, stateWhenKilled); return streamBusyErr; } else { log_message("Error (KillAsyncOperation): PBKillIO failed immediately: %d (State: %d).", killErr, stateWhenKilled); if (gTCPState == TCP_STATE_IDLE && gCurrentPendingPB == NULL) { log_message("KillAsyncOperation: State is now IDLE, proceeding despite PBKillIO error."); return noErr; } return streamBusyErr; } } return noErr; }
-
-// --- Low-Level Synchronous Polling TCP Helpers (for Sending) ---
 
 // LowLevelSyncPoll remains unchanged
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode) { OSErr err; if (pBlock == NULL || giveTime == NULL) return paramErr; pBlock->ioCompletion = nil; pBlock->ioResult = 1; pBlock->csCode = csCode; err = PBControlAsync((ParmBlkPtr)pBlock); if (err != noErr) { log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err); return err; } while (pBlock->ioResult > 0) { giveTime(); } return pBlock->ioResult; }
 // LowTCPCreateSync remains unchanged
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen) { OSErr err; TCPiopb pbCreate; if (streamPtr == NULL || connectionBuffer == NULL) return paramErr; memset(&pbCreate, 0, sizeof(TCPiopb)); pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum; pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L; pbCreate.csParam.create.rcvBuff = connectionBuffer; pbCreate.csParam.create.rcvBuffLen = connBufferLen; pbCreate.csParam.create.notifyProc = nil; err = PBControlSync((ParmBlkPtr)&pbCreate); if (err == noErr) { *streamPtr = pbCreate.tcpStream; if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream."); err = ioErr; } } else { *streamPtr = NULL; log_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err); } return err; }
+
+// LowTCPPassiveOpenSyncPoll - gPeerIP/Port set here now
+static OSErr LowTCPPassiveOpenSyncPoll(SInt8 timeoutTicks, GiveTimePtr giveTime) {
+    OSErr err; TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr;
+    memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream;
+    pb.csParam.open.commandTimeoutValue = timeoutTicks; pb.csParam.open.validityFlags = 0;
+    pb.csParam.open.localPort = PORT_TCP; pb.csParam.open.localHost = 0L;
+    pb.csParam.open.remoteHost = 0L; pb.csParam.open.remotePort = 0;
+    err = LowLevelSyncPoll(&pb, giveTime, TCPPassiveOpen);
+    if (err == noErr) { gPeerIP = pb.csParam.open.remoteHost; gPeerPort = pb.csParam.open.remotePort; } // Store peer info
+    else { gPeerIP = 0; gPeerPort = 0; }
+    return err;
+}
+
 // LowTCPActiveOpenSyncPoll remains unchanged
 static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.open.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.open.ulpTimeoutAction = AbortTrue; pb.csParam.open.validityFlags = timeoutValue | timeoutAction; pb.csParam.open.commandTimeoutValue = 0; pb.csParam.open.remoteHost = remoteHost; pb.csParam.open.remotePort = remotePort; pb.csParam.open.localPort = 0; pb.csParam.open.localHost = 0; return LowLevelSyncPoll(&pb, giveTime, TCPActiveOpen); }
 // LowTCPSendSyncPoll remains unchanged
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (wdsPtr == NULL) return invalidWDS; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.send.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.send.ulpTimeoutAction = AbortTrue; pb.csParam.send.validityFlags = timeoutValue | timeoutAction; pb.csParam.send.pushFlag = push; pb.csParam.send.urgentFlag = false; pb.csParam.send.wdsPtr = wdsPtr; return LowLevelSyncPoll(&pb, giveTime, TCPSend); }
+// LowTCPRcvSyncPoll remains unchanged
+static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) { OSErr err; TCPiopb pb; unsigned short initialBufferLen; if (gTCPStream == NULL) return invalidStreamPtr; if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return invalidBufPtr; if (markFlag == NULL || urgentFlag == NULL) return paramErr; initialBufferLen = *bufferLen; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.receive.commandTimeoutValue = timeoutTicks; pb.csParam.receive.rcvBuff = buffer; pb.csParam.receive.rcvBuffLen = initialBufferLen; err = LowLevelSyncPoll(&pb, giveTime, TCPRcv); *bufferLen = pb.csParam.receive.rcvBuffLen; *markFlag = pb.csParam.receive.markFlag; *urgentFlag = pb.csParam.receive.urgentFlag; return err; }
+// LowTCPStatusSyncPoll remains unchanged
+static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (amtUnread == NULL || connState == NULL) return paramErr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPStatus); if (err == noErr) { *amtUnread = pb.csParam.status.amtUnreadData; *connState = pb.csParam.status.connectionState; } else { *amtUnread = 0; *connState = 0; log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err); if (err == invalidStreamPtr) err = connectionDoesntExist; } return err; }
 // LowTCPAbortSyncPoll remains unchanged
 static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) { log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort."); return noErr; } memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPAbort); if (err == connectionDoesntExist || err == invalidStreamPtr) { log_to_file_only("LowTCPAbortSyncPoll: Abort completed (conn not exist/invalid stream). Result: %d", err); err = noErr; } else if (err != noErr) { log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed: %d", err); } else { log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful."); } return err; }
 // LowTCPReleaseSync remains unchanged

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -8,10 +8,11 @@
 #include "peer_mac.h"
 #include "dialog.h" // For updating UI if needed
 #include "dialog_peerlist.h"
-#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem
+#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem, AddrToStr
 #include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
+#include <MacTypes.h> // Ensure Byte is available
 #include <Memory.h> // For NewPtrClear, DisposePtr, BlockMoveData
 #include <string.h> // For memset, strcmp, strlen
 #include <stdio.h>  // For sprintf
@@ -20,865 +21,201 @@
 #include <OSUtils.h> // For Delay
 
 // --- Constants ---
-#define kTCPRecvBufferSize 8192           // Buffer for receiving data on listener stream
-#define kTCPListenInternalBufferSize 8192 // Internal buffer for the listener stream
-#define kTCPSendInternalBufferSize 2048   // Internal buffer for temporary sender streams
-#define kTCPListenRetryDelayTicks 60      // Delay before retrying listen after certain errors
-#define kConnectTimeoutTicks 300          // Timeout for TCPActiveOpen (5 sec)
-#define kSendTimeoutTicks 180             // Timeout for TCPSend (3 sec)
-#define kCloseTimeoutTicks 120            // Timeout for TCPClose (2 sec)
-#define kQuitLoopDelayTicks 15            // Delay+Yield between QUIT sends (approx 1/4 sec)
-#define kMacTCPTimeoutErr (-23014)        // MacTCP ULP timeout error code
-#define AbortTrue 1                       // ULP Timeout Action: Abort connection
+#define kTCPRecvBufferSize 8192
+#define kTCPInternalBufferSize 8192
+#define kConnectTimeoutTicks 300
+#define kSendTimeoutTicks 180
+#define kCloseTimeoutTicks 120
+#define kAbortTimeoutTicks 60
+#define kKillWaitTimeoutTicks 180
+#define kQuitLoopDelayTicks 120
+#define kErrorRetryDelayTicks 120
+
+#define kMacTCPTimeoutErr (-23016)
+#define AbortTrue 1
 
 // --- Globals ---
-
-// Listener Stream (for incoming connections)
-static StreamPtr gTCPListenStream = NULL;
-static Ptr gTCPListenInternalBuffer = NULL;
-static Ptr gTCPRecvBuffer = NULL;           // Receive buffer for listener stream
-static TCPiopb gListenPB;                   // For TCPPassiveOpen
-static TCPiopb gRecvPB;                     // For TCPRcv
-static TCPiopb gClosePB;                    // For TCPClose (incoming connection)
-// static TCPiopb gListenReleasePB;         // Release is synchronous, no PB needed
-
-// Listener State Machine
-static TCPListenerState gListenerState = TCP_LSTATE_UNINITIALIZED;
-static TCPiopb *gListenPendingOpPB = NULL; // PB for the listener's current async operation
-static Boolean gNeedToListen = false;      // Flag: should start listening when idle?
-
-// Incoming connection details
+static StreamPtr gTCPStream = NULL;
+static Ptr gTCPInternalBuffer = NULL;
+static Ptr gTCPRecvBuffer = NULL;
+static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
+static TCPiopb gListenPB;
+static TCPiopb gRecvPB;
+static TCPiopb gClosePB;
+static TCPiopb *gCurrentPendingPB = NULL;
+static Boolean gIsSending = false;
+volatile static Boolean gNeedToStartListen = false;
+volatile static Boolean gNeedToStartRecv = false;
+volatile static Boolean gNeedToProcessData = false;
+volatile static Boolean gNeedToCloseIncoming = false;
+volatile static unsigned short gRcvDataLength = 0;
 static ip_addr gPeerIP = 0;
 static tcp_port gPeerPort = 0;
 
-
 // --- Forward Declarations ---
-static OSErr StartListening(void);
-static OSErr StartRecv(void);
-static OSErr StartCloseIncoming(void); // Close the accepted incoming connection gracefully
-
-static void HandleListenComplete(OSErr ioResult);
-static void HandleRecvComplete(OSErr ioResult);
-static void HandleCloseIncomingComplete(OSErr ioResult);
-
-static void ProcessTCPReceive(void);
-static OSErr KillListenerPendingOperation(const char* callerContext);
-
-// Low-level sync helpers
+static void ProcessTCPReceive(unsigned short dataLength);
+static OSErr StartAsyncListen(void);
+static OSErr StartAsyncRecv(void);
+static OSErr StartAsyncCloseIncoming(void);
+static OSErr KillAsyncOperation(GiveTimePtr giveTime);
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
-static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
-static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
-static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime);
+static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
+static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
+static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
 
-// Internal synchronous send helper using temporary stream
-static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
-                                 const char *messageBuffer, int messageLen,
-                                 SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
-                                 GiveTimePtr giveTime);
-
-
 // --- Shared Logic Callbacks (implementation unchanged) ---
-static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context;
-    int addResult = AddOrUpdatePeer(ip, username);
-    if (addResult > 0) {
-        log_message("Peer connected/updated via TCP: %s@%s", username, ip);
-        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
-    } else if (addResult < 0) {
-        log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
-    }
-    return addResult;
+static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) { (void)platform_context; int addResult = AddOrUpdatePeer(ip, username); if (addResult > 0) { log_message("Peer connected/updated via TCP: %s@%s", username, ip); if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } else if (addResult < 0) { log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip); } return addResult; }
+static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) { (void)platform_context; (void)ip; char displayMsg[BUFFER_SIZE + 100]; if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) { sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : ""); AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r"); log_message("Message from %s@%s: %s", username, ip, message_content); } else { log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready."); } }
+static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) { (void)platform_context; if (!ip) return; log_message("Peer %s has sent QUIT notification via TCP.", ip); if (MarkPeerInactive(ip)) { if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } }
+
+// --- Completion Routines (Pascal Convention) ---
+
+// ListenCompleteProc remains unchanged
+pascal void ListenCompleteProc(struct TCPiopb *iopb) {
+    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
+    if (ioResult == noErr) { gPeerIP = iopb->csParam.open.remoteHost; gPeerPort = iopb->csParam.open.remotePort; gTCPState = TCP_STATE_CONNECTED_IN; gNeedToStartRecv = true; }
+    else { const char *errMsg = "Unknown Error"; Boolean isReqAborted = (ioResult == reqAborted); if (isReqAborted) errMsg = "reqAborted (-23015)"; else if (ioResult == connectionExists) errMsg = "connectionExists (-23007)"; else if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)"; else if (ioResult == commandTimeout) errMsg = "commandTimeout (-23016)";
+        if (!isReqAborted) { log_message("ListenCompleteProc: Error: %d (%s)", ioResult, errMsg); } else { log_to_file_only("ListenCompleteProc: Request aborted (%d).", ioResult); }
+        gTCPState = TCP_STATE_IDLE; if (ioResult != invalidStreamPtr && !isReqAborted) { gNeedToStartListen = true; } else if (ioResult == invalidStreamPtr) { gTCPState = TCP_STATE_ERROR; log_message("ListenCompleteProc: CRITICAL - Stream invalid."); } }
 }
-static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context; (void)ip;
-    char displayMsg[BUFFER_SIZE + 100];
-    if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
-        sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
-        AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r");
-        log_message("Message from %s@%s: %s", username, ip, message_content);
-    } else {
-        log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
-    }
+
+// RecvCompleteProc remains unchanged
+pascal void RecvCompleteProc(struct TCPiopb *iopb) {
+    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
+    if (ioResult == noErr) { gRcvDataLength = iopb->csParam.receive.rcvBuffLen; gNeedToProcessData = true; }
+    else if (ioResult == connectionClosing) { gRcvDataLength = iopb->csParam.receive.rcvBuffLen; gNeedToProcessData = true; gNeedToCloseIncoming = false; }
+    else { gRcvDataLength = 0; const char *errMsg = "Unknown Error"; Boolean isReqAborted = (ioResult == reqAborted); if (isReqAborted) errMsg = "reqAborted (-23015)"; else if (ioResult == connectionTerminated) errMsg = "connectionTerminated (-23012)"; else if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)";
+        if (!isReqAborted) { log_message("RecvCompleteProc: Error: %d (%s)", ioResult, errMsg); } else { log_to_file_only("RecvCompleteProc: Request aborted (%d).", ioResult); }
+        if (ioResult == invalidStreamPtr) { gTCPState = TCP_STATE_ERROR; log_message("RecvCompleteProc: CRITICAL - Stream invalid."); } else if (!isReqAborted) { gNeedToCloseIncoming = true; } }
 }
-static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context; if (!ip) return;
-    log_message("Peer %s has sent QUIT notification via TCP.", ip);
-    if (MarkPeerInactive(ip)) {
-        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
-    }
+
+// CloseCompleteProc remains unchanged
+pascal void CloseCompleteProc(struct TCPiopb *iopb) {
+    OSErr ioResult = iopb->ioResult; gCurrentPendingPB = NULL;
+    if (ioResult != noErr) { log_message("CloseCompleteProc: Warning - Async close failed: %d", ioResult); } else { log_to_file_only("CloseCompleteProc: Async close completed."); }
+    gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true;
 }
+
 
 // --- Public Functions ---
 
-OSErr InitTCP(short macTCPRefNum) {
-    OSErr err;
-    // Only initialize Listener stream here
-    log_message("Initializing TCP Listener Stream...");
-    if (macTCPRefNum == 0) return paramErr;
-    if (gTCPListenStream != NULL || gListenerState != TCP_LSTATE_UNINITIALIZED) {
-        log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gListenerState);
-        return streamAlreadyOpen;
-    }
+// InitTCP remains unchanged
+OSErr InitTCP(short macTCPRefNum) { OSErr err; log_message("Initializing Single TCP Stream (Async Strategy)..."); if (macTCPRefNum == 0) return paramErr; if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) { log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState); return streamAlreadyOpen; }
+    gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize); gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize); if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) { log_message("Fatal Error: Could not allocate TCP buffers."); if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer); if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer); gTCPInternalBuffer = gTCPRecvBuffer = NULL; return memFullErr; } log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
+    log_message("Creating Single Stream..."); err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize); if (err != noErr || gTCPStream == NULL) { log_message("Error: Failed to create TCP Stream: %d", err); CleanupTCP(macTCPRefNum); return err; } log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
+    gTCPState = TCP_STATE_IDLE; gCurrentPendingPB = NULL; gIsSending = false; gNeedToStartListen = true; gNeedToStartRecv = false; gNeedToProcessData = false; gNeedToCloseIncoming = false; gPeerIP = 0; gPeerPort = 0; log_message("TCP initialization complete. State: IDLE. Will start listening on next poll."); return noErr; }
 
-    // Allocate Listener buffers
-    gTCPListenInternalBuffer = NewPtrClear(kTCPListenInternalBufferSize);
-    gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
+// CleanupTCP remains unchanged
+void CleanupTCP(short macTCPRefNum) { log_message("Cleaning up Single TCP Stream (Async Strategy)..."); StreamPtr streamToRelease = gTCPStream; TCPState stateBeforeCleanup = gTCPState; gTCPStream = NULL; gTCPState = TCP_STATE_RELEASING;
+    if (gCurrentPendingPB != NULL && stateBeforeCleanup != TCP_STATE_IDLE) { log_message("Cleanup: Attempting async kill of pending operation (State: %d)...", stateBeforeCleanup); OSErr killErr = PBKillIO((ParmBlkPtr)gCurrentPendingPB, false); if (killErr != noErr) { log_message("Warning: PBKillIO failed immediately during cleanup: %d", killErr); } gCurrentPendingPB = NULL; }
+    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_RECEIVING) { log_message("Cleanup: Attempting synchronous abort (best effort)..."); LowTCPAbortSyncPoll(YieldTimeToSystem); }
+    if (streamToRelease != NULL && macTCPRefNum != 0) { log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease); OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease); if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr); else log_to_file_only("Sync release successful."); } else if (streamToRelease != NULL) { log_message("Warning: Cannot release stream, MacTCP refnum is 0."); }
+    gTCPState = TCP_STATE_UNINITIALIZED; gCurrentPendingPB = NULL; gIsSending = false; gNeedToStartListen = false; gNeedToStartRecv = false; gNeedToProcessData = false; gNeedToCloseIncoming = false; gPeerIP = 0; gPeerPort = 0;
+    if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; } if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; } log_message("TCP cleanup finished."); }
 
-    if (gTCPListenInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
-        log_message("Fatal Error: Could not allocate Listener TCP buffers.");
-        if (gTCPListenInternalBuffer) DisposePtr(gTCPListenInternalBuffer);
-        if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer);
-        gTCPListenInternalBuffer = gTCPRecvBuffer = NULL;
-        return memFullErr;
-    }
-    log_message("Allocated Listener TCP buffers (Internal: %ld, Recv: %ld).",
-                (long)kTCPListenInternalBufferSize, (long)kTCPRecvBufferSize);
-
-    // Create Listener Stream
-    log_message("Creating Listener Stream...");
-    err = LowTCPCreateSync(macTCPRefNum, &gTCPListenStream, gTCPListenInternalBuffer, kTCPListenInternalBufferSize);
-    if (err != noErr || gTCPListenStream == NULL) {
-        log_message("Error: Failed to create Listener Stream: %d", err);
-        CleanupTCP(macTCPRefNum); // Clean up allocated buffers
-        return err;
-    }
-    log_message("Listener Stream created (0x%lX).", (unsigned long)gTCPListenStream);
-
-    // Initialize state
-    gListenerState = TCP_LSTATE_IDLE;
-    gListenPendingOpPB = NULL;
-    gNeedToListen = true; // Start by wanting to listen
-
-    // Initiate the first listen
-    err = StartListening();
-    if (err != noErr && err != 1) { // 1 means pending
-         log_message("Error: Failed to start initial async TCP listen: %d. Cleaning up.", err);
-         CleanupTCP(macTCPRefNum);
-         return err;
-    }
-
-    log_message("Initial asynchronous TCP listen STARTING on port %d.", PORT_TCP);
-    return noErr;
+// PollTCP remains unchanged
+void PollTCP(void) { OSErr err; unsigned long dummyTimer; if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) return; if (gIsSending) return; if (gCurrentPendingPB != NULL) return;
+    if (gNeedToStartListen && gTCPState == TCP_STATE_IDLE) { gNeedToStartListen = false; log_to_file_only("PollTCP: Starting async listen..."); err = StartAsyncListen(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async listen: %d. Retrying later.", err); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; Delay(kErrorRetryDelayTicks, &dummyTimer); } return; }
+    if (gNeedToStartRecv && gTCPState == TCP_STATE_CONNECTED_IN) { gNeedToStartRecv = false; log_to_file_only("PollTCP: Starting async receive..."); err = StartAsyncRecv(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async receive: %d. Closing connection.", err); gTCPState = TCP_STATE_CONNECTED_IN; gNeedToCloseIncoming = true; } return; }
+    if (gNeedToProcessData) { gNeedToProcessData = false; log_to_file_only("PollTCP: Processing received data (%u bytes)...", gRcvDataLength); ProcessTCPReceive(gRcvDataLength); gRcvDataLength = 0;
+         if (gTCPState == TCP_STATE_RECEIVING) { log_to_file_only("PollTCP: Starting next async receive..."); err = StartAsyncRecv(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start next async receive: %d. Closing connection.", err); gTCPState = TCP_STATE_RECEIVING; gNeedToCloseIncoming = true; } }
+         else if (gTCPState == TCP_STATE_CONNECTED_IN) { char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr); log_message("PollTCP: Peer %s closed connection gracefully. Returning to IDLE.", peerIPStr); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; }
+         else { log_message("PollTCP: WARNING - Processed data but state is unexpected: %d", gTCPState); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } return; }
+    if (gNeedToCloseIncoming) { gNeedToCloseIncoming = false; if (gTCPState == TCP_STATE_RECEIVING || gTCPState == TCP_STATE_CONNECTED_IN) { log_message("PollTCP: Closing incoming connection gracefully..."); err = StartAsyncCloseIncoming(); if (err != noErr && err != 1) { log_message("PollTCP: Failed to start async close: %d. Assuming closed, returning to IDLE.", err); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } }
+         else { log_message("PollTCP: WARNING - NeedToCloseIncoming flag set, but state is unexpected: %d. Returning to IDLE.", gTCPState); gTCPState = TCP_STATE_IDLE; gNeedToStartListen = true; } return; }
 }
 
-void CleanupTCP(short macTCPRefNum) {
-    OSErr killErr = noErr;
-    log_message("Cleaning up TCP Listener Stream..."); // Only listener now
+// GetTCPState remains unchanged
+TCPState GetTCPState(void) { return gTCPState; }
 
-    // --- Cleanup Listener Stream ---
-    StreamPtr listenStreamToRelease = gTCPListenStream;
-    gTCPListenStream = NULL; // Prevent further use
+// WaitForKillCompletion remains unchanged
+static OSErr WaitForKillCompletion(GiveTimePtr giveTime, const char* context) { unsigned long startTime = TickCount(); log_to_file_only("WaitForKillCompletion (%s): Waiting for state to return to IDLE...", context); while ((TickCount() - startTime) < kKillWaitTimeoutTicks) { if (gTCPState == TCP_STATE_IDLE && gCurrentPendingPB == NULL) { log_to_file_only("WaitForKillCompletion (%s): Kill completed (State IDLE).", context); return noErr; } giveTime(); } log_message("Error (%s): Timeout waiting for PBKillIO to complete. State: %d", context, gTCPState); return reqAborted; }
 
-    // Kill pending listener operation
-    if (gListenPendingOpPB != NULL) {
-        log_message("Cleanup: Killing pending listener operation (State: %d)...", gListenerState);
-        killErr = PBKillIO((ParmBlkPtr)gListenPendingOpPB, false); // Async kill
-        if (killErr != noErr) log_message("Warning: PBKillIO failed for listener: %d", killErr);
-        gListenPendingOpPB = NULL;
-    }
+// TCP_SendTextMessageSync remains unchanged
+OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) { OSErr err = noErr, finalErr = noErr; ip_addr targetIP = 0; char messageBuffer[BUFFER_SIZE]; int formattedLen; struct wdsEntry sendWDS[2];
+    log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIP); if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
+    if (gIsSending) { log_message("Warning (SendText): Send already in progress."); return streamBusyErr; } gIsSending = true; log_to_file_only("TCP_SendTextMessageSync: Acquired send lock.");
+    err = KillAsyncOperation(giveTime); if (err != noErr) { log_message("Error (SendText): Failed to kill pending async operation (%d). Cannot send.", err); finalErr = streamBusyErr; goto SendTextCleanup; } if (gTCPState != TCP_STATE_IDLE) { log_message("Error (SendText): State not IDLE (%d) after kill attempt. Cannot send.", gTCPState); finalErr = streamBusyErr; goto SendTextCleanup; }
+    err = ParseIPv4(peerIP, &targetIP); if (err != noErr || targetIP == 0) { log_message("Error (SendText): Could not parse peer IP '%s'.", peerIP); finalErr = paramErr; goto SendTextCleanup; }
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message); if (formattedLen <= 0) { log_message("Error (SendText): Failed to format TEXT message for %s.", peerIP); finalErr = paramErr; goto SendTextCleanup; }
+    log_to_file_only("SendText: Connecting..."); err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
+    if (err == noErr) { log_to_file_only("SendText: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL; log_to_file_only("SendText: Sending data..."); err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime); if (err == noErr) { log_to_file_only("SendText: Send successful."); } else { log_message("Error (SendText): Send failed: %d", err); finalErr = err; } log_to_file_only("SendText: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime); if (abortErr != noErr) { log_message("Warning (SendText): Abort failed: %d", abortErr); if (finalErr == noErr) finalErr = abortErr; } }
+    else { log_message("Error (SendText): Connect failed: %d", err); finalErr = err; }
+SendTextCleanup: gNeedToStartListen = true; gIsSending = false; log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr); return finalErr; }
 
-    // Release listener stream synchronously
-    if (listenStreamToRelease != NULL && macTCPRefNum != 0) {
-        log_message("Attempting sync release of listener stream 0x%lX...", (unsigned long)listenStreamToRelease);
-        OSErr relErr = LowTCPReleaseSync(macTCPRefNum, listenStreamToRelease);
-        if (relErr != noErr) log_message("Warning: Sync release failed for listener: %d", relErr);
-        else log_to_file_only("Sync release successful for listener.");
-    } else if (listenStreamToRelease != NULL) {
-        log_message("Warning: Cannot release listener stream, MacTCP refnum is 0.");
-    }
-
-    // Reset listener state
-    gListenerState = TCP_LSTATE_UNINITIALIZED;
-    gListenPendingOpPB = NULL;
-    gNeedToListen = false;
-    gPeerIP = 0; gPeerPort = 0;
-
-    // --- Dispose Buffers ---
-    if (gTCPRecvBuffer != NULL) {
-        log_message("Disposing TCP receive buffer.");
-        DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL;
-    }
-     if (gTCPListenInternalBuffer != NULL) {
-        log_message("Disposing TCP listener internal buffer.");
-        DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
-    }
-    // No sender buffer/stream to clean up here
-
-    log_message("TCP Stream cleanup finished.");
-}
+// TCP_SendQuitMessagesSync remains unchanged
+OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) { int i; OSErr lastErr = noErr, currentErr = noErr; char quitMessageBuffer[BUFFER_SIZE]; int formattedLen, activePeerCount = 0, sentCount = 0; unsigned long dummyTimer; struct wdsEntry sendWDS[2];
+    log_message("TCP_SendQuitMessagesSync: Starting..."); if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (giveTime == NULL) return paramErr;
+    if (gIsSending) { log_message("Warning (SendQuit): Send already in progress."); return streamBusyErr; } gIsSending = true; log_to_file_only("TCP_SendQuitMessagesSync: Acquired send lock.");
+    currentErr = KillAsyncOperation(giveTime); if (currentErr != noErr) { log_message("Error (SendQuit): Failed to kill pending async operation (%d). Cannot send.", currentErr); lastErr = streamBusyErr; goto SendQuitCleanup; } if (gTCPState != TCP_STATE_IDLE) { log_message("Error (SendQuit): State not IDLE (%d) after kill attempt. Cannot send.", gTCPState); lastErr = streamBusyErr; goto SendQuitCleanup; }
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, ""); if (formattedLen <= 0) { log_message("Error (SendQuit): Failed to format QUIT message."); lastErr = paramErr; goto SendQuitCleanup; }
+    for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++; log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount); if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
+    for (i = 0; i < MAX_PEERS; ++i) { if (gPeerManager.peers[i].active) { ip_addr currentTargetIP = 0; currentErr = noErr; if (gTCPState != TCP_STATE_IDLE) { log_message("CRITICAL (SendQuit): State not IDLE (%d) before processing peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip); lastErr = ioErr; break; } log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
+            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP); if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse peer IP '%s'. Skipping.", gPeerManager.peers[i].ip); lastErr = currentErr; goto NextPeerDelay; }
+            log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip); currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
+            if (currentErr == noErr) { log_to_file_only("SendQuit: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL; log_to_file_only("SendQuit: Sending data..."); currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime); if (currentErr == noErr) { log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip); sentCount++; } else { log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr); lastErr = currentErr; } log_to_file_only("SendQuit: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime); if (abortErr != noErr) { log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr); if (lastErr == noErr) lastErr = abortErr; } }
+            else { log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr); lastErr = currentErr; }
+        NextPeerDelay: log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip); giveTime(); Delay(kQuitLoopDelayTicks, &dummyTimer); } }
+SendQuitCleanup: log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr); gNeedToStartListen = true; gIsSending = false; log_to_file_only("TCP_SendQuitMessagesSync: Released send lock."); return lastErr; }
 
 
-void PollTCPListener(short macTCPRefNum) {
-    OSErr ioResult;
-    TCPListenerState previousState;
+// --- Private Helpers ---
 
-    // If listener stream is gone or in error state, do nothing
-    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_UNINITIALIZED || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) {
-        return;
-    }
+// ProcessTCPReceive remains unchanged
+static void ProcessTCPReceive(unsigned short dataLength) { char senderIPStrFromConnection[INET_ADDRSTRLEN], senderIPStrFromPayload[INET_ADDRSTRLEN]; char senderUsername[32], msgType[32], content[BUFFER_SIZE]; static tcp_platform_callbacks_t mac_callbacks = { .add_or_update_peer = mac_tcp_add_or_update_peer, .display_text_message = mac_tcp_display_text_message, .mark_peer_inactive = mac_tcp_mark_peer_inactive }; if (dataLength > 0 && gTCPRecvBuffer != NULL) { OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection); if (addrErr != noErr) sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF); if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0'; else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) { log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection); handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL); if (strcmp(msgType, MSG_QUIT) == 0) log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection); } else log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength); } else if (dataLength == 0) log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal)."); else log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL?"); }
 
-    // Check if we need to start listening
-    if (gListenPendingOpPB == NULL && gListenerState == TCP_LSTATE_IDLE && gNeedToListen) {
-        log_to_file_only("PollListener: Stream idle and needs to listen. Starting listen.");
-        StartListening(); // Ignore error, will retry on next poll if fails
-        return; // Don't check completion immediately
-    }
-
-    // Check if a listener operation is pending
-    if (gListenPendingOpPB != NULL) {
-        ioResult = gListenPendingOpPB->ioResult;
-
-        if (ioResult > 0) {
-            // Still pending, do nothing
-            return;
-        }
-
-        // --- Listener Operation Completed (Success or Error) ---
-        log_to_file_only("PollListener: Pending operation (State: %d) completed with result: %d", gListenerState, ioResult);
-
-        // Capture state *before* clearing gListenPendingOpPB and calling handler
-        previousState = gListenerState;
-        gListenPendingOpPB = NULL; // Clear pending operation pointer
-
-        // Call the appropriate handler based on the state *when the operation was started*
-        switch (previousState) {
-            case TCP_LSTATE_LISTENING:
-                HandleListenComplete(ioResult);
-                break;
-            case TCP_LSTATE_RECEIVING:
-                HandleRecvComplete(ioResult);
-                break;
-            case TCP_LSTATE_CLOSING:
-                HandleCloseIncomingComplete(ioResult);
-                break;
-            // Should not have pending ops in these states
-            case TCP_LSTATE_IDLE:
-            case TCP_LSTATE_UNINITIALIZED:
-            case TCP_LSTATE_ERROR:
-            case TCP_LSTATE_RELEASING:
-                 log_message("PollListener: CRITICAL - Operation completed but listener was in unexpected state %d!", previousState);
-                 gListenerState = TCP_LSTATE_IDLE;
-                 gNeedToListen = true;
-                break;
-        }
-    }
-}
-
-// Public function to get listener state
-TCPListenerState GetTCPListenerState(void) {
-    return gListenerState;
-}
-
-
-// Sends a text message SYNCHRONOUSLY using a temporary stream.
-OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
-    OSErr err = noErr;
-    ip_addr targetIP = 0;
-    char messageBuffer[BUFFER_SIZE]; // Local buffer for formatted message
-    int formattedLen;
-
-    log_to_file_only("TCP_SendTextMessageSync: Attempting to send TEXT to %s", peerIP);
-
-    if (gMacTCPRefNum == 0) return notOpenErr;
-    if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
-
-    // Parse IP
-    err = ParseIPv4(peerIP, &targetIP);
-    if (err != noErr || targetIP == 0) {
-        log_message("Error (SendText): Could not parse peer IP '%s'.", peerIP);
-        return paramErr;
-    }
-
-    // Format message into local buffer
-    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT,
-                                  gMyUsername, gMyLocalIPStr, message);
-    if (formattedLen <= 0) {
-        log_message("Error (SendText): Failed to format TEXT message for %s.", peerIP);
-        return paramErr;
-    }
-
-    // Use the internal helper that manages a temporary stream
-    err = InternalSyncTCPSend(targetIP, PORT_TCP, messageBuffer, formattedLen,
-                              kConnectTimeoutTicks, kSendTimeoutTicks, giveTime);
-
-    if (err == noErr) log_message("Successfully sent TEXT message to %s.", peerIP);
-    else log_message("Failed to send TEXT message to %s (Error: %d).", peerIP, err);
-
-    return err;
-}
-
-
-// Sends QUIT messages SYNCHRONOUSLY using temporary streams with delay.
-OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
-    int i;
-    OSErr lastErr = noErr;
-    char quitMessageBuffer[BUFFER_SIZE]; // Local buffer
-    int formattedLen;
-    int activePeerCount = 0;
-    int sentCount = 0;
-    unsigned long dummyTimer; // For Delay
-
-    log_message("TCP_SendQuitMessagesSync: Starting...");
-
-    if (gMacTCPRefNum == 0) return notOpenErr;
-    if (giveTime == NULL) return paramErr;
-
-    // Format the QUIT message once
-    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT,
-                                  gMyUsername, gMyLocalIPStr, "");
-    if (formattedLen <= 0) {
-        log_message("Error (SendQuit): Failed to format QUIT message.");
-        return paramErr;
-    }
-
-    // Count active peers
-    for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
-    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
-    if (activePeerCount == 0) return noErr;
-
-    // Iterate through peers
-    for (i = 0; i < MAX_PEERS; ++i) {
-        if (gPeerManager.peers[i].active) {
-            ip_addr currentTargetIP = 0;
-            OSErr parseErr, sendErr;
-
-            log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s",
-                        gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-
-            // Parse IP
-            parseErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
-            if (parseErr != noErr || currentTargetIP == 0) {
-                log_message("Error (SendQuit): Could not parse peer IP '%s'. Skipping.", gPeerManager.peers[i].ip);
-                lastErr = parseErr;
-                continue;
-            }
-
-            // Use the internal helper that manages a temporary stream
-            sendErr = InternalSyncTCPSend(currentTargetIP, PORT_TCP, quitMessageBuffer, formattedLen,
-                                          kConnectTimeoutTicks, kSendTimeoutTicks, giveTime); // Use standard timeouts
-
-            if (sendErr == noErr) {
-                log_message("Successfully sent QUIT to %s.", gPeerManager.peers[i].ip);
-                sentCount++;
-            } else {
-                log_message("Error sending QUIT to %s: %d", gPeerManager.peers[i].ip, sendErr);
-                lastErr = sendErr;
-            }
-
-            // *** ADD YIELD AND DELAY BETWEEN PEERS ***
-            log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
-            giveTime(); // Basic yield
-            Delay(kQuitLoopDelayTicks, &dummyTimer); // Add specific delay
-
-        } // end if peer active
-    } // end for loop
-
-    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
-    return lastErr;
-}
-
-
-// --- Private Listener State Machine Helpers ---
-
-// Kill the currently pending listener operation, if any.
-static OSErr KillListenerPendingOperation(const char* callerContext) {
-    OSErr killErr = noErr;
-    if (gListenPendingOpPB != NULL) {
-        TCPListenerState stateBeforeKill = gListenerState;
-        log_message("Info (%s): Attempting to kill pending listener operation (State: %d)...", callerContext, stateBeforeKill);
-
-        killErr = PBKillIO((ParmBlkPtr)gListenPendingOpPB, false); // Async kill
-
-        if (killErr == noErr) {
-            log_to_file_only("Info (%s): PBKillIO initiated successfully for listener.", callerContext);
-            // Assume kill works, clear state
-            gListenPendingOpPB = NULL;
-            gListenerState = TCP_LSTATE_IDLE;
-            return noErr;
-        } else {
-            log_message("Error (%s): PBKillIO failed immediately for listener: %d. State left as %d.", callerContext, killErr, stateBeforeKill);
-            return killErr;
-        }
-    }
-    return noErr; // Nothing to kill
-}
-
-
-// Initiate TCPPassiveOpen on the listener stream
-static OSErr StartListening(void) {
-    OSErr err;
-    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
-    if (gListenPendingOpPB != NULL || gListenerState != TCP_LSTATE_IDLE) {
-        log_to_file_only("StartListening: Cannot start, pending op exists or state (%d) not IDLE.", gListenerState);
-        return inProgress;
-    }
-
-    log_to_file_only("StartListening: Initiating TCPPassiveOpen...");
+// StartAsyncListen - *** UPDATED CAST ***
+static OSErr StartAsyncListen(void) {
+    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gCurrentPendingPB != NULL || gTCPState != TCP_STATE_IDLE) return inProgress;
     memset(&gListenPB, 0, sizeof(TCPiopb));
-    gListenPB.ioCompletion = nil;
-    gListenPB.ioCRefNum = gMacTCPRefNum;
-    gListenPB.csCode = TCPPassiveOpen;
-    gListenPB.tcpStream = gTCPListenStream;
-    gListenPB.csParam.open.validityFlags = 0;
-    gListenPB.csParam.open.localPort = PORT_TCP;
-    gListenPB.csParam.open.localHost = 0L;
-    gListenPB.csParam.open.remoteHost = 0L;
-    gListenPB.csParam.open.remotePort = 0;
-
-    gListenerState = TCP_LSTATE_LISTENING; // Set state *before* async call
-    gListenPendingOpPB = &gListenPB;
-    err = PBControlAsync((ParmBlkPtr)&gListenPB);
-    if (err != noErr) {
-        log_message("Error (StartListening): PBControlAsync failed immediately: %d", err);
-        gListenPendingOpPB = NULL;
-        gListenerState = TCP_LSTATE_IDLE; // Revert state
-        gNeedToListen = true; // Ensure retry
-        return err;
-    }
-    return 1; // Pending
+    // *** USE TCPIOCompletionProcPtr ***
+    gListenPB.ioCompletion = (TCPIOCompletionProcPtr)ListenCompleteProc;
+    gListenPB.ioCRefNum = gMacTCPRefNum; gListenPB.csCode = TCPPassiveOpen; gListenPB.tcpStream = gTCPStream;
+    gListenPB.csParam.open.validityFlags = 0; gListenPB.csParam.open.localPort = PORT_TCP; gListenPB.csParam.open.commandTimeoutValue = 0;
+    gTCPState = TCP_STATE_LISTENING; gCurrentPendingPB = &gListenPB; err = PBControlAsync((ParmBlkPtr)&gListenPB);
+    if (err != noErr) { log_message("Error (StartAsyncListen): PBControlAsync failed immediately: %d", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_IDLE; return err; } return 1;
 }
 
-// Initiate TCPRcv on the listener stream
-static OSErr StartRecv(void) {
-    OSErr err;
-    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
-    // Should be called when connection is established (state LISTENING after completion)
-     if (gListenPendingOpPB != NULL || (gListenerState != TCP_LSTATE_LISTENING && gListenerState != TCP_LSTATE_RECEIVING)) {
-        log_message("StartRecv: Cannot start, pending op exists or state (%d) invalid.", gListenerState);
-        return (gListenPendingOpPB != NULL) ? inProgress : paramErr;
-    }
-     if (gTCPRecvBuffer == NULL) return invalidBufPtr;
-
-    log_to_file_only("StartRecv: Initiating TCPRcv...");
+// StartAsyncRecv - *** UPDATED CAST ***
+static OSErr StartAsyncRecv(void) {
+    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gTCPRecvBuffer == NULL) return invalidBufPtr; if (gCurrentPendingPB != NULL || gTCPState != TCP_STATE_CONNECTED_IN) return inProgress;
     memset(&gRecvPB, 0, sizeof(TCPiopb));
-    gRecvPB.ioCompletion = nil;
-    gRecvPB.ioCRefNum = gMacTCPRefNum;
-    gRecvPB.csCode = TCPRcv;
-    gRecvPB.tcpStream = gTCPListenStream;
-    gRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;
-    gRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize;
-    gRecvPB.csParam.receive.commandTimeoutValue = 0;
-
-    gListenerState = TCP_LSTATE_RECEIVING; // Set state *before* async call
-    gListenPendingOpPB = &gRecvPB;
-    err = PBControlAsync((ParmBlkPtr)&gRecvPB);
-    if (err != noErr) {
-        log_message("Error (StartRecv): PBControlAsync failed immediately: %d", err);
-        gListenPendingOpPB = NULL;
-        gListenerState = TCP_LSTATE_IDLE; // Revert state? Or CLOSING? Go IDLE.
-        gNeedToListen = true;
-        return err;
-    }
-    return 1; // Pending
+    // *** USE TCPIOCompletionProcPtr ***
+    gRecvPB.ioCompletion = (TCPIOCompletionProcPtr)RecvCompleteProc;
+    gRecvPB.ioCRefNum = gMacTCPRefNum; gRecvPB.csCode = TCPRcv; gRecvPB.tcpStream = gTCPStream;
+    gRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer; gRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize; gRecvPB.csParam.receive.commandTimeoutValue = 0;
+    gTCPState = TCP_STATE_RECEIVING; gCurrentPendingPB = &gRecvPB; err = PBControlAsync((ParmBlkPtr)&gRecvPB);
+    if (err != noErr) { log_message("Error (StartAsyncRecv): PBControlAsync failed immediately: %d", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_CONNECTED_IN; return err; } return 1;
 }
 
-// Initiate TCPClose on the listener stream (for incoming connection)
-static OSErr StartCloseIncoming(void) {
-    OSErr err;
-    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
-    // Can be called after Recv error or processing QUIT
-
-    // Kill pending Recv if any
-    err = KillListenerPendingOperation("StartCloseIncoming");
-    if (err != noErr) {
-        log_message("Error (StartCloseIncoming): Failed to kill prior operation (%d). Cannot initiate close.", err);
-        gListenerState = TCP_LSTATE_ERROR;
-        return err;
-    }
-    // State should now be IDLE
-
-    log_to_file_only("StartCloseIncoming: Initiating TCPClose (graceful)...");
+// StartAsyncCloseIncoming - *** UPDATED CAST ***
+static OSErr StartAsyncCloseIncoming(void) {
+    OSErr err; if (gTCPStream == NULL) return invalidStreamPtr; if (gCurrentPendingPB != NULL || (gTCPState != TCP_STATE_CONNECTED_IN && gTCPState != TCP_STATE_RECEIVING)) return inProgress;
     memset(&gClosePB, 0, sizeof(TCPiopb));
-    gClosePB.ioCompletion = nil;
-    gClosePB.ioCRefNum = gMacTCPRefNum;
-    gClosePB.csCode = TCPClose;
-    gClosePB.tcpStream = gTCPListenStream;
-    gClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction;
-    gClosePB.csParam.close.ulpTimeoutValue = kCloseTimeoutTicks;
-    gClosePB.csParam.close.ulpTimeoutAction = AbortTrue; // Abort if close times out
-
-    gListenerState = TCP_LSTATE_CLOSING; // Set state *before* async call
-    gListenPendingOpPB = &gClosePB;
-    err = PBControlAsync((ParmBlkPtr)&gClosePB);
-    if (err != noErr) {
-        log_message("Error (StartCloseIncoming): PBControlAsync failed immediately: %d. Assuming closed.", err);
-        gListenPendingOpPB = NULL;
-        gListenerState = TCP_LSTATE_IDLE; // Revert state to IDLE
-        gNeedToListen = true; // Try listening again
-        return noErr; // Goal (closed) likely achieved
-    }
-    return 1; // Pending
+    // *** USE TCPIOCompletionProcPtr ***
+    gClosePB.ioCompletion = (TCPIOCompletionProcPtr)CloseCompleteProc;
+    gClosePB.ioCRefNum = gMacTCPRefNum; gClosePB.csCode = TCPClose; gClosePB.tcpStream = gTCPStream;
+    gClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction; gClosePB.csParam.close.ulpTimeoutValue = kCloseTimeoutTicks; gClosePB.csParam.close.ulpTimeoutAction = AbortTrue;
+    gTCPState = TCP_STATE_CLOSING_IN; gCurrentPendingPB = &gClosePB; err = PBControlAsync((ParmBlkPtr)&gClosePB);
+    if (err != noErr) { log_message("Error (StartAsyncCloseIncoming): PBControlAsync failed immediately: %d. Assuming closed.", err); gCurrentPendingPB = NULL; gTCPState = TCP_STATE_IDLE; return noErr; } return 1;
 }
 
-// --- Listener State Completion Handlers ---
+// KillAsyncOperation remains unchanged
+static OSErr KillAsyncOperation(GiveTimePtr giveTime) { OSErr killErr = noErr; TCPiopb *pbToKill = gCurrentPendingPB; TCPState stateWhenKilled = gTCPState; if (pbToKill != NULL && stateWhenKilled != TCP_STATE_IDLE) { log_message("KillAsyncOperation: Attempting async kill of pending operation (State: %d)...", stateWhenKilled); killErr = PBKillIO((ParmBlkPtr)pbToKill, false); if (killErr == noErr) { killErr = WaitForKillCompletion(giveTime, "KillAsyncOperation"); if (killErr != noErr) { log_message("KillAsyncOperation: Failed waiting for kill completion."); return streamBusyErr; } return noErr; } else if (killErr == paramErr) { log_message("CRITICAL (KillAsyncOperation): PBKillIO failed with paramErr (%d)! Cannot interrupt async op (State: %d).", killErr, stateWhenKilled); return streamBusyErr; } else { log_message("Error (KillAsyncOperation): PBKillIO failed immediately: %d (State: %d).", killErr, stateWhenKilled); if (gTCPState == TCP_STATE_IDLE && gCurrentPendingPB == NULL) { log_message("KillAsyncOperation: State is now IDLE, proceeding despite PBKillIO error."); return noErr; } return streamBusyErr; } } return noErr; }
 
-static void HandleListenComplete(OSErr ioResult) {
-    if (ioResult == noErr) {
-        // Connection indication received
-        gPeerIP = gListenPB.csParam.open.remoteHost;
-        gPeerPort = gListenPB.csParam.open.remotePort;
-        char senderIPStr[INET_ADDRSTRLEN];
-        AddrToStr(gPeerIP, senderIPStr);
-        log_message("HandleListenComplete: Connection Indication from %s:%u.", senderIPStr, gPeerPort);
+// --- Low-Level Synchronous Polling TCP Helpers (for Sending) ---
 
-        // Start receiving data
-        OSErr err = StartRecv();
-        if (err != noErr && err != 1) { // 1=pending
-            log_message("Error (HandleListenComplete): Failed to start receive: %d. Closing incoming.", err);
-            StartCloseIncoming(); // Close gracefully
-        }
-        // State is now RECEIVING (set by StartRecv) or CLOSING
-    } else {
-        // Handle errors
-        const char *errMsg = "Unknown Error";
-        Boolean isConnectionExists = (ioResult == connectionExists);
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-        Boolean isReqAborted = (ioResult == reqAborted);
-        if (isConnectionExists) errMsg = "connectionExists (-23007)";
-        else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-        else if (isReqAborted) errMsg = "reqAborted (-23015)";
-
-        if (isReqAborted) {
-             log_to_file_only("HandleListenComplete: Listen aborted (result %d).", ioResult);
-             gListenerState = TCP_LSTATE_IDLE; // Ensure state is IDLE
-        } else {
-            log_message("Error (HandleListenComplete): TCPPassiveOpen failed: %d (%s)", ioResult, errMsg);
-            gListenerState = TCP_LSTATE_IDLE; // Go back to idle
-            if (isInvalidStream) {
-                 log_message("CRITICAL: Listener Stream invalid. Setting state to ERROR.");
-                 gListenerState = TCP_LSTATE_ERROR;
-                 gNeedToListen = false;
-            } else {
-                 gNeedToListen = true; // Try listening again later
-                 if (isConnectionExists) {
-                     unsigned long dummyTimer;
-                     Delay(kTCPListenRetryDelayTicks, &dummyTimer);
-                 }
-            }
-        }
-    }
-}
-
-static void HandleRecvComplete(OSErr ioResult) {
-     if (ioResult == noErr) {
-        // Data received successfully
-        ProcessTCPReceive(); // Process data in gTCPRecvBuffer
-
-        // If ProcessTCPReceive didn't trigger a close, start next receive
-        if (gListenerState == TCP_LSTATE_RECEIVING) { // Check state hasn't changed
-            OSErr err = StartRecv();
-             if (err != noErr && err != 1) {
-                 log_message("Error (HandleRecvComplete): Failed to start next receive: %d. Closing.", err);
-                 StartCloseIncoming();
-             }
-             // State remains RECEIVING (set by StartRecv) or CLOSING
-        } else {
-             log_to_file_only("HandleRecvComplete: State changed during processing (now %d). Not starting new receive.", gListenerState);
-        }
-    } else if (ioResult == connectionClosing) {
-         // Peer initiated graceful close
-         char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
-         log_message("HandleRecvComplete: Connection closing gracefully from %s.", peerIPStr);
-         ProcessTCPReceive(); // Process any final data
-         gListenerState = TCP_LSTATE_IDLE; // Go back to idle
-         gNeedToListen = true; // Listen again
-    } else {
-         // Handle receive errors
-         char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
-         const char *errMsg = "Unknown Error";
-         Boolean isConnTerminated = (ioResult == connectionTerminated);
-         Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-         Boolean isReqAborted = (ioResult == reqAborted);
-         if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
-         else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-         else if (isReqAborted) errMsg = "reqAborted (-23015)";
-
-        if (isReqAborted) {
-            log_to_file_only("HandleRecvComplete: Receive aborted (result %d).", ioResult);
-            gListenerState = TCP_LSTATE_IDLE;
-        } else {
-            log_message("Error (HandleRecvComplete): Receive failed from %s: %d (%s).", peerIPStr, ioResult, errMsg);
-            if (isInvalidStream) {
-                 log_message("CRITICAL: Listener Stream invalid. Setting state to ERROR.");
-                 gListenerState = TCP_LSTATE_ERROR;
-                 gNeedToListen = false;
-            } else {
-                 // For other errors (like terminated), close our end gracefully
-                 StartCloseIncoming();
-                 // State is now CLOSING
-            }
-        }
-    }
-}
-
-static void HandleCloseIncomingComplete(OSErr ioResult) {
-    // Graceful close of incoming connection completed (or failed)
-    if (ioResult == noErr) {
-        log_to_file_only("HandleCloseIncomingComplete: Graceful close completed.");
-    } else {
-        log_message("Warning (HandleCloseIncomingComplete): Graceful close failed: %d", ioResult);
-    }
-    gListenerState = TCP_LSTATE_IDLE; // Connection is closed, return to idle
-    gNeedToListen = true; // Try listening again
-}
-
-
-// Process data received in gTCPRecvBuffer
-static void ProcessTCPReceive(void) {
-    char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN];
-    char senderUsername[32];
-    char msgType[32];
-    char content[BUFFER_SIZE];
-    unsigned short dataLength;
-
-    static tcp_platform_callbacks_t mac_callbacks = {
-        .add_or_update_peer = mac_tcp_add_or_update_peer,
-        .display_text_message = mac_tcp_display_text_message,
-        .mark_peer_inactive = mac_tcp_mark_peer_inactive
-    };
-
-    // Use the static gRecvPB directly here.
-    dataLength = gRecvPB.csParam.receive.rcvBuffLen;
-
-    if (dataLength > 0) {
-        OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
-        if (addrErr != noErr) {
-            sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
-            log_to_file_only("ProcessTCPReceive: AddrToStr failed (%d). Using fallback '%s'.", addrErr, senderIPStrFromConnection);
-        }
-
-        if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
-            log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection);
-            handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL);
-
-            // If QUIT received, initiate close immediately
-            if (strcmp(msgType, MSG_QUIT) == 0) {
-                 log_message("ProcessTCPReceive: QUIT received from %s. Initiating close.", senderIPStrFromConnection);
-                 StartCloseIncoming(); // Close gracefully
-            }
-        } else {
-            log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
-        }
-    } else {
-        log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing).");
-    }
-}
-
-
-// --- Low-Level Synchronous TCP Helpers ---
-
-// Creates a TCP stream synchronously. (Unchanged)
-static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen)
-{
-    OSErr err; TCPiopb pbCreate;
-    if (streamPtr == NULL || connectionBuffer == NULL) return paramErr;
-    memset(&pbCreate, 0, sizeof(TCPiopb));
-    pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum;
-    pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L;
-    pbCreate.csParam.create.rcvBuff = connectionBuffer;
-    pbCreate.csParam.create.rcvBuffLen = connBufferLen;
-    pbCreate.csParam.create.notifyProc = nil;
-    err = PBControlSync((ParmBlkPtr)&pbCreate);
-    if (err == noErr) {
-        *streamPtr = pbCreate.tcpStream;
-        if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): NULL stream."); err = ioErr; }
-    } else { *streamPtr = NULL; }
-    return err;
-}
-
-// Opens a TCP connection synchronously using TCPActiveOpen.
-// Uses polling with giveTime.
-static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-
-    if (giveTime == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) { log_message("Error (LowTCPOpenConnectionSync): Failed alloc PB."); return memFullErr; }
-
-    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPActiveOpen; pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-    pBlock->csParam.open.ulpTimeoutValue = timeoutTicks;
-    pBlock->csParam.open.ulpTimeoutAction = AbortTrue;
-    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction;
-    pBlock->csParam.open.commandTimeoutValue = 0;
-    pBlock->csParam.open.remoteHost = remoteHost;
-    pBlock->csParam.open.remotePort = remotePort;
-    pBlock->csParam.open.localPort = 0; pBlock->csParam.open.localHost = 0;
-
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_message("Error (LowTCPOpenConnectionSync): PBControlAsync failed: %d", err);
-        DisposePtr((Ptr)pBlock); return err;
-    }
-    while (pBlock->ioResult > 0) { giveTime(); } // Poll
-    err = pBlock->ioResult;
-    DisposePtr((Ptr)pBlock);
-    return err;
-}
-
-// Sends data synchronously using TCPSend.
-// Uses polling with giveTime.
-static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-
-    if (giveTime == NULL || wdsPtr == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) { log_message("Error (LowTCPSendSync): Failed alloc PB."); return memFullErr; }
-
-    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPSend; pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-    pBlock->csParam.send.ulpTimeoutValue = timeoutTicks;
-    pBlock->csParam.send.ulpTimeoutAction = AbortTrue;
-    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction;
-    pBlock->csParam.send.pushFlag = push;
-    pBlock->csParam.send.urgentFlag = false; // Assuming not urgent
-    pBlock->csParam.send.wdsPtr = wdsPtr;
-
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_message("Error (LowTCPSendSync): PBControlAsync failed: %d", err);
-        DisposePtr((Ptr)pBlock); return err;
-    }
-    while (pBlock->ioResult > 0) { giveTime(); } // Poll
-    err = pBlock->ioResult;
-    DisposePtr((Ptr)pBlock);
-    return err;
-}
-
-// Aborts a TCP connection synchronously using TCPAbort.
-// Uses polling with giveTime.
-static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-
-    if (giveTime == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) { log_message("Error (LowTCPAbortSync): Failed alloc PB."); return memFullErr; }
-
-    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPAbort; pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_to_file_only("Info (LowTCPAbortSync): PBControlAsync failed: %d", err);
-        DisposePtr((Ptr)pBlock);
-        // Return noErr generally, as abort is best-effort cleanup
-        return (err == connectionDoesntExist || err == invalidStreamPtr) ? noErr : err;
-    }
-    while (pBlock->ioResult > 0) { giveTime(); } // Poll
-    err = pBlock->ioResult;
-    if (err != noErr && err != connectionDoesntExist && err != invalidStreamPtr) {
-         log_message("Warning (LowTCPAbortSync): Abort completed with error: %d", err);
-    }
-    DisposePtr((Ptr)pBlock);
-    // Return noErr generally for abort, unless unexpected error occurred
-    return (err == connectionDoesntExist || err == invalidStreamPtr || err == noErr) ? noErr : err;
-}
-
-// Releases a TCP stream synchronously. (Unchanged)
-static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr)
-{
-    OSErr err; TCPiopb pbRelease;
-    if (streamPtr == NULL) return invalidStreamPtr;
-    memset(&pbRelease, 0, sizeof(TCPiopb));
-    pbRelease.ioCompletion = nil; pbRelease.ioCRefNum = macTCPRefNum;
-    pbRelease.csCode = TCPRelease; pbRelease.tcpStream = streamPtr;
-    err = PBControlSync((ParmBlkPtr)&pbRelease);
-    if (err != noErr && err != invalidStreamPtr) { log_message("Warning (LowTCPReleaseSync): Failed: %d", err); }
-    else if (err == invalidStreamPtr) { log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid.", (unsigned long)streamPtr); err = noErr; }
-    return err;
-}
-
-// Internal function to perform a complete synchronous send operation using a temporary stream
-static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
-                                 const char *messageBuffer, int messageLen,
-                                 SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
-                                 GiveTimePtr giveTime)
-{
-    OSErr err = noErr;
-    OSErr finalErr = noErr;
-    StreamPtr tempStream = NULL;
-    Ptr tempConnBuffer = NULL;
-    struct wdsEntry sendWDS[2];
-
-    log_to_file_only("InternalSyncTCPSend: To IP %lu:%u (%d bytes)", (unsigned long)targetIP, targetPort, messageLen);
-
-    // 1. Allocate temporary buffer for the temporary stream
-    tempConnBuffer = NewPtrClear(kTCPSendInternalBufferSize);
-    if (tempConnBuffer == NULL) {
-        log_message("Error (InternalSyncTCPSend): Failed to allocate temporary connection buffer.");
-        return memFullErr;
-    }
-
-    // 2. Create temporary stream
-    err = LowTCPCreateSync(gMacTCPRefNum, &tempStream, tempConnBuffer, kTCPSendInternalBufferSize);
-    if (err != noErr || tempStream == NULL) {
-        log_message("Error (InternalSyncTCPSend): LowTCPCreateSync failed: %d", err);
-        DisposePtr(tempConnBuffer); // Clean up buffer
-        return err;
-    }
-    log_to_file_only("InternalSyncTCPSend: Temp stream 0x%lX created.", (unsigned long)tempStream);
-
-    // 3. Connect using the temporary stream
-    log_to_file_only("InternalSyncTCPSend: Connecting temp stream 0x%lX...", (unsigned long)tempStream);
-    err = LowTCPOpenConnectionSync(tempStream, connectTimeoutTicks, targetIP, targetPort, giveTime);
-    if (err == noErr) {
-        log_to_file_only("InternalSyncTCPSend: Connected successfully.");
-
-        // 4. Send data
-        sendWDS[0].length = messageLen;
-        sendWDS[0].ptr = (Ptr)messageBuffer; // Cast away const, WDS expects Ptr
-        sendWDS[1].length = 0; sendWDS[1].ptr = NULL; // Terminator for WDS array
-
-        log_to_file_only("InternalSyncTCPSend: Sending data...");
-        err = LowTCPSendSync(tempStream, sendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
-        if (err == noErr) {
-            log_to_file_only("InternalSyncTCPSend: Send successful.");
-        } else {
-            log_message("Error (InternalSyncTCPSend): LowTCPSendSync failed: %d", err);
-            finalErr = err; // Record send error
-        }
-
-        // 5. Abort connection (no need for graceful close for one-shot send)
-        log_to_file_only("InternalSyncTCPSend: Aborting connection...");
-        OSErr abortErr = LowTCPAbortSync(tempStream, giveTime);
-        if (abortErr != noErr) {
-            log_message("Warning (InternalSyncTCPSend): LowTCPAbortSync failed: %d", abortErr);
-            if (finalErr == noErr) finalErr = abortErr; // Record abort error if no prior error
-        }
-
-    } else {
-        log_message("Error (InternalSyncTCPSend): LowTCPOpenConnectionSync failed: %d", err);
-        finalErr = err; // Record connect error
-    }
-
-    // 6. Release the temporary stream (regardless of errors)
-    log_to_file_only("InternalSyncTCPSend: Releasing temp stream 0x%lX...", (unsigned long)tempStream);
-    OSErr releaseErr = LowTCPReleaseSync(gMacTCPRefNum, tempStream);
-    if (releaseErr != noErr) {
-        log_message("Warning (InternalSyncTCPSend): LowTCPReleaseSync failed: %d", releaseErr);
-        if (finalErr == noErr) finalErr = releaseErr; // Record release error if no prior error
-    }
-
-    // 7. Dispose the temporary connection buffer
-    DisposePtr(tempConnBuffer);
-
-    log_to_file_only("InternalSyncTCPSend: Finished. Final status: %d", finalErr);
-    return finalErr;
-}
+// LowLevelSyncPoll remains unchanged
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode) { OSErr err; if (pBlock == NULL || giveTime == NULL) return paramErr; pBlock->ioCompletion = nil; pBlock->ioResult = 1; pBlock->csCode = csCode; err = PBControlAsync((ParmBlkPtr)pBlock); if (err != noErr) { log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err); return err; } while (pBlock->ioResult > 0) { giveTime(); } return pBlock->ioResult; }
+// LowTCPCreateSync remains unchanged
+static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen) { OSErr err; TCPiopb pbCreate; if (streamPtr == NULL || connectionBuffer == NULL) return paramErr; memset(&pbCreate, 0, sizeof(TCPiopb)); pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum; pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L; pbCreate.csParam.create.rcvBuff = connectionBuffer; pbCreate.csParam.create.rcvBuffLen = connBufferLen; pbCreate.csParam.create.notifyProc = nil; err = PBControlSync((ParmBlkPtr)&pbCreate); if (err == noErr) { *streamPtr = pbCreate.tcpStream; if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream."); err = ioErr; } } else { *streamPtr = NULL; log_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err); } return err; }
+// LowTCPActiveOpenSyncPoll remains unchanged
+static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.open.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.open.ulpTimeoutAction = AbortTrue; pb.csParam.open.validityFlags = timeoutValue | timeoutAction; pb.csParam.open.commandTimeoutValue = 0; pb.csParam.open.remoteHost = remoteHost; pb.csParam.open.remotePort = remotePort; pb.csParam.open.localPort = 0; pb.csParam.open.localHost = 0; return LowLevelSyncPoll(&pb, giveTime, TCPActiveOpen); }
+// LowTCPSendSyncPoll remains unchanged
+static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (wdsPtr == NULL) return invalidWDS; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.send.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.send.ulpTimeoutAction = AbortTrue; pb.csParam.send.validityFlags = timeoutValue | timeoutAction; pb.csParam.send.pushFlag = push; pb.csParam.send.urgentFlag = false; pb.csParam.send.wdsPtr = wdsPtr; return LowLevelSyncPoll(&pb, giveTime, TCPSend); }
+// LowTCPAbortSyncPoll remains unchanged
+static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) { log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort."); return noErr; } memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPAbort); if (err == connectionDoesntExist || err == invalidStreamPtr) { log_to_file_only("LowTCPAbortSyncPoll: Abort completed (conn not exist/invalid stream). Result: %d", err); err = noErr; } else if (err != noErr) { log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed: %d", err); } else { log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful."); } return err; }
+// LowTCPReleaseSync remains unchanged
+static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr) { OSErr err; TCPiopb pbRelease; if (streamPtr == NULL) return invalidStreamPtr; memset(&pbRelease, 0, sizeof(TCPiopb)); pbRelease.ioCompletion = nil; pbRelease.ioCRefNum = macTCPRefNum; pbRelease.csCode = TCPRelease; pbRelease.tcpStream = streamPtr; err = PBControlSync((ParmBlkPtr)&pbRelease); if (err != noErr && err != invalidStreamPtr) { log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err); } else if (err == invalidStreamPtr) { log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid.", (unsigned long)streamPtr); err = noErr; } return err; }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,11 +1,16 @@
+//====================================
+// FILE: ./classic_mac/tcp.c
+//====================================
+
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
 #include "dialog.h"
 #include "dialog_peerlist.h"
-#include "network.h"
-#include "../shared/messaging_logic.h"
+#include "network.h" // For gMacTCPRefNum, gMyLocalIPStr, gMyUsername, ParseIPv4
+#include "../shared/messaging_logic.h" // For handle_received_tcp_message
+
 #include <Devices.h>
 #include <Errors.h>
 #include <MacTypes.h>
@@ -13,49 +18,107 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <Events.h>
-#include <OSUtils.h>
+#include <Events.h>  // For Delay
+#include <OSUtils.h> // For TickCount if needed, though Delay takes dummy timer
+
+// MacTCP Constants (ensure these are defined or use MacTCP headers if available)
 #define kTCPRecvBufferSize 8192
-#define kTCPInternalBufferSize 8192
-#define kTCPPassiveOpenULPTimeoutSeconds 2
-#define kTCPListenPollTimeoutTicks 5
-#define kTCPRecvPollTimeoutTicks 1
-#define kTCPStatusPollTimeoutTicks 1
-#define kConnectTimeoutTicks 300
-#define kSendTimeoutTicks 180
-#define kAbortTimeoutTicks 60
-#define kQuitLoopDelayTicks 120
-#define kErrorRetryDelayTicks 120
-#define kMacTCPTimeoutErr (-23016)
-#define AbortTrue 1
-static StreamPtr gTCPStream = NULL;
-static Ptr gTCPInternalBuffer = NULL;
-static Ptr gTCPRecvBuffer = NULL;
+#define kTCPInternalBufferSize 8192 // For TCPCreate's rcvBuff
+
+// Timeouts, chosen empirically or from documentation recommendations
+#define kTCPPassiveOpenULPTimeoutSeconds 2 // ULP timeout for passive open (TCP default)
+#define kTCPListenPollTimeoutTicks 150      // How long OUR app polls a single PassiveOpen call
+#define kTCPRecvPollTimeoutTicks 1        // How long OUR app polls a single Rcv Call
+#define kTCPStatusPollTimeoutTicks 1      // How long OUR app polls a single Status call
+
+#define kConnectTimeoutTicks 300    // Approx 5 seconds for ActiveOpen ULP Timeout
+#define kSendTimeoutTicks 180       // Approx 3 seconds for Send ULP Timeout
+#define kAbortTimeoutTicks 60      // Approx 1 second for Abort ULP timeout
+#define kQuitLoopDelayTicks 120    // Approx 2 seconds delay between sending QUIT to peers
+#define kErrorRetryDelayTicks 120   // Approx 2 seconds delay after certain recoverable errors
+
+// MacTCP Error Codes (from MacTCPCommontypes.h or equivalent documentation)
+#define kMacTCPTimeoutErr (-23016)  // commandTimeout
+#define kDuplicateSocketErr (-23017) // duplicateSocket
+#define kConnectionExistsErr (-23007) // connectionExists
+#define kConnectionClosingErr (-23005) // connectionClosing
+#define kConnectionDoesntExistErr (-23008) // connectionDoesntExist
+#define kInvalidStreamPtrErr (-23010) // invalidStreamPtr
+#define kInvalidWDSErr (-23014)       // Use for invalidWDS checks
+#define kInvalidBufPtrErr (-23013)    // Use for invalidBufPtr checks
+#define AbortTrue 1 // For ULP Timeout Action
+
+// --- TCP State Machine and Globals ---
+static StreamPtr gTCPStream = NULL;         // Our single TCP stream
+static Ptr gTCPInternalBuffer = NULL;   // Buffer for TCPCreate (manages connection state)
+static Ptr gTCPRecvBuffer = NULL;       // Our application buffer for TCPRcv
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static Boolean gIsSending = false;
-static ip_addr gPeerIP = 0;
-static tcp_port gPeerPort = 0;
+static Boolean gIsSending = false;          // Simple mutex for send operations
+static ip_addr gPeerIP = 0;             // IP of the currently connected peer (for incoming)
+static tcp_port gPeerPort = 0;           // Port of the currently connected peer (for incoming)
+
+// Forward declarations for static helper functions
 static void ProcessTCPReceive(unsigned short dataLength);
-static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode);
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
 static OSErr LowTCPPassiveOpenSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime);
 static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
-static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
-static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
-static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime);
+static OSErr LowTCPRcvSyncPoll(SInt8 pollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
+static OSErr LowTCPStatusSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
+static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicks, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
-static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) { (void)platform_context; int addResult = AddOrUpdatePeer(ip, username); if (addResult > 0) { log_message("Peer connected/updated via TCP: %s@%s", username, ip); if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } else if (addResult < 0) { log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip); } return addResult; }
-static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) { (void)platform_context; (void)ip; char displayMsg[BUFFER_SIZE + 100]; if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) { sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : ""); AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r"); log_message("Message from %s@%s: %s", username, ip, message_content); } else { log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready."); } }
-static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) { (void)platform_context; if (!ip) return; log_message("Peer %s has sent QUIT notification via TCP.", ip); if (MarkPeerInactive(ip)) { if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } }
+
+
+// --- Platform Callbacks for Shared Messaging Logic ---
+static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
+    (void)platform_context; // Unused
+    int addResult = AddOrUpdatePeer(ip, username);
+    if (addResult > 0) { // New peer added
+        log_message("Peer connected/updated via TCP: %s@%s", username, ip);
+        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
+    } else if (addResult < 0) { // List full or other error
+        log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
+    }
+    return addResult;
+}
+
+static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
+    (void)platform_context; // Unused
+    (void)ip; // IP is available if needed, but username is primary for display
+    char displayMsg[BUFFER_SIZE + 100];
+
+    if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
+        sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
+        AppendToMessagesTE(displayMsg);
+        AppendToMessagesTE("\r"); // Newline for Mac TE
+        log_message("Message from %s@%s: %s", username, ip, message_content);
+    } else {
+        log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
+    }
+}
+
+static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
+    (void)platform_context; // Unused
+    if (!ip) return;
+    log_message("Peer %s has sent QUIT notification via TCP.", ip);
+    if (MarkPeerInactive(ip)) {
+        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
+    }
+}
+
+// --- TCP Initialization and Cleanup ---
 OSErr InitTCP(short macTCPRefNum) {
     OSErr err;
     log_message("Initializing Single TCP Stream (Sync Poll Strategy)...");
+
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
         log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
-        return streamAlreadyOpen;
+        return streamAlreadyOpen; // -23011
     }
+
+    // Allocate buffers
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
@@ -66,215 +129,695 @@ OSErr InitTCP(short macTCPRefNum) {
         return memFullErr;
     }
     log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
+
     log_message("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
         log_message("Error: Failed to create TCP Stream: %d", err);
-        CleanupTCP(macTCPRefNum);
+        CleanupTCP(macTCPRefNum); // Cleanup partial allocations
         return err;
     }
     log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
+
     gTCPState = TCP_STATE_IDLE;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
     log_message("TCP initialization complete. State: IDLE.");
     return noErr;
 }
+
 void CleanupTCP(short macTCPRefNum) {
     log_message("Cleaning up Single TCP Stream (Sync Poll Strategy)...");
-    StreamPtr streamToRelease = gTCPStream;
+    StreamPtr streamToRelease = gTCPStream; // Cache before modifying globals
     TCPState stateBeforeCleanup = gTCPState;
-    gTCPStream = NULL;
-    gTCPState = TCP_STATE_RELEASING;
-    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN) {
+
+    // Tentatively set state to prevent re-entry or further operations
+    gTCPState = TCP_STATE_RELEASING; 
+    gTCPStream = NULL; // Mark stream as unusable *before* trying to release
+
+    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_LISTENING_POLL) {
          log_message("Cleanup: Attempting synchronous abort (best effort)...");
          if (streamToRelease != NULL) {
-             StreamPtr currentGlobalStream = gTCPStream;
-             gTCPStream = streamToRelease;
-             LowTCPAbortSyncPoll(YieldTimeToSystem);
-             gTCPStream = currentGlobalStream;
+             // Temporarily restore gTCPStream for LowTCPAbortSyncPoll
+             StreamPtr currentGlobalStream = gTCPStream; 
+             gTCPStream = streamToRelease; 
+             LowTCPAbortSyncPoll(kAbortTimeoutTicks, YieldTimeToSystem);
+             gTCPStream = currentGlobalStream; // Restore (now NULL)
          }
     }
+
     if (streamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
         OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
         if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr);
         else log_to_file_only("Sync release successful.");
     } else if (streamToRelease != NULL) {
-        log_message("Warning: Cannot release stream, MacTCP refnum is 0.");
+        log_message("Warning: Cannot release stream, MacTCP refnum is 0 or stream already NULLed.");
     }
+
+    // Final state and resource cleanup
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
+
     if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; }
     if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; }
     log_message("TCP cleanup finished.");
 }
+
+
+// --- Main TCP Polling Logic ---
 void PollTCP(GiveTimePtr giveTime) {
     OSErr err;
     unsigned short amountUnread = 0;
-    Byte connectionState = 0;
-    unsigned long dummyTimer;
+    Byte connectionState = 0; // MacTCP connection state (0=closed, 2=listen, 8=established, etc.)
+    unsigned long dummyTimer; // For Delay()
+
     if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
-        return;
+        return; // Not in a pollable state
     }
-    if (gIsSending) { return; }
+    if (gIsSending) { return; } // Don't interfere with an active send operation
+
     switch (gTCPState) {
         case TCP_STATE_IDLE:
             log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll (ULP: %ds, AppPoll: %d ticks)...", kTCPPassiveOpenULPTimeoutSeconds, kTCPListenPollTimeoutTicks);
             err = LowTCPPassiveOpenSyncPoll(kTCPListenPollTimeoutTicks, giveTime);
             if (err == noErr) {
-                char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr);
+                char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr); // gPeerIP set by LowTCPPassiveOpenSyncPoll
                 log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
                 gTCPState = TCP_STATE_CONNECTED_IN;
-                goto CheckConnectedInData;
-            } else if (err == commandTimeout) {
+                goto CheckConnectedInData; // Immediately check this new connection for data
+            } else if (err == commandTimeout) { // -23016
                 log_to_file_only("PollTCP: Passive Open Poll window (%d ticks) timed out. No connection. Returning to IDLE.", kTCPListenPollTimeoutTicks);
-                gTCPState = TCP_STATE_IDLE;
-            } else {
-                log_message("PollTCP: Passive Open Poll failed: %d. Returning to IDLE.", err);
-                gTCPState = TCP_STATE_IDLE;
-                if (err == duplicateSocket || err == connectionExists) {
-                     log_message("PollTCP: Delaying %d ticks due to error %d.", kErrorRetryDelayTicks, err);
-                     Delay(kErrorRetryDelayTicks, &dummyTimer);
+                gTCPState = TCP_STATE_IDLE; // Remain idle
+            } else if (err == kDuplicateSocketErr || err == kConnectionExistsErr) { // -23017 or -23007
+                log_message("PollTCP: Passive Open Poll failed with %d. Attempting to Abort stream to reset.", err);
+                // ** NEW LOGIC FOR Issue 2 **
+                // Abort the stream to clear the problematic state before trying passive open again.
+                OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                if (abortErr == noErr) {
+                    log_message("PollTCP: Abort successful after Passive Open failure. Will retry passive open.");
+                } else {
+                    log_message("PollTCP: CRITICAL - Abort FAILED (%d) after Passive Open failure. TCP might be stuck.", abortErr);
+                    // Consider moving to TCP_STATE_ERROR if abort repeatedly fails.
                 }
+                gTCPState = TCP_STATE_IDLE; // Remain idle, will retry passive open next cycle
+                log_message("PollTCP: Delaying %d ticks due to error %d before retrying passive open.", kErrorRetryDelayTicks, err);
+                Delay(kErrorRetryDelayTicks, &dummyTimer);
+            } else {
+                log_message("PollTCP: Passive Open Poll failed with other error: %d. Returning to IDLE.", err);
+                gTCPState = TCP_STATE_IDLE; // Remain idle
             }
             break;
+
         case TCP_STATE_CONNECTED_IN:
-CheckConnectedInData:
+CheckConnectedInData: // Label for goto from successful passive open
             log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
-            err = LowTCPStatusSyncPoll(giveTime, &amountUnread, &connectionState);
+            err = LowTCPStatusSyncPoll(kTCPStatusPollTimeoutTicks, giveTime, &amountUnread, &connectionState);
             if (err != noErr) {
                 log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
-                LowTCPAbortSyncPoll(giveTime);
-                gTCPState = TCP_STATE_IDLE;
+                LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Attempt to clean up
+                gTCPState = TCP_STATE_IDLE; // Reset state machine
                 break;
             }
+
+            // MacTCP States: 8 (Established), 10 (FIN_WAIT_1), 12 (FIN_WAIT_2), 14 (CLOSE_WAIT)
+            // We are interested if it's NOT one of these active/closing states.
             if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
                  char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                  log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Assuming closed/aborted. Returning to IDLE.", connectionState, peerIPStr);
-                 gTCPState = TCP_STATE_IDLE;
+                 gTCPState = TCP_STATE_IDLE; // Connection is no longer valid
                  break;
             }
+            
             log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
             if (amountUnread > 0) {
-                unsigned short bytesToRead = kTCPRecvBufferSize;
+                unsigned short bytesToRead = kTCPRecvBufferSize; // Max to read in one go
                 Boolean markFlag = false, urgentFlag = false;
                 log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
                 err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
+                
                 if (err == noErr) {
                     log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                     ProcessTCPReceive(bytesToRead);
-                } else if (err == connectionClosing) {
+                    // Remain in TCP_STATE_CONNECTED_IN to check for more data or state changes
+                } else if (err == kConnectionClosingErr) { // -23005 "all data on this connection has already been delivered"
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
-                    ProcessTCPReceive(bytesToRead);
-                    gTCPState = TCP_STATE_IDLE;
-                } else if (err == commandTimeout) {
-                     log_to_file_only("PollTCP: Rcv poll timed out despite status showing data?");
-                } else {
+                    if (bytesToRead > 0) ProcessTCPReceive(bytesToRead); // Process any last bytes
+                    gTCPState = TCP_STATE_IDLE; // Connection is gracefully closing from peer end
+                } else if (err == commandTimeout) { // -23016
+                     log_to_file_only("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
+                     // Remain in TCP_STATE_CONNECTED_IN
+                } else { // Other errors
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
-                    LowTCPAbortSyncPoll(giveTime);
-                    gTCPState = TCP_STATE_IDLE;
+                    LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Attempt to clean up
+                    gTCPState = TCP_STATE_IDLE; // Reset state machine
                 }
-            } else {
-                 if (connectionState == 14 ) {
+            } else { // No unread data
+                 if (connectionState == 14 ) { // CLOSE_WAIT: peer has closed, waiting for us to close
                      char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                      log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Returning to IDLE.", peerIPStr);
+                     // MacTCP should transition out of this, or we might need to TCPClose then TCPAbort if it lingers.
+                     // For now, returning to IDLE will attempt a Passive Open, which might clear this state
+                     // or we might need a TCPClose here.
+                     // Let's try aborting our end to fully close it.
+                     LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
                      gTCPState = TCP_STATE_IDLE;
                  }
+                 // If state is 8, 10, 12 and no data, just continue polling status.
             }
             break;
+
+        // Other states (LISTENING_POLL, ERROR, RELEASING, UNINITIALIZED) are handled by the initial checks or not directly polled here.
         default:
             log_message("PollTCP: In unexpected state %d.", gTCPState);
-            gTCPState = TCP_STATE_IDLE;
+            gTCPState = TCP_STATE_IDLE; // Attempt to recover
             break;
     }
 }
+
 TCPState GetTCPState(void) { return gTCPState; }
-OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
-    OSErr err = noErr, finalErr = noErr; ip_addr targetIP = 0; char messageBuffer[BUFFER_SIZE]; int formattedLen; struct wdsEntry sendWDS[2];
-    log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIP);
-    if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
-    if (gIsSending) { log_message("Warning (SendText): Send already in progress."); return streamBusyErr; }
-    if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
-    gIsSending = true;
-    err = ParseIPv4(peerIP, &targetIP); if (err != noErr || targetIP == 0) { finalErr = paramErr; goto SendTextCleanup; }
-    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message); if (formattedLen <= 0) { finalErr = paramErr; goto SendTextCleanup; }
-    log_to_file_only("SendText: Connecting..."); err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
+
+// --- TCP Send Operations ---
+OSErr TCP_SendTextMessageSync(const char *peerIPStr, const char *message, GiveTimePtr giveTime) {
+    OSErr err = noErr, finalErr = noErr;
+    ip_addr targetIP = 0;
+    char messageBuffer[BUFFER_SIZE];
+    int formattedLen;
+    struct wdsEntry sendWDS[2]; // Simple WDS: one buffer for message, one terminator
+
+    log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIPStr);
+
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (peerIPStr == NULL || message == NULL || giveTime == NULL) return paramErr;
+
+    if (gIsSending) { 
+        log_message("Warning (SendText): Send already in progress."); 
+        return streamBusyErr; // Or a specific "busy" error
+    }
+    if (gTCPState != TCP_STATE_IDLE) { 
+        log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState); 
+        return streamBusyErr; // Or a specific "state" error
+    }
+
+    gIsSending = true; // Acquire "lock"
+
+    err = ParseIPv4(peerIPStr, &targetIP);
+    if (err != noErr || targetIP == 0) {
+        log_message("Error (SendText): Invalid peer IP '%s'.", peerIPStr);
+        finalErr = paramErr;
+        goto SendTextCleanup;
+    }
+
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message);
+    if (formattedLen <= 0) {
+        log_message("Error (SendText): format_message failed.");
+        finalErr = paramErr; // Or a specific formatting error
+        goto SendTextCleanup;
+    }
+
+    log_to_file_only("SendText: Connecting to %s...", peerIPStr);
+    err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
-        log_to_file_only("SendText: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
-        log_to_file_only("SendText: Sending data..."); err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
-        if (err != noErr) { log_message("Error (SendText): Send failed: %d", err); finalErr = err; } else { log_to_file_only("SendText: Send successful."); }
-        log_to_file_only("SendText: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
-        if (abortErr != noErr) { log_message("Warning (SendText): Abort failed: %d", abortErr); if (finalErr == noErr) finalErr = abortErr; }
-    } else { log_message("Error (SendText): Connect failed: %d", err); finalErr = err; }
-SendTextCleanup: gIsSending = false; log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr); return finalErr;
+        log_to_file_only("SendText: Connected successfully to %s.", peerIPStr);
+        sendWDS[0].length = formattedLen; // MacTCP expects length of data, not including null terminator for strings
+        sendWDS[0].ptr = (Ptr)messageBuffer;
+        sendWDS[1].length = 0; // Terminator for WDS
+        sendWDS[1].ptr = NULL;
+
+        log_to_file_only("SendText: Sending data (%d bytes)...", formattedLen);
+        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true /*pushFlag*/, (Ptr)sendWDS, giveTime);
+        if (err != noErr) {
+            log_message("Error (SendText): Send failed to %s: %d", peerIPStr, err);
+            finalErr = err;
+        } else {
+            log_to_file_only("SendText: Send successful to %s.", peerIPStr);
+        }
+
+        // Always abort after send for this simple client model
+        log_to_file_only("SendText: Aborting connection to %s...", peerIPStr);
+        OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime); // Use specific abort timeout
+        if (abortErr != noErr) {
+            log_message("Warning (SendText): Abort failed for %s: %d", peerIPStr, abortErr);
+            if (finalErr == noErr) finalErr = abortErr; // Report abort error if send was okay
+        }
+    } else {
+        log_message("Error (SendText): Connect to %s failed: %d", peerIPStr, err);
+        finalErr = err; // Store the connect error
+    }
+
+SendTextCleanup:
+    gIsSending = false; // Release "lock"
+    gTCPState = TCP_STATE_IDLE; // Ensure state is reset to IDLE after send attempt
+    log_to_file_only("TCP_SendTextMessageSync to %s: Released send lock. Final Status: %d.", peerIPStr, finalErr);
+    return finalErr;
 }
+
+
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
-    int i; OSErr lastErr = noErr, currentErr = noErr; char quitMessageBuffer[BUFFER_SIZE]; int formattedLen, activePeerCount = 0, sentCount = 0; unsigned long dummyTimer; struct wdsEntry sendWDS[2];
+    int i;
+    OSErr lastErr = noErr, currentErr = noErr;
+    char quitMessageBuffer[BUFFER_SIZE];
+    int formattedLen, activePeerCount = 0, sentCount = 0;
+    unsigned long dummyTimer; // For Delay()
+    struct wdsEntry sendWDS[2];
+
     log_message("TCP_SendQuitMessagesSync: Starting...");
-    if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (giveTime == NULL) return paramErr;
-    if (gIsSending) { log_message("Warning (SendQuit): Send already in progress."); return streamBusyErr; }
-    if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendQuit): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
-    gIsSending = true;
-    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, ""); if (formattedLen <= 0) { lastErr = paramErr; goto SendQuitCleanup; }
+
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (giveTime == NULL) return paramErr;
+
+    if (gIsSending) { 
+        log_message("Warning (SendQuit): Send already in progress."); 
+        return streamBusyErr; 
+    }
+    // Check if stream is IDLE. If not, it implies an incoming connection might be active,
+    // which means we shouldn't interfere.
+    if (gTCPState != TCP_STATE_IDLE) {
+        log_message("Warning (SendQuit): Stream not IDLE (state %d). Cannot send QUIT now. Peer might be connecting.", gTCPState);
+        return streamBusyErr;
+    }
+    
+    gIsSending = true; // Acquire "lock"
+
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, "");
+    if (formattedLen <= 0) {
+        log_message("Error (SendQuit): format_message for QUIT failed.");
+        lastErr = paramErr;
+        goto SendQuitCleanup;
+    }
+
     for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
-    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount); if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
+    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
+    if (activePeerCount == 0) {
+        lastErr = noErr; // No peers to notify is not an error
+        goto SendQuitCleanup;
+    }
+
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
-            ip_addr currentTargetIP = 0; currentErr = noErr;
-            if (gTCPState != TCP_STATE_IDLE) { log_message("CRITICAL (SendQuit): State not IDLE (%d) before peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip); lastErr = ioErr; break; }
+            ip_addr currentTargetIP = 0;
+            currentErr = noErr; // Reset for this peer
+
+            // Double check state before each peer, though gIsSending should protect this.
+            if (gTCPState != TCP_STATE_IDLE) { 
+                log_message("CRITICAL (SendQuit): State became non-IDLE (%d) during QUIT loop for peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip);
+                if (lastErr == noErr) lastErr = ioErr; // Indicate a general I/O problem
+                break; 
+            }
+
             log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP); if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip); if (lastErr == noErr) lastErr = currentErr; goto NextPeerDelay; }
+            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
+            if (currentErr != noErr || currentTargetIP == 0) {
+                log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip);
+                if (lastErr == noErr) lastErr = currentErr;
+                goto NextPeerDelay; // Use goto for clarity to reach delay
+            }
+
             log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip);
             currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
-            if (currentErr == connectionExists) {
-                log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
-            } else if (currentErr == noErr) {
-                log_to_file_only("SendQuit: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
-                log_to_file_only("SendQuit: Sending data..."); currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
-                if (currentErr == noErr) { log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip); sentCount++; }
-                else { log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr); if (lastErr == noErr) lastErr = currentErr; }
-                log_to_file_only("SendQuit: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
-                if (abortErr != noErr) { log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr); if (lastErr == noErr) lastErr = abortErr; }
-            } else { log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr); if (lastErr == noErr) lastErr = currentErr; }
+            
+            if (currentErr == noErr) {
+                log_to_file_only("SendQuit: Connected successfully to %s.", gPeerManager.peers[i].ip);
+                sendWDS[0].length = formattedLen;
+                sendWDS[0].ptr = (Ptr)quitMessageBuffer;
+                sendWDS[1].length = 0;
+                sendWDS[1].ptr = NULL;
+
+                log_to_file_only("SendQuit: Sending data to %s...", gPeerManager.peers[i].ip);
+                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true /*pushFlag*/, (Ptr)sendWDS, giveTime);
+                if (currentErr == noErr) {
+                    log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip);
+                    sentCount++;
+                } else {
+                    log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
+                    if (lastErr == noErr) lastErr = currentErr; // Capture first send error
+                }
+                
+                log_to_file_only("SendQuit: Aborting connection to %s...", gPeerManager.peers[i].ip);
+                OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                if (abortErr != noErr) {
+                    log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr);
+                    if (lastErr == noErr) lastErr = abortErr; // Capture first abort error
+                }
+            } else { // ActiveOpen failed
+                log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
+                // **NEW LOGIC FOR Issue 4**
+                if (lastErr == noErr) lastErr = currentErr; // Capture the connect error
+                // Special handling for connectionExists during QUIT send
+                if (currentErr == kConnectionExistsErr) {
+                     log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
+                     // Don't treat this specific error as a failure that prevents other QUITs necessarily,
+                     // but it should be reflected in lastErr if no other "harder" errors occurred.
+                }
+            }
         NextPeerDelay:
             log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
-            giveTime(); Delay(kQuitLoopDelayTicks, &dummyTimer);
+            giveTime(); // Yield first
+            Delay(kQuitLoopDelayTicks, &dummyTimer); // Then delay
         }
     }
-SendQuitCleanup: log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr); gIsSending = false; return lastErr;
+
+SendQuitCleanup:
+    gIsSending = false; // Release "lock"
+    gTCPState = TCP_STATE_IDLE; // Ensure stream is IDLE after attempts
+    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
+    return lastErr;
 }
-static void ProcessTCPReceive(unsigned short dataLength) { char senderIPStrFromConnection[INET_ADDRSTRLEN], senderIPStrFromPayload[INET_ADDRSTRLEN]; char senderUsername[32], msgType[32], content[BUFFER_SIZE]; static tcp_platform_callbacks_t mac_callbacks = { .add_or_update_peer = mac_tcp_add_or_update_peer, .display_text_message = mac_tcp_display_text_message, .mark_peer_inactive = mac_tcp_mark_peer_inactive }; if (dataLength > 0 && gTCPRecvBuffer != NULL) { OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection); if (addrErr != noErr) sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF); if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0'; else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) { log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection); handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL); if (strcmp(msgType, MSG_QUIT) == 0) log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection); } else log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength); } else if (dataLength == 0) log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal)."); else log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL?"); }
-static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode) { OSErr err; if (pBlock == NULL || giveTime == NULL) return paramErr; pBlock->ioCompletion = nil; pBlock->ioResult = 1; pBlock->csCode = csCode; err = PBControlAsync((ParmBlkPtr)pBlock); if (err != noErr) { log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err); return err; } while (pBlock->ioResult > 0) { giveTime(); } return pBlock->ioResult; }
-static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen) { OSErr err; TCPiopb pbCreate; if (streamPtr == NULL || connectionBuffer == NULL) return paramErr; memset(&pbCreate, 0, sizeof(TCPiopb)); pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum; pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L; pbCreate.csParam.create.rcvBuff = connectionBuffer; pbCreate.csParam.create.rcvBuffLen = connBufferLen; pbCreate.csParam.create.notifyProc = nil; err = PBControlSync((ParmBlkPtr)&pbCreate); if (err == noErr) { *streamPtr = pbCreate.tcpStream; if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream."); err = ioErr; } } else { *streamPtr = NULL; log_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err); } return err; }
-static OSErr LowTCPPassiveOpenSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime) {
+
+
+// --- TCP Data Processing and Low-Level Wrappers ---
+
+static void ProcessTCPReceive(unsigned short dataLength) {
+    char senderIPStrFromConnection[INET_ADDRSTRLEN];
+    char senderIPStrFromPayload[INET_ADDRSTRLEN]; // Parsed from message
+    char senderUsername[32];
+    char msgType[32];
+    char content[BUFFER_SIZE];
+
+    // Static struct for callbacks, initialized once
+    static tcp_platform_callbacks_t mac_callbacks = {
+        .add_or_update_peer = mac_tcp_add_or_update_peer,
+        .display_text_message = mac_tcp_display_text_message,
+        .mark_peer_inactive = mac_tcp_mark_peer_inactive
+    };
+
+    if (dataLength > 0 && gTCPRecvBuffer != NULL) {
+        // Get sender's IP from the connection parameters (gPeerIP is set by PassiveOpen)
+        OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
+        if (addrErr != noErr) { // Fallback if AddrToStr fails
+            sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
+            log_to_file_only("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
+        }
+
+        // Ensure received data is null-terminated for string operations (parse_message)
+        // This is safe because gTCPRecvBuffer is kTCPRecvBufferSize.
+        if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0';
+        else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; // Max case
+
+        if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
+            log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
+                             msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
+            // Use senderIPStrFromConnection (actual source IP of TCP segment) for identification
+            handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL);
+
+            if (strcmp(msgType, MSG_QUIT) == 0) {
+                log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
+                // The PollTCP state machine will see the connection state change (e.g. to CLOSE_WAIT)
+                // and should transition to IDLE.
+            }
+        } else {
+            log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
+        }
+    } else if (dataLength == 0) {
+        log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal or KeepAlive).");
+    } else { // Should not happen if dataLength > 0
+        log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
+    }
+}
+
+
+// LowLevelSyncPoll: Generic wrapper for making asynchronous MacTCP calls
+// and polling them to completion synchronously.
+// Takes a 'pollTimeoutTicks' for how long *this wrapper* will poll, not the ULP timeout.
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks) {
     OSErr err;
-    TCPiopb pb;
-    if (gTCPStream == NULL) return invalidStreamPtr;
-    memset(&pb, 0, sizeof(TCPiopb));
-    pb.ioCRefNum = gMacTCPRefNum;
-    pb.tcpStream = gTCPStream;
-    pb.csParam.open.commandTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
-    pb.csParam.open.validityFlags = timeoutValue;
-    pb.csParam.open.localPort = PORT_TCP;
-    pb.csParam.open.localHost = 0L;
-    pb.csParam.open.remoteHost = 0L;
-    pb.csParam.open.remotePort = 0;
-    err = LowLevelSyncPoll(&pb, giveTime, TCPPassiveOpen);
+    unsigned long startTime = TickCount();
+
+    if (pBlock == NULL || giveTime == NULL) return paramErr;
+
+    pBlock->ioCompletion = nil; // Synchronous polling
+    pBlock->ioCRefNum = gMacTCPRefNum; // Ensure this is always set
+    pBlock->tcpStream = gTCPStream;   // Ensure this is always set for stream operations
+    pBlock->ioResult = 1;       // Must be > 0 for async calls (InProgress equivalent for MacTCP)
+    pBlock->csCode = csCode;    // The specific TCP command
+
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
+        return err;
+    }
+
+    // Poll for completion or app-defined timeout
+    // Note: appPollTimeoutTicks = 0 means poll indefinitely until ioResult changes
+    while (pBlock->ioResult > 0) { 
+        giveTime(); // Critical to allow MacTCP to process
+        if (appPollTimeoutTicks > 0 && (TickCount() - startTime) >= (unsigned long)appPollTimeoutTicks) {
+            // Application-level polling timeout detected.
+            // This is NOT a MacTCP ULP timeout. It means OUR polling loop timed out.
+            // We need to tell MacTCP to cancel THIS specific operation if possible, or just return a timeout.
+            // For many calls like Open/Send/Rcv, MacTCP has its own ULP timeout.
+            // This wrapper's timeout is more of a fallback for calls that might not have one
+            // or if we want to limit how long *we* wait for MacTCP's own timeout.
+            log_to_file_only("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
+            // It's tricky to "cancel" a pending PBControlAsync without aborting the whole stream.
+            // For now, we assume MacTCP's internal ULP timeouts are the primary mechanism.
+            // This timeout here mostly protects OUR main loop from getting stuck if ioResult somehow
+            // never changes from 1 for a call that should eventually complete or error out.
+            // Let's return a generic timeout, MacTCP's ioResult might still be 1.
+            // In practice, for TCP calls, MacTCP's ULP timeouts (set in csParams) should trigger first.
+            return commandTimeout; // Indicate OUR polling loop timed out.
+        }
+    }
+    return pBlock->ioResult; // Return MacTCP's final result code
+}
+
+
+static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr rcvBuff, unsigned long rcvBuffLen) {
+    OSErr err;
+    TCPiopb pbCreate;
+
+    if (streamPtrOut == NULL || rcvBuff == NULL) return paramErr;
+
+    memset(&pbCreate, 0, sizeof(TCPiopb));
+    pbCreate.ioCompletion = nil; // Synchronous
+    pbCreate.ioCRefNum = macTCPRefNum;
+    pbCreate.csCode = TCPCreate;
+    pbCreate.tcpStream = 0L; // Output from MacTCP
+
+    pbCreate.csParam.create.rcvBuff = rcvBuff;
+    pbCreate.csParam.create.rcvBuffLen = rcvBuffLen; // Typically kTCPInternalBufferSize
+    pbCreate.csParam.create.notifyProc = nil; // No ASR for this simple client
+
+    err = PBControlSync((ParmBlkPtr)&pbCreate); // TCPCreate is typically fast, direct sync is okay
     if (err == noErr) {
-        gPeerIP = pb.csParam.open.remoteHost;
-        gPeerPort = pb.csParam.open.remotePort;
+        *streamPtrOut = pbCreate.tcpStream;
+        if (*streamPtrOut == NULL) {
+            log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
+            err = ioErr; // General I/O error
+        }
     } else {
-        gPeerIP = 0; gPeerPort = 0;
+        *streamPtrOut = NULL;
+        log_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err);
     }
     return err;
 }
-static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.open.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.open.ulpTimeoutAction = AbortTrue; pb.csParam.open.validityFlags = timeoutValue | timeoutAction; pb.csParam.open.commandTimeoutValue = 0; pb.csParam.open.remoteHost = remoteHost; pb.csParam.open.remotePort = remotePort; pb.csParam.open.localPort = 0; pb.csParam.open.localHost = 0; return LowLevelSyncPoll(&pb, giveTime, TCPActiveOpen); }
-static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (wdsPtr == NULL) return invalidWDS; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.send.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.send.ulpTimeoutAction = AbortTrue; pb.csParam.send.validityFlags = timeoutValue | timeoutAction; pb.csParam.send.pushFlag = push; pb.csParam.send.urgentFlag = false; pb.csParam.send.wdsPtr = wdsPtr; return LowLevelSyncPoll(&pb, giveTime, TCPSend); }
-static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) { OSErr err; TCPiopb pb; unsigned short initialBufferLen; if (gTCPStream == NULL) return invalidStreamPtr; if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return invalidBufPtr; if (markFlag == NULL || urgentFlag == NULL) return paramErr; initialBufferLen = *bufferLen; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.receive.commandTimeoutValue = timeoutTicks; pb.csParam.receive.rcvBuff = buffer; pb.csParam.receive.rcvBuffLen = initialBufferLen; err = LowLevelSyncPoll(&pb, giveTime, TCPRcv); *bufferLen = pb.csParam.receive.rcvBuffLen; *markFlag = pb.csParam.receive.markFlag; *urgentFlag = pb.csParam.receive.urgentFlag; return err; }
-static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (amtUnread == NULL || connState == NULL) return paramErr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPStatus); if (err == noErr) { *amtUnread = pb.csParam.status.amtUnreadData; *connState = pb.csParam.status.connectionState; } else { *amtUnread = 0; *connState = 0; log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err); if (err == invalidStreamPtr) err = connectionDoesntExist; } return err; }
-static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) { log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort."); return noErr; } memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPAbort); if (err == connectionDoesntExist || err == invalidStreamPtr) { log_to_file_only("LowTCPAbortSyncPoll: Abort completed (conn not exist/invalid stream). Result: %d", err); err = noErr; } else if (err != noErr) { log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed: %d", err); } else { log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful."); } return err; }
-static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr) { OSErr err; TCPiopb pbRelease; if (streamPtr == NULL) return invalidStreamPtr; memset(&pbRelease, 0, sizeof(TCPiopb)); pbRelease.ioCompletion = nil; pbRelease.ioCRefNum = macTCPRefNum; pbRelease.csCode = TCPRelease; pbRelease.tcpStream = streamPtr; err = PBControlSync((ParmBlkPtr)&pbRelease); if (err != noErr && err != invalidStreamPtr) { log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err); } else if (err == invalidStreamPtr) { log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid.", (unsigned long)streamPtr); err = noErr; } return err; }
+
+// Listens for an incoming connection. Sets gPeerIP and gPeerPort on success.
+static OSErr LowTCPPassiveOpenSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime) {
+    OSErr err;
+    TCPiopb pbOpen;
+
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+
+    memset(&pbOpen, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+    
+    // ULP Timeout for the connection attempt itself (after first SYN)
+    pbOpen.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds; 
+    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue; // Abort if ULP timeout expires
+    // Command timeout for THIS PBControl call (waiting for initial SYN)
+    // MacTCP PassiveOpen uses commandTimeoutValue field for the "no SYN received" timeout.
+    // The docs for TCPPassiveOpen (page 41) say:
+    // "command timeout in seconds; 0 = infinity" -> This is pbOpen.csParam.open.commandTimeoutValue (offset 35)
+    // Let's make this explicit for MacTCP's internal timer.
+    pbOpen.csParam.open.commandTimeoutValue = 2; // Wait 2 seconds for an incoming SYN
+
+    pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction; // Indicate ULP timeout fields are valid
+
+    pbOpen.csParam.open.localPort = PORT_TCP; // Listen on our standard TCP port
+    pbOpen.csParam.open.localHost = 0L;       // Listen on all local interfaces (gMyLocalIP)
+    pbOpen.csParam.open.remoteHost = 0L;      // Accept from any remote host
+    pbOpen.csParam.open.remotePort = 0;       // Accept from any remote port
+    
+    // IP options (TOS, precedence, etc.) - use defaults
+    pbOpen.csParam.open.tosFlags = 0;    // Routine
+    pbOpen.csParam.open.precedence = 0;  // Routine
+    pbOpen.csParam.open.dontFrag = false;
+    pbOpen.csParam.open.timeToLive = 0;  // Default (usually 60-64)
+    pbOpen.csParam.open.security = 0;
+    pbOpen.csParam.open.optionCnt = 0;
+    // pbOpen.csParam.open.options would go here if optionCnt > 0
+
+    err = LowLevelSyncPoll(&pbOpen, giveTime, TCPPassiveOpen, appPollTimeoutTicks);
+    if (err == noErr) {
+        gPeerIP = pbOpen.csParam.open.remoteHost;   // Capture peer's IP
+        gPeerPort = pbOpen.csParam.open.remotePort; // Capture peer's port
+    } else {
+        gPeerIP = 0; gPeerPort = 0; // Clear if open failed
+    }
+    return err;
+}
+
+static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicksForCall, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
+    TCPiopb pbOpen;
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+
+    memset(&pbOpen, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+
+    pbOpen.csParam.open.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60); // Convert ticks to seconds for ULP timeout
+    if (pbOpen.csParam.open.ulpTimeoutValue == 0) pbOpen.csParam.open.ulpTimeoutValue = 1; // Minimum 1 second ULP
+    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
+    pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
+    
+    pbOpen.csParam.open.commandTimeoutValue = 0; // Not used for ActiveOpen ULP timeout handles it
+
+    pbOpen.csParam.open.remoteHost = remoteHost;
+    pbOpen.csParam.open.remotePort = remotePort;
+    pbOpen.csParam.open.localPort = 0;  // Ephemeral local port
+    pbOpen.csParam.open.localHost = 0L; // OS chooses local IP
+
+    // Default IP options
+    pbOpen.csParam.open.tosFlags = 0;
+    pbOpen.csParam.open.precedence = 0;
+    pbOpen.csParam.open.dontFrag = false;
+    pbOpen.csParam.open.timeToLive = 0; // Default
+    pbOpen.csParam.open.security = 0;
+    pbOpen.csParam.open.optionCnt = 0;
+
+    // The LowLevelSyncPoll's appPollTimeoutTicks should be longer than ULP timeout for this active open.
+    // Let ULP timeout be primary. Poll for slightly longer than ULP.
+    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60; // Poll for ULP + 1 second cushion
+
+    return LowLevelSyncPoll(&pbOpen, giveTime, TCPActiveOpen, appPollTimeout);
+}
+
+static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicksForCall, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) {
+    TCPiopb pbSend;
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (wdsPtr == NULL) return kInvalidWDSErr; 
+
+    memset(&pbSend, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+    
+    pbSend.csParam.send.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60); // Convert ULP timeout to seconds
+    if (pbSend.csParam.send.ulpTimeoutValue == 0) pbSend.csParam.send.ulpTimeoutValue = 1; // Min 1 sec
+    pbSend.csParam.send.ulpTimeoutAction = AbortTrue;
+    pbSend.csParam.send.validityFlags = timeoutValue | timeoutAction;
+    
+    pbSend.csParam.send.pushFlag = push;
+    pbSend.csParam.send.urgentFlag = false; // Not using urgent data
+    pbSend.csParam.send.wdsPtr = wdsPtr;
+    // sendLength and sendFree are output params from TCPSend, not input.
+
+    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60; // Poll for ULP + 1 second cushion
+    return LowLevelSyncPoll(&pbSend, giveTime, TCPSend, appPollTimeout);
+}
+
+static OSErr LowTCPRcvSyncPoll(SInt8 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) {
+    OSErr err;
+    TCPiopb pbRcv;
+    unsigned short initialBufferLen;
+
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return kInvalidBufPtrErr;
+    if (markFlag == NULL || urgentFlag == NULL) return paramErr;
+
+    initialBufferLen = *bufferLen; // Save original buffer length
+    memset(&pbRcv, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+
+    // commandTimeoutValue for TCPRcv is how long TCP waits for data before completing the call.
+    // 0 = infinite. We use our appPollTimeoutTicks in the wrapper.
+    // Let's set a short MacTCP command timeout, and let our wrapper control overall poll.
+    pbRcv.csParam.receive.commandTimeoutValue = 1; // 1 second MacTCP command timeout for data arrival
+    pbRcv.csParam.receive.rcvBuff = buffer;
+    pbRcv.csParam.receive.rcvBuffLen = initialBufferLen;
+    
+    err = LowLevelSyncPoll(&pbRcv, giveTime, TCPRcv, appPollTimeoutTicks);
+    
+    *bufferLen = pbRcv.csParam.receive.rcvBuffLen; // Actual bytes received
+    *markFlag = pbRcv.csParam.receive.markFlag;
+    *urgentFlag = pbRcv.csParam.receive.urgentFlag;
+    return err;
+}
+
+static OSErr LowTCPStatusSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) {
+    OSErr err;
+    TCPiopb pbStat;
+
+    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (amtUnread == NULL || connState == NULL) return paramErr;
+
+    memset(&pbStat, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+    
+    err = LowLevelSyncPoll(&pbStat, giveTime, TCPStatus, appPollTimeoutTicks);
+    if (err == noErr) {
+        *amtUnread = pbStat.csParam.status.amtUnreadData;
+        *connState = pbStat.csParam.status.connectionState;
+    } else {
+        *amtUnread = 0;
+        *connState = 0; // Indicate unknown/closed state on error
+        log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
+        // If status fails with invalid stream, the connection is effectively gone.
+        if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr; // Map to more logical error for caller
+    }
+    return err;
+}
+
+static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicksForAbort, GiveTimePtr giveTime) {
+    OSErr err;
+    TCPiopb pbAbort;
+
+    if (gTCPStream == NULL) {
+        log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
+        return noErr; // Or invalidStreamPtr, but for reset purposes, noErr if already gone is fine.
+    }
+    
+    memset(&pbAbort, 0, sizeof(TCPiopb));
+    // ioCRefNum and tcpStream will be set by LowLevelSyncPoll
+    // Abort does not strictly use ULP timeout in csParams, but we poll for completion.
+    // The ulpTimeoutTicksForAbort is for our polling loop.
+    
+    err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, ulpTimeoutTicksForAbort);
+    
+    // **MODIFIED LOGIC** Treat "already gone" errors as a successful abort for state reset.
+    if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr) { // -23008 or -23010
+        log_to_file_only("LowTCPAbortSyncPoll: Abort completed (connection doesn't exist or stream invalid). Result: %d. Considered OK for reset.", err);
+        err = noErr; // THIS IS THE KEY CHANGE: Map these to success for our state machine
+    } else if (err != noErr) {
+        log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
+    } else {
+        log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful.");
+    }
+    return err;
+}
+
+static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease) {
+    OSErr err;
+    TCPiopb pbRelease;
+
+    if (streamToRelease == NULL) return kInvalidStreamPtrErr;
+
+    memset(&pbRelease, 0, sizeof(TCPiopb));
+    pbRelease.ioCompletion = nil; // Synchronous
+    pbRelease.ioCRefNum = macTCPRefNum;
+    pbRelease.csCode = TCPRelease;
+    pbRelease.tcpStream = streamToRelease; // Specify the stream to release
+
+    err = PBControlSync((ParmBlkPtr)&pbRelease);
+    // If stream is already invalid, MacTCP might return invalidStreamPtr. This is not a disaster.
+    if (err != noErr && err != kInvalidStreamPtrErr) {
+        log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
+    } else if (err == kInvalidStreamPtrErr) {
+        log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
+        err = noErr; // Treat as success for cleanup purposes
+    }
+    return err;
+}

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,179 +1,212 @@
+//====================================
+// FILE: ./classic_mac/tcp.c
+//====================================
+
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
-#include "dialog.h"
+#include "dialog.h" // For updating UI if needed
 #include "dialog_peerlist.h"
-#include "network.h"
+#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem
 #include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
-#include <Memory.h>
-#include <string.h>
-#include <stdio.h>
-#define kTCPRecvBufferSize 8192
-#define kTCPListenInternalBufferSize 8192
-#define kTCPListenRetryDelayTicks 60
-#define AbortTrue 1
-static StreamPtr gTCPListenStream = NULL;
-static Ptr gTCPListenInternalBuffer = NULL;
-static Ptr gTCPRecvBuffer = NULL;
-static TCPiopb gTCPListenPB;
-static TCPiopb gTCPRecvPB;
-static TCPiopb gTCPClosePB;
-static TCPiopb gTCPReleasePB;
-static Boolean gTCPListenPending = false;
-static Boolean gTCPRecvPending = false;
-static Boolean gTCPClosePending = false;
-static Boolean gTCPReleasePending = false;
-static StreamPtr gStreamBeingReleased = NULL;
-static Boolean gNeedToReListen = false;
-ip_addr gCurrentConnectionIP = 0;
-tcp_port gCurrentConnectionPort = 0;
-Boolean gIsConnectionActive = false;
+#include <Memory.h> // For NewPtrClear, DisposePtr
+#include <string.h> // For memset, strcmp
+#include <stdio.h>  // For sprintf
+#include <stdlib.h> // For size_t if needed
+
+// --- Constants ---
+#define kTCPRecvBufferSize 8192           // Buffer for receiving data on the listener stream
+#define kTCPListenInternalBufferSize 8192 // Internal buffer needed by MacTCP for the listener stream
+#define kTCPSenderInternalBufferSize 2048 // Smaller internal buffer for temporary sender streams
+#define kTCPListenRetryDelayTicks 60      // Delay before retrying listen after certain errors
+#define kShutdownConnectTimeoutTicks 180  // Timeout for connecting when sending QUIT (3 sec)
+#define kShutdownSendTimeoutTicks 120     // Timeout for sending QUIT data (2 sec)
+#define kRuntimeConnectTimeoutTicks 300   // Timeout for connecting when sending TEXT (5 sec)
+#define kRuntimeSendTimeoutTicks 180      // Timeout for sending TEXT data (3 sec)
+#define AbortTrue 1                       // ULP Timeout Action: Abort connection
+
+// --- Listener Stream Globals ---
+static StreamPtr gTCPListenStream = NULL;         // The persistent stream for listening
+static Ptr gTCPListenInternalBuffer = NULL; // MacTCP's internal buffer for the listener
+static Ptr gTCPRecvBuffer = NULL;           // Our buffer for received data on the listener
+static TCPiopb gTCPListenPB;                // PB for TCPPassiveOpen (listen)
+static TCPiopb gTCPRecvPB;                  // PB for TCPRcv (receive data)
+static TCPiopb gTCPClosePB;                 // PB for TCPClose (close accepted connection)
+
+// --- Listener State ---
+static Boolean gTCPListenPending = false;   // Is TCPPassiveOpen pending?
+static Boolean gTCPRecvPending = false;     // Is TCPRcv pending?
+static Boolean gTCPClosePending = false;    // Is TCPClose pending?
+static Boolean gNeedToReListen = false;     // Flag to re-issue listen after connection ends/fails
+ip_addr gCurrentConnectionIP = 0;           // IP of peer connected to listener stream
+tcp_port gCurrentConnectionPort = 0;       // Port of peer connected to listener stream
+Boolean gIsConnectionActive = false;        // Is listener stream currently handling an active connection?
+
+// --- Forward Declarations ---
 static OSErr StartAsyncTCPListen(short macTCPRefNum);
 static OSErr StartAsyncTCPRecv(short macTCPRefNum);
-static OSErr StartAsyncTCPClose(short macTCPRefNum, StreamPtr streamToClose, Boolean abortConnection);
-static OSErr StartAsyncTCPRelease(short macTCPRefNum, StreamPtr streamToRelease);
+static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection);
 static void ProcessTCPReceive(short macTCPRefNum);
 static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult);
 static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult);
 static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult);
-static void HandleReleaseCompletion(short macTCPRefNum, OSErr ioResult);
+
+// --- Low-Level Synchronous TCP Helper Functions ---
+static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
+static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, ip_addr *localHost, tcp_port *localPort, GiveTimePtr giveTime);
+static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent, Ptr wdsPtr, GiveTimePtr giveTime);
+static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime);
+static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
+
+// --- Shared Logic Callbacks ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused context
     int addResult = AddOrUpdatePeer(ip, username);
     if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
         if (gMainWindow != NULL && gPeerListHandle != NULL) {
-            UpdatePeerDisplayList(true);
+            UpdatePeerDisplayList(true); // Update UI if a new peer is seen
         }
     } else if (addResult < 0) {
         log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
+
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context;
-    (void)ip;
-    char displayMsg[BUFFER_SIZE + 100];
+    (void)platform_context; // Unused context
+    (void)ip; // IP address is available if needed, but username is primary display info
+    char displayMsg[BUFFER_SIZE + 100]; // Ensure buffer is large enough
+
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
+        // Format message for display
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
-        AppendToMessagesTE("\r");
+        AppendToMessagesTE("\r"); // Add newline
         log_message("Message from %s@%s: %s", username, ip, message_content);
     } else {
+        // Log if UI isn't ready
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
+
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused context
     if (!ip) return;
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
+        // Update UI if peer is successfully marked inactive
         if (gMainWindow != NULL && gPeerListHandle != NULL) {
             UpdatePeerDisplayList(true);
         }
     }
 }
+
+// --- Public Functions ---
+
 OSErr InitTCPListener(short macTCPRefNum) {
     OSErr err;
-    TCPiopb pbCreate;
-    log_message("Initializing TCP Listener (Single Stream Approach)...");
+    StreamPtr tempListenStream = NULL;
+
+    log_message("Initializing TCP Listener Stream...");
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPListenStream != NULL) {
         log_message("Error (InitTCPListener): Already initialized?");
-        return streamAlreadyOpen;
+        return streamAlreadyOpen; // Already initialized
     }
+
+    // Allocate buffers
     gTCPListenInternalBuffer = NewPtrClear(kTCPListenInternalBufferSize);
      if (gTCPListenInternalBuffer == NULL) {
         log_message("Fatal Error: Could not allocate TCP listen internal buffer (%ld bytes).", (long)kTCPListenInternalBufferSize);
         return memFullErr;
     }
-    log_message("Allocated %ld bytes for TCP listen internal buffer at 0x%lX.", (long)kTCPListenInternalBufferSize, (unsigned long)gTCPListenInternalBuffer);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
     if (gTCPRecvBuffer == NULL) {
         log_message("Fatal Error: Could not allocate TCP receive buffer (%ld bytes).", (long)kTCPRecvBufferSize);
         DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
         return memFullErr;
     }
-    log_message("Allocated %ld bytes for TCP receive buffer at 0x%lX.", (long)kTCPRecvBufferSize, (unsigned long)gTCPRecvBuffer);
-    memset(&pbCreate, 0, sizeof(TCPiopb));
-    pbCreate.ioCompletion = nil;
-    pbCreate.ioCRefNum = macTCPRefNum;
-    pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L;
-    pbCreate.csParam.create.rcvBuff = gTCPListenInternalBuffer;
-    pbCreate.csParam.create.rcvBuffLen = kTCPListenInternalBufferSize;
-    pbCreate.csParam.create.notifyProc = nil;
-    pbCreate.csParam.create.userDataPtr = nil;
-    log_message("Calling PBControlSync (TCPCreate) for listener stream...");
-    err = PBControlSync((ParmBlkPtr)&pbCreate);
-    if (err != noErr) {
-        log_message("Error (InitTCPListener): TCPCreate failed. Error: %d", err);
-        if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL;
-        if (gTCPListenInternalBuffer) DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
+    log_message("Allocated TCP buffers (ListenInternal: %ld, Recv: %ld).",
+                (long)kTCPListenInternalBufferSize, (long)kTCPRecvBufferSize);
+
+    // Create the persistent listener stream
+    log_message("Creating Listener Stream...");
+    err = LowTCPCreateSync(macTCPRefNum, &tempListenStream, gTCPListenInternalBuffer, kTCPListenInternalBufferSize);
+    if (err != noErr || tempListenStream == NULL) {
+        log_message("Error: Failed to create Listener Stream: %d", err);
+        CleanupTCPListener(macTCPRefNum); // Clean up allocated buffers
         return err;
     }
-    gTCPListenStream = pbCreate.tcpStream;
-    if (gTCPListenStream == NULL) {
-        log_message("Error (InitTCPListener): TCPCreate succeeded but returned NULL stream.");
-        if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL;
-        if (gTCPListenInternalBuffer) DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
-        return ioErr;
-    }
-    log_message("TCP Listener Stream created successfully (StreamPtr: 0x%lX).", (unsigned long)gTCPListenStream);
+    gTCPListenStream = tempListenStream;
+    log_message("Listener Stream created successfully (StreamPtr: 0x%lX).", (unsigned long)gTCPListenStream);
+
+    // Initialize state variables
     gNeedToReListen = false;
     gIsConnectionActive = false;
     gTCPListenPending = false;
     gTCPRecvPending = false;
     gTCPClosePending = false;
-    gTCPReleasePending = false;
-    gStreamBeingReleased = NULL;
+
+    // Start the first asynchronous listen
     err = StartAsyncTCPListen(macTCPRefNum);
-    if (err != noErr && err != 1) {
-         log_message("Error (InitTCPListener): Failed to start initial async TCP listen. Error: %d", err);
+    if (err != noErr && err != 1) { // 1 means already pending (shouldn't happen here)
+         log_message("Error: Failed to start initial async TCP listen: %d. Cleaning up.", err);
          CleanupTCPListener(macTCPRefNum);
          return err;
     }
     log_message("Initial asynchronous TCP listen STARTING on port %d.", PORT_TCP);
     return noErr;
 }
+
 void CleanupTCPListener(short macTCPRefNum) {
     OSErr relErr;
-    TCPiopb pbReleaseSync;
-    log_message("Cleaning up TCP Listener (Single Stream Approach)...");
-    StreamPtr listenStreamToRelease = gTCPListenStream;
-    gTCPListenStream = NULL;
-    if (gTCPListenPending && gTCPListenPB.tcpStream == listenStreamToRelease) PBKillIO((ParmBlkPtr)&gTCPListenPB, false);
-    if (gTCPRecvPending && gTCPRecvPB.tcpStream == listenStreamToRelease) PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
-    if (gTCPClosePending && gTCPClosePB.tcpStream == listenStreamToRelease) PBKillIO((ParmBlkPtr)&gTCPClosePB, false);
-    if (gTCPReleasePending && gTCPReleasePB.tcpStream == listenStreamToRelease) PBKillIO((ParmBlkPtr)&gTCPReleasePB, false);
+    log_message("Cleaning up TCP Listener Stream...");
+
+    StreamPtr listenStreamToRelease = gTCPListenStream; // Capture current stream pointer
+    gTCPListenStream = NULL; // Prevent further use
+
+    // Kill any pending operations on the listener stream
+    if (gTCPListenPending && gTCPListenPB.tcpStream == listenStreamToRelease) {
+        PBKillIO((ParmBlkPtr)&gTCPListenPB, false); // Async kill, ignore error
+        log_to_file_only("CleanupTCPListener: Killed pending Listen IO.");
+    }
+    if (gTCPRecvPending && gTCPRecvPB.tcpStream == listenStreamToRelease) {
+        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
+        log_to_file_only("CleanupTCPListener: Killed pending Receive IO.");
+    }
+    if (gTCPClosePending && gTCPClosePB.tcpStream == listenStreamToRelease) {
+        PBKillIO((ParmBlkPtr)&gTCPClosePB, false);
+        log_to_file_only("CleanupTCPListener: Killed pending Close IO.");
+    }
+
+    // Reset state flags
     gTCPListenPending = false;
     gTCPRecvPending = false;
     gTCPClosePending = false;
-    gTCPReleasePending = false;
     gNeedToReListen = false;
     gIsConnectionActive = false;
-    gStreamBeingReleased = NULL;
     gCurrentConnectionIP = 0;
     gCurrentConnectionPort = 0;
+
+    // Release the stream synchronously if it exists and driver is open
     if (listenStreamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting synchronous release of listener stream 0x%lX...", (unsigned long)listenStreamToRelease);
-        memset(&pbReleaseSync, 0, sizeof(TCPiopb));
-        pbReleaseSync.ioCompletion = nil;
-        pbReleaseSync.ioCRefNum = macTCPRefNum;
-        pbReleaseSync.csCode = TCPRelease;
-        pbReleaseSync.tcpStream = listenStreamToRelease;
-        relErr = PBControlSync((ParmBlkPtr)&pbReleaseSync);
+        relErr = LowTCPReleaseSync(macTCPRefNum, listenStreamToRelease);
         if (relErr != noErr) {
-             log_message("Warning (CleanupTCPListener): Synchronous TCPRelease failed. Error: %d", relErr);
+             // Log warning, but proceed with buffer cleanup
+             log_message("Warning (CleanupTCPListener): Synchronous TCPRelease failed: %d", relErr);
         } else {
              log_to_file_only("CleanupTCPListener: Synchronous TCPRelease successful.");
         }
     } else if (listenStreamToRelease != NULL) {
         log_message("Warning (CleanupTCPListener): Cannot release stream, MacTCP refnum is 0.");
     }
+
+    // Dispose buffers
     if (gTCPRecvBuffer != NULL) {
         log_message("Disposing TCP receive buffer at 0x%lX.", (unsigned long)gTCPRecvBuffer);
         DisposePtr(gTCPRecvBuffer);
@@ -184,299 +217,557 @@ void CleanupTCPListener(short macTCPRefNum) {
         DisposePtr(gTCPListenInternalBuffer);
         gTCPListenInternalBuffer = NULL;
     }
-    log_message("TCP Listener cleanup finished.");
+
+    log_message("TCP Listener Stream cleanup finished.");
 }
+
 void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP) {
     OSErr ioResult;
+
+    // Check for completed Listen operation
     if (gTCPListenPending) {
         ioResult = gTCPListenPB.ioResult;
-        if (ioResult <= 0) {
-            gTCPListenPending = false;
+        if (ioResult <= 0) { // Completed (success or error)
+            gTCPListenPending = false; // Clear flag *before* handling
             HandleListenerCompletion(macTCPRefNum, ioResult);
         }
     }
-    if (gTCPRecvPending) {
+
+    // Check for completed Receive operation (only if connection is active)
+    if (gTCPRecvPending && gIsConnectionActive) {
+        // Defensive check: Ensure the completion is for the correct stream
         if (gTCPRecvPB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
             ioResult = gTCPRecvPB.ioResult;
-            if (ioResult <= 0) {
-                gTCPRecvPending = false;
+            if (ioResult <= 0) { // Completed
+                gTCPRecvPending = false; // Clear flag *before* handling
                 HandleReceiveCompletion(macTCPRefNum, ioResult);
             }
         } else if (gTCPRecvPending) {
+             // Should not happen if state is managed correctly, but log defensively
              log_message("Warning (PollTCPListener): Receive pending but stream pointer mismatch or NULL. Clearing flag.");
              gTCPRecvPending = false;
         }
     }
+
+    // Check for completed Close operation
     if (gTCPClosePending) {
+        // Defensive check: Ensure the completion is for the correct stream
         if (gTCPClosePB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
             ioResult = gTCPClosePB.ioResult;
-            if (ioResult <= 0) {
-                gTCPClosePending = false;
+            if (ioResult <= 0) { // Completed
+                gTCPClosePending = false; // Clear flag *before* handling
                 HandleCloseCompletion(macTCPRefNum, ioResult);
             }
         } else if (gTCPClosePending) {
-             log_message("Warning (PollTCPListener): Close pending but stream pointer mismatch or NULL. Clearing flag.");
+             log_message("Warning (PollTCPListener): Async Close pending but stream pointer mismatch or NULL. Clearing flag.");
              gTCPClosePending = false;
         }
     }
-    if (gTCPReleasePending) {
-        if (gTCPReleasePB.tcpStream == gStreamBeingReleased && gStreamBeingReleased != NULL) {
-            ioResult = gTCPReleasePB.ioResult;
-            if (ioResult <= 0) {
-                gTCPReleasePending = false;
-                HandleReleaseCompletion(macTCPRefNum, ioResult);
-            }
-        } else if (gTCPReleasePending) {
-             log_message("Warning (PollTCPListener): Release pending but stream pointer mismatch or NULL. Clearing flag.");
-             gTCPReleasePending = false;
-             gStreamBeingReleased = NULL;
-        }
-    }
+
+    // Check if we need to re-issue the listen command
     if (gNeedToReListen && gTCPListenStream != NULL &&
-        !gTCPListenPending && !gTCPRecvPending && !gTCPClosePending && !gTCPReleasePending)
+        !gTCPListenPending && !gTCPRecvPending && !gTCPClosePending && !gIsConnectionActive)
     {
         log_to_file_only("PollTCPListener: Conditions met to attempt re-issuing listen.");
-        gNeedToReListen = false;
-        gIsConnectionActive = false;
+        gNeedToReListen = false; // Clear flag *before* attempting
         OSErr err = StartAsyncTCPListen(macTCPRefNum);
-        if (err != noErr && err != 1) {
+        if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen here)
             log_message("Error (PollTCPListener): Attempt to re-issue listen failed immediately. Error: %d. Will retry later.", err);
-            gNeedToReListen = true;
+            gNeedToReListen = true; // Set flag again to retry on next poll
         } else {
             log_to_file_only("PollTCPListener: Re-issued Async TCPPassiveOpen successfully (or already pending).");
         }
     } else if (gNeedToReListen && gTCPListenStream == NULL) {
+        // This indicates a serious problem, listener stream was likely released due to error
         log_message("Warning (PollTCPListener): Need to re-listen but stream is NULL. Cannot proceed.");
-        gNeedToReListen = false;
+        gNeedToReListen = false; // Stop trying if stream is gone
     }
 }
+
+// Internal function to perform a complete synchronous send operation using a temporary stream
+static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
+                                 const char *messageBuffer, int messageLen,
+                                 SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
+                                 GiveTimePtr giveTime)
+{
+    OSErr err = noErr;
+    OSErr finalErr = noErr;
+    StreamPtr tempStream = NULL;
+    Ptr tempConnBuffer = NULL;
+    struct wdsEntry sendWDS[2];
+
+    log_to_file_only("InternalSyncTCPSend: To IP %lu:%u (%d bytes)", (unsigned long)targetIP, targetPort, messageLen);
+
+    // 1. Allocate temporary buffer for the temporary stream
+    tempConnBuffer = NewPtrClear(kTCPSenderInternalBufferSize);
+    if (tempConnBuffer == NULL) {
+        log_message("Error (InternalSyncTCPSend): Failed to allocate temporary connection buffer.");
+        return memFullErr;
+    }
+
+    // 2. Create temporary stream
+    err = LowTCPCreateSync(gMacTCPRefNum, &tempStream, tempConnBuffer, kTCPSenderInternalBufferSize);
+    if (err != noErr || tempStream == NULL) {
+        log_message("Error (InternalSyncTCPSend): LowTCPCreateSync failed: %d", err);
+        DisposePtr(tempConnBuffer); // Clean up buffer
+        return err;
+    }
+    log_to_file_only("InternalSyncTCPSend: Temp stream 0x%lX created.", (unsigned long)tempStream);
+
+    // 3. Connect using the temporary stream
+    log_to_file_only("InternalSyncTCPSend: Connecting temp stream 0x%lX...", (unsigned long)tempStream);
+    err = LowTCPOpenConnectionSync(tempStream, connectTimeoutTicks, targetIP, targetPort, NULL, NULL, giveTime);
+    if (err == noErr) {
+        log_to_file_only("InternalSyncTCPSend: Connected successfully.");
+
+        // 4. Send data
+        sendWDS[0].length = messageLen;
+        sendWDS[0].ptr = (Ptr)messageBuffer; // Cast away const, WDS expects Ptr
+        sendWDS[1].length = 0; // Terminator for WDS array
+        sendWDS[1].ptr = NULL;
+
+        log_to_file_only("InternalSyncTCPSend: Sending data...");
+        err = LowTCPSendSync(tempStream, sendTimeoutTicks, true, false, (Ptr)sendWDS, giveTime);
+        if (err == noErr) {
+            log_to_file_only("InternalSyncTCPSend: Send successful.");
+        } else {
+            log_message("Error (InternalSyncTCPSend): LowTCPSendSync failed: %d", err);
+            finalErr = err; // Record send error
+        }
+
+        // 5. Abort connection (no need for graceful close for one-shot send)
+        log_to_file_only("InternalSyncTCPSend: Aborting connection...");
+        OSErr abortErr = LowTCPAbortSync(tempStream, giveTime);
+        if (abortErr != noErr) {
+            log_message("Warning (InternalSyncTCPSend): LowTCPAbortSync failed: %d", abortErr);
+            if (finalErr == noErr) finalErr = abortErr; // Record abort error if no prior error
+        }
+
+    } else {
+        log_message("Error (InternalSyncTCPSend): LowTCPOpenConnectionSync failed: %d", err);
+        finalErr = err; // Record connect error
+    }
+
+    // 6. Release the temporary stream (regardless of errors)
+    log_to_file_only("InternalSyncTCPSend: Releasing temp stream 0x%lX...", (unsigned long)tempStream);
+    OSErr releaseErr = LowTCPReleaseSync(gMacTCPRefNum, tempStream);
+    if (releaseErr != noErr) {
+        log_message("Warning (InternalSyncTCPSend): LowTCPReleaseSync failed: %d", releaseErr);
+        if (finalErr == noErr) finalErr = releaseErr; // Record release error if no prior error
+    }
+
+    // 7. Dispose the temporary connection buffer
+    DisposePtr(tempConnBuffer);
+
+    log_to_file_only("InternalSyncTCPSend: Finished. Final status: %d", finalErr);
+    return finalErr;
+}
+
+
+OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
+    OSErr err = noErr;
+    ip_addr targetIP = 0;
+    char messageBuffer[BUFFER_SIZE];
+    int formattedLen;
+
+    log_to_file_only("TCP_SendTextMessageSync: Attempting to send TEXT to %s", peerIP);
+
+    if (gMacTCPRefNum == 0) {
+        log_message("Error (TCP_SendTextMessageSync): MacTCP not initialized.");
+        return notOpenErr;
+    }
+    if (peerIP == NULL || message == NULL || giveTime == NULL) {
+        return paramErr;
+    }
+
+    // Parse the destination IP address
+    err = ParseIPv4(peerIP, &targetIP);
+    if (err != noErr || targetIP == 0) {
+        log_message("Error (TCP_SendTextMessageSync): Could not parse peer IP string '%s'.", peerIP);
+        return paramErr;
+    }
+
+    // Format the message using the shared protocol function
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT,
+                                  gMyUsername, gMyLocalIPStr, message);
+    if (formattedLen <= 0) {
+        log_message("Error (TCP_SendTextMessageSync): Failed to format TEXT message for %s.", peerIP);
+        return paramErr; // Or a more specific error
+    }
+
+    // Use the internal synchronous send function
+    err = InternalSyncTCPSend(targetIP, PORT_TCP, messageBuffer, formattedLen,
+                              kRuntimeConnectTimeoutTicks, kRuntimeSendTimeoutTicks, giveTime);
+
+    if (err == noErr) {
+        log_message("Successfully sent TEXT message to %s.", peerIP);
+    } else {
+        log_message("Failed to send TEXT message to %s (Error: %d).", peerIP, err);
+    }
+
+    return err;
+}
+
+
+OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
+    int i;
+    OSErr lastErr = noErr; // Track the last error encountered
+    char quitMessageBuffer[BUFFER_SIZE];
+    int formattedLen;
+    int activePeerCount = 0;
+    int sentCount = 0;
+
+    log_message("TCP_SendQuitMessagesSync: Starting...");
+
+    if (gMacTCPRefNum == 0) {
+        log_message("TCP_SendQuitMessagesSync: Cannot send, MacTCP not initialized.");
+        return notOpenErr;
+    }
+     if (giveTime == NULL) {
+        return paramErr;
+    }
+
+    // Format the QUIT message once
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT,
+                                  gMyUsername, gMyLocalIPStr, "");
+    if (formattedLen <= 0) {
+        log_message("Error (TCP_SendQuitMessagesSync): Failed to format QUIT message.");
+        return paramErr; // Or a more specific error
+    }
+
+    // Count active peers first (for logging)
+    for (i = 0; i < MAX_PEERS; ++i) {
+        if (gPeerManager.peers[i].active) {
+            activePeerCount++;
+        }
+    }
+    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
+
+    // Iterate through peers and send QUIT using temporary streams
+    for (i = 0; i < MAX_PEERS; ++i) {
+        if (gPeerManager.peers[i].active) {
+            ip_addr targetIP = 0;
+            OSErr parseErr, sendErr;
+
+            log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s",
+                        gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
+
+            // Parse IP for this peer
+            parseErr = ParseIPv4(gPeerManager.peers[i].ip, &targetIP);
+            if (parseErr != noErr || targetIP == 0) {
+                log_message("Error: Could not parse peer IP string '%s'. Skipping.", gPeerManager.peers[i].ip);
+                lastErr = parseErr; // Record the error
+                continue; // Skip this peer
+            }
+
+            // Send using the internal synchronous function
+            sendErr = InternalSyncTCPSend(targetIP, PORT_TCP, quitMessageBuffer, formattedLen,
+                                          kShutdownConnectTimeoutTicks, kShutdownSendTimeoutTicks, giveTime);
+
+            if (sendErr == noErr) {
+                log_message("Successfully sent QUIT to %s.", gPeerManager.peers[i].ip);
+                sentCount++;
+            } else {
+                log_message("Error sending QUIT to %s: %d", gPeerManager.peers[i].ip, sendErr);
+                lastErr = sendErr; // Record the error
+                // Continue trying other peers even if one fails
+            }
+
+            // Yield time between attempts to be cooperative
+            giveTime();
+        }
+    }
+
+    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers.", sentCount, activePeerCount);
+
+    // Return the last error encountered (or noErr if all succeeded)
+    return lastErr;
+}
+
+
+// --- Private Helper Functions ---
+
 static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult) {
+    // Ensure this completion is for the current listener stream
     StreamPtr completedListenerStream = gTCPListenPB.tcpStream;
     if (completedListenerStream != gTCPListenStream || gTCPListenStream == NULL) {
         log_message("Warning (HandleListenerCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                     (unsigned long)completedListenerStream, (unsigned long)gTCPListenStream);
         return;
     }
+
     if (ioResult == noErr) {
+        // Connection indication received
         ip_addr acceptedIP = gTCPListenPB.csParam.open.remoteHost;
         tcp_port acceptedPort = gTCPListenPB.csParam.open.remotePort;
         char senderIPStr[INET_ADDRSTRLEN];
-        AddrToStr(acceptedIP, senderIPStr);
+        AddrToStr(acceptedIP, senderIPStr); // Use DNR to get string representation
         log_message("TCP Connection Indication from %s:%u on listener stream 0x%lX.",
                     senderIPStr, acceptedPort, (unsigned long)completedListenerStream);
+
+        // Check if we are already handling a connection or have other pending ops
         if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
              log_message("Warning: New connection indication while listener stream busy (Active: %d, RecvPending: %d, ClosePending: %d). Setting flag to re-listen later.",
                          gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-             gNeedToReListen = true;
+             gNeedToReListen = true; // We missed this connection, need to listen again later
         } else {
+            // Accept the connection state
             gCurrentConnectionIP = acceptedIP;
             gCurrentConnectionPort = acceptedPort;
             gIsConnectionActive = true;
+
+            // Start the first receive operation for this new connection
             OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-            if (err != noErr && err != 1) {
-                log_message("Error (HandleListenerCompletion): Failed to start first TCPRcv on listener stream. Error: %d. Releasing connection state.", err);
-                gIsConnectionActive = false;
+            if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen)
+                log_message("Error (HandleListenerCompletion): Failed to start first TCPRcv on listener stream. Error: %d. Closing connection state.", err);
+                gIsConnectionActive = false; // Reset state
                 gCurrentConnectionIP = 0;
                 gCurrentConnectionPort = 0;
+                // Don't start Close here, just set flag to re-listen
                 gNeedToReListen = true;
             } else {
                  log_to_file_only("HandleListenerCompletion: First TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
             }
         }
     } else {
+        // Handle errors from TCPPassiveOpen
         const char *errMsg = "Unknown Error";
-        Boolean isConnectionExists = (ioResult == connectionExists);
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-        Boolean isBadBuf = (ioResult == invalidBufPtr);
-        Boolean isInsufficientRes = (ioResult == insufficientResources);
+        Boolean isConnectionExists = (ioResult == connectionExists); // Transient, try again
+        Boolean isInvalidStream = (ioResult == invalidStreamPtr);   // Fatal for this stream
+        Boolean isReqAborted = (ioResult == reqAborted);           // Usually from PBKillIO
+        // Add other common errors if needed
         if (isConnectionExists) errMsg = "connectionExists (-23007)";
         else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-        else if (isBadBuf) errMsg = "invalidBufPtr (-23004)";
-        else if (isInsufficientRes) errMsg = "insufficientResources (-23005)";
+        else if (isReqAborted) errMsg = "reqAborted (-23015)";
+
         if (isConnectionExists) {
+             // This can happen if MacTCP's internal state is temporarily busy. Retry after a short delay.
              log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with transient error: %d (%s). Will retry after delay.", ioResult, errMsg);
              unsigned long dummyTimer;
-             Delay(kTCPListenRetryDelayTicks, &dummyTimer);
-             gNeedToReListen = true;
+             Delay(kTCPListenRetryDelayTicks, &dummyTimer); // Simple delay
+             gNeedToReListen = true; // Flag to retry
+        } else if (isReqAborted) {
+             // This is expected if we killed the listen (e.g., during cleanup)
+             log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
+             // Don't automatically set gNeedToReListen here, cleanup handles it
         } else {
+            // Other errors
             log_message("Error (HandleListenerCompletion): TCPPassiveOpen completed with error: %d (%s)", ioResult, errMsg);
             if (isInvalidStream) {
-                 log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid. Attempting release.", (unsigned long)gTCPListenStream);
-                 StartAsyncTCPRelease(macTCPRefNum, gTCPListenStream);
-                 gNeedToReListen = false;
+                 // This stream is unusable. Log and prevent further use.
+                 log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid. It will be cleaned up.", (unsigned long)gTCPListenStream);
+                 // CleanupNetworking will handle the release. Don't try to use it further.
+                 gTCPListenStream = NULL; // Mark as unusable
+                 gNeedToReListen = false; // Cannot re-listen on a NULL stream
             } else {
+                 // For other errors, attempt to re-listen later
                  gNeedToReListen = true;
             }
         }
     }
 }
+
 static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult) {
     StreamPtr completedRecvStream = gTCPRecvPB.tcpStream;
+
+    // Ensure completion is for the correct, non-NULL listener stream
     if (completedRecvStream != gTCPListenStream || gTCPListenStream == NULL) {
          log_message("Warning (HandleReceiveCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                      (unsigned long)completedRecvStream, (unsigned long)gTCPListenStream);
          return;
     }
+
+    // If connection is no longer marked active (e.g., closed during processing), handle differently
      if (!gIsConnectionActive) {
          if (ioResult == noErr) {
+             // Received data but connection state changed. Process data but don't continue.
              log_to_file_only("Warning (HandleReceiveCompletion): Receive completed successfully but connection no longer marked active. Data processed, not re-issuing receive.");
-             ProcessTCPReceive(macTCPRefNum);
+             ProcessTCPReceive(macTCPRefNum); // Process any final data
          } else {
              log_to_file_only("Warning (HandleReceiveCompletion): Receive completed with error %d, connection already inactive.", ioResult);
          }
-         gNeedToReListen = true;
-         return;
+         // If the error wasn't just an abort, we likely need to re-listen eventually
+         if (ioResult != reqAborted) {
+            gNeedToReListen = true;
+         }
+         return; // Do not proceed further
      }
+
+    // Handle completion results for an active connection
     if (ioResult == noErr) {
+        // Data received successfully
         ProcessTCPReceive(macTCPRefNum);
+
+        // If connection is still active after processing, issue the next receive
         if (gIsConnectionActive && gTCPListenStream != NULL) {
             OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-             if (err != noErr && err != 1) {
-                 log_message("Error (HandleReceiveCompletion): Failed to start next async TCP receive after successful receive. Error: %d. Closing connection state.", err);
-                 gIsConnectionActive = false;
-                 gCurrentConnectionIP = 0;
-                 gCurrentConnectionPort = 0;
-                 StartAsyncTCPClose(macTCPRefNum, gTCPListenStream, true);
+             if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen)
+                 log_message("Error (HandleReceiveCompletion): Failed to start next async TCP receive after successful receive. Error: %d. Closing connection.", err);
+                 // Couldn't start next receive, close the connection abruptly
+                 StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
              } else {
                  log_to_file_only("HandleReceiveCompletion: Successfully re-issued TCPRcv on stream 0x%lX.", (unsigned long)gTCPListenStream);
              }
         } else {
-             log_to_file_only("HandleReceiveCompletion: Connection stream closed/inactive during processing or stream became NULL. Not starting new receive.");
-             if (gTCPListenStream != NULL) {
+             // Connection became inactive during processing (e.g., ProcessTCPReceive handled QUIT)
+             // or stream became NULL (fatal error).
+             log_to_file_only("HandleReceiveCompletion: Connection stream closed/inactive or stream became NULL during processing. Not starting new receive.");
+             // If stream still exists and no close is pending, flag to re-listen
+             if (gTCPListenStream != NULL && !gTCPClosePending) {
                  gNeedToReListen = true;
              }
         }
     } else if (ioResult == connectionClosing) {
+         // Peer initiated graceful close
          char senderIPStr[INET_ADDRSTRLEN];
          AddrToStr(gCurrentConnectionIP, senderIPStr);
          log_message("TCP Connection closing gracefully from %s (Stream: 0x%lX).", senderIPStr, (unsigned long)completedRecvStream);
+         // Process any final data that might have been in the buffer
+         ProcessTCPReceive(macTCPRefNum);
+         // Clean up connection state and flag to re-listen
          gIsConnectionActive = false;
          gCurrentConnectionIP = 0;
          gCurrentConnectionPort = 0;
          gNeedToReListen = true;
     } else {
+         // Handle receive errors
          char senderIPStr[INET_ADDRSTRLEN];
-         AddrToStr(gCurrentConnectionIP, senderIPStr);
+         AddrToStr(gCurrentConnectionIP, senderIPStr); // Get IP for logging
          const char *errMsg = "Unknown Error";
-         Boolean isConnDoesntExist = (ioResult == connectionDoesntExist);
-         Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-         Boolean isConnTerminated = (ioResult == connectionTerminated);
-         Boolean isBadBuf = (ioResult == invalidBufPtr);
-         if (isConnDoesntExist) errMsg = "connectionDoesntExist (-23008)";
+         Boolean isConnTerminated = (ioResult == connectionTerminated); // Abrupt close
+         Boolean isInvalidStream = (ioResult == invalidStreamPtr);   // Fatal
+         Boolean isReqAborted = (ioResult == reqAborted);           // From PBKillIO
+         // Add other relevant errors
+         if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
          else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-         else if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
-         else if (isBadBuf) errMsg = "invalidBufPtr (-23004)";
-        log_message("Error (HandleReceiveCompletion): Async TCPRcv completed with error: %d (%s) from %s (Stream: 0x%lX).", ioResult, errMsg, senderIPStr, (unsigned long)completedRecvStream);
+         else if (isReqAborted) errMsg = "reqAborted (-23015)";
+
+        if (isReqAborted) {
+            log_to_file_only("HandleReceiveCompletion: Async TCPRcv completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
+        } else {
+            log_message("Error (HandleReceiveCompletion): Async TCPRcv completed with error: %d (%s) from %s (Stream: 0x%lX).", ioResult, errMsg, senderIPStr, (unsigned long)completedRecvStream);
+        }
+
+        // Clean up connection state
         gIsConnectionActive = false;
         gCurrentConnectionIP = 0;
         gCurrentConnectionPort = 0;
+
+        // Handle fatal stream error
         if (isInvalidStream) {
-             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during receive. Attempting release.", (unsigned long)gTCPListenStream);
-             StartAsyncTCPRelease(macTCPRefNum, gTCPListenStream);
-             gNeedToReListen = false;
-        } else {
-             log_to_file_only("HandleReceiveCompletion: Attempting abortive close due to receive error.");
-             StartAsyncTCPClose(macTCPRefNum, gTCPListenStream, true);
+             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during receive. It will be cleaned up.", (unsigned long)gTCPListenStream);
+             gTCPListenStream = NULL; // Mark as unusable
+             gNeedToReListen = false; // Cannot re-listen
+        } else if (!isReqAborted) {
+             // For other errors (like connectionTerminated), flag to re-listen
+             gNeedToReListen = true;
         }
     }
 }
+
 static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult) {
     StreamPtr closedStream = gTCPClosePB.tcpStream;
+
+    // Ensure completion is for the correct, non-NULL listener stream
     if (closedStream != gTCPListenStream || gTCPListenStream == NULL) {
          log_message("Warning (HandleCloseCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                      (unsigned long)closedStream, (unsigned long)gTCPListenStream);
          return;
     }
+
+    // Connection is definitely inactive now
+    gIsConnectionActive = false;
+    gCurrentConnectionIP = 0;
+    gCurrentConnectionPort = 0;
+
     if (ioResult == noErr) {
         log_to_file_only("HandleCloseCompletion: Async TCPClose completed successfully for stream 0x%lX.", (unsigned long)closedStream);
     } else {
+        // Handle close errors
         const char *errMsg = "Unknown Error";
-        if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)";
-        else if (ioResult == connectionDoesntExist) errMsg = "connectionDoesntExist (-23008)";
-        else if (ioResult == connectionClosing) errMsg = "connectionClosing (-23009)";
-        log_message("Error (HandleCloseCompletion): Async TCPClose for stream 0x%lX completed with error: %d (%s)", (unsigned long)closedStream, ioResult, errMsg);
-        if (ioResult == invalidStreamPtr) {
-             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during close. Attempting release.", (unsigned long)gTCPListenStream);
-             StartAsyncTCPRelease(macTCPRefNum, gTCPListenStream);
-             gNeedToReListen = false;
-             return;
+        Boolean isInvalidStream = (ioResult == invalidStreamPtr); // Fatal
+        Boolean isReqAborted = (ioResult == reqAborted);         // From PBKillIO
+        // Add other relevant errors (e.g., connectionDoesntExist)
+        if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
+        else if (isReqAborted) errMsg = "reqAborted (-23015)";
+
+        if (isReqAborted) {
+             log_to_file_only("HandleCloseCompletion: Async TCPClose completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
+        } else {
+            log_message("Error (HandleCloseCompletion): Async TCPClose for stream 0x%lX completed with error: %d (%s)", (unsigned long)closedStream, ioResult, errMsg);
+        }
+
+        // Handle fatal stream error
+        if (isInvalidStream) {
+             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during close. It will be cleaned up.", (unsigned long)gTCPListenStream);
+             gTCPListenStream = NULL; // Mark as unusable
+             gNeedToReListen = false; // Cannot re-listen
+             return; // Don't set flag below
         }
     }
-    log_to_file_only("HandleCloseCompletion: Setting flag to re-listen.");
-    gNeedToReListen = true;
-}
-static void HandleReleaseCompletion(short macTCPRefNum, OSErr ioResult) {
-    StreamPtr releasedStream = gTCPReleasePB.tcpStream;
-    if (releasedStream != gStreamBeingReleased || releasedStream == NULL) {
-        log_message("Warning (HandleReleaseCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Expected: 0x%lX).",
-                    (unsigned long)releasedStream, (unsigned long)gStreamBeingReleased);
-        if (gStreamBeingReleased != releasedStream) {
-             gStreamBeingReleased = NULL;
-        }
-        return;
-    }
-    gStreamBeingReleased = NULL;
-    if (ioResult == noErr) {
-        log_to_file_only("HandleReleaseCompletion: Async TCPRelease completed successfully for stream 0x%lX.", (unsigned long)releasedStream);
-    } else {
-         const char *errMsg = "Unknown Error";
-         if (ioResult == invalidStreamPtr) errMsg = "invalidStreamPtr (-23010)";
-        log_message("Error (HandleReleaseCompletion): Async TCPRelease for stream 0x%lX completed with error: %d (%s)", (unsigned long)releasedStream, ioResult, errMsg);
-    }
-    if (releasedStream == gTCPListenStream) {
-         log_message("HandleReleaseCompletion: Listener stream 0x%lX was released. Setting global pointer to NULL.", (unsigned long)releasedStream);
-         gTCPListenStream = NULL;
-         gNeedToReListen = false;
-         gIsConnectionActive = false;
-         gCurrentConnectionIP = 0;
-         gCurrentConnectionPort = 0;
+
+    // If the close wasn't just an abort, we need to re-listen
+    if (ioResult != reqAborted) {
+        log_to_file_only("HandleCloseCompletion: Setting flag to re-listen.");
+        gNeedToReListen = true;
     }
 }
+
+
+// Start listening for incoming connections on the persistent listener stream
 static OSErr StartAsyncTCPListen(short macTCPRefNum) {
     OSErr err;
+
     if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPListen): Cannot listen, gTCPListenStream is NULL.");
         return invalidStreamPtr;
     }
     if (gTCPListenPending) {
         log_to_file_only("StartAsyncTCPListen: Listen already pending on stream 0x%lX.", (unsigned long)gTCPListenStream);
-        return 1;
+        return 1; // Indicate already pending
     }
+    // Cannot start listen if stream is busy with an active connection or other ops
     if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
         log_message("Error (StartAsyncTCPListen): Cannot listen, stream 0x%lX is busy (Active: %d, RecvPending: %d, ClosePending: %d).",
                     (unsigned long)gTCPListenStream, gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-        return inProgress;
+        return inProgress; // Indicate busy
     }
-    if (gTCPReleasePending && gStreamBeingReleased == gTCPListenStream) {
-         log_message("Error (StartAsyncTCPListen): Cannot listen, stream 0x%lX release is pending.", (unsigned long)gTCPListenStream);
-         return inProgress;
-    }
+
+    // Prepare the parameter block for TCPPassiveOpen
     memset(&gTCPListenPB, 0, sizeof(TCPiopb));
-    gTCPListenPB.ioCompletion = nil;
+    gTCPListenPB.ioCompletion = nil; // Use polling
     gTCPListenPB.ioCRefNum = macTCPRefNum;
     gTCPListenPB.csCode = TCPPassiveOpen;
     gTCPListenPB.tcpStream = gTCPListenStream;
-    gTCPListenPB.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    gTCPListenPB.csParam.open.ulpTimeoutValue = kTCPDefaultTimeout;
-    gTCPListenPB.csParam.open.ulpTimeoutAction = AbortTrue;
-    gTCPListenPB.csParam.open.commandTimeoutValue = 0;
+    // Set timeouts (optional, 0 usually means infinite for passive open)
+    gTCPListenPB.csParam.open.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
+    gTCPListenPB.csParam.open.ulpTimeoutValue = kTCPDefaultTimeout; // Use default (0 = infinite)
+    gTCPListenPB.csParam.open.ulpTimeoutAction = AbortTrue; // Action if timeout occurs (irrelevant if value is 0)
+    gTCPListenPB.csParam.open.commandTimeoutValue = 0; // No timeout for the command itself
+    // Specify local port and allow any remote host/port
     gTCPListenPB.csParam.open.localPort = PORT_TCP;
-    gTCPListenPB.csParam.open.localHost = 0L;
-    gTCPListenPB.csParam.open.remoteHost = 0L;
-    gTCPListenPB.csParam.open.remotePort = 0;
-    gTCPListenPB.csParam.open.userDataPtr = nil;
-    gTCPListenPending = true;
+    gTCPListenPB.csParam.open.localHost = 0L; // Listen on all local interfaces
+    gTCPListenPB.csParam.open.remoteHost = 0L; // Accept connection from any remote IP
+    gTCPListenPB.csParam.open.remotePort = 0;  // Accept connection from any remote port
+    gTCPListenPB.csParam.open.userDataPtr = nil; // No user data
+
+    // Issue the asynchronous call
+    gTCPListenPending = true; // Set flag *before* calling
     err = PBControlAsync((ParmBlkPtr)&gTCPListenPB);
     if (err != noErr) {
         log_message("Error (StartAsyncTCPListen): PBControlAsync(TCPPassiveOpen) failed immediately. Error: %d", err);
-        gTCPListenPending = false;
+        gTCPListenPending = false; // Clear flag on immediate failure
         return err;
     }
+
     log_to_file_only("StartAsyncTCPListen: Async TCPPassiveOpen initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1;
+    return 1; // Indicate call initiated successfully (pending)
 }
+
+// Start receiving data on the active connection (listener stream)
 static OSErr StartAsyncTCPRecv(short macTCPRefNum) {
     OSErr err;
+
     if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPRecv): Cannot receive, gTCPListenStream is NULL.");
         return invalidStreamPtr;
@@ -487,183 +778,395 @@ static OSErr StartAsyncTCPRecv(short macTCPRefNum) {
     }
     if (gTCPRecvPending) {
          log_to_file_only("StartAsyncTCPRecv: Receive already pending on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return 1;
+         return 1; // Indicate already pending
     }
+    // Can only receive if a connection is active
     if (!gIsConnectionActive) {
-         log_message("Error (StartAsyncTCPRecv): Cannot receive, connection not active on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return connectionDoesntExist;
+         log_to_file_only("Warning (StartAsyncTCPRecv): Cannot receive, connection not marked active on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
+         return connectionDoesntExist; // Or appropriate error
     }
-    if (gTCPListenPending || gTCPClosePending || (gTCPReleasePending && gStreamBeingReleased == gTCPListenStream)) {
-         log_message("Error (StartAsyncTCPRecv): Cannot receive, stream 0x%lX has other pending operations (Listen: %d, Close: %d, Release: %d).",
-                     (unsigned long)gTCPListenStream, gTCPListenPending, gTCPClosePending, gTCPReleasePending);
-         return inProgress;
+    // Cannot receive if other operations are blocking the stream
+    if (gTCPListenPending || gTCPClosePending) {
+         log_message("Error (StartAsyncTCPRecv): Cannot receive, stream 0x%lX has other pending operations (Listen: %d, Close: %d).",
+                     (unsigned long)gTCPListenStream, gTCPListenPending, gTCPClosePending);
+         return inProgress; // Indicate busy
     }
+
+    // Prepare the parameter block for TCPRcv
     memset(&gTCPRecvPB, 0, sizeof(TCPiopb));
-    gTCPRecvPB.ioCompletion = nil;
+    gTCPRecvPB.ioCompletion = nil; // Use polling
     gTCPRecvPB.ioCRefNum = macTCPRefNum;
     gTCPRecvPB.csCode = TCPRcv;
     gTCPRecvPB.tcpStream = gTCPListenStream;
-    gTCPRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;
-    gTCPRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize;
-    gTCPRecvPB.csParam.receive.commandTimeoutValue = 0;
-    gTCPRecvPB.csParam.receive.userDataPtr = nil;
-    gTCPRecvPending = true;
+    gTCPRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;     // Our receive buffer
+    gTCPRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize; // Max bytes to receive
+    gTCPRecvPB.csParam.receive.commandTimeoutValue = 0; // No timeout for the receive command itself
+    gTCPRecvPB.csParam.receive.userDataPtr = nil; // No user data
+
+    // Issue the asynchronous call
+    gTCPRecvPending = true; // Set flag *before* calling
     err = PBControlAsync((ParmBlkPtr)&gTCPRecvPB);
     if (err != noErr) {
         log_message("Error (StartAsyncTCPRecv): PBControlAsync(TCPRcv) failed immediately. Error: %d", err);
-        gTCPRecvPending = false;
-        gIsConnectionActive = false;
-        gCurrentConnectionIP = 0;
-        gCurrentConnectionPort = 0;
-        StartAsyncTCPClose(macTCPRefNum, gTCPListenStream, true);
+        gTCPRecvPending = false; // Clear flag on immediate failure
+        // If receive fails immediately, the connection is likely broken. Close it.
+        StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
         return err;
     }
+
     log_to_file_only("StartAsyncTCPRecv: Async TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1;
+    return 1; // Indicate call initiated successfully (pending)
 }
-static OSErr StartAsyncTCPClose(short macTCPRefNum, StreamPtr streamToClose, Boolean abortConnection) {
+
+// Start closing the active connection on the listener stream
+static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection) {
     OSErr err;
-    if (streamToClose == NULL) {
+
+    if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPClose): Cannot close NULL stream.");
         return invalidStreamPtr;
     }
-    if (streamToClose != gTCPListenStream) {
-        log_message("Error (StartAsyncTCPClose): Attempt to close non-listener stream 0x%lX.", (unsigned long)streamToClose);
-        return invalidStreamPtr;
-    }
     if (gTCPClosePending) {
-        log_to_file_only("StartAsyncTCPClose: Close already pending for listener stream 0x%lX.", (unsigned long)streamToClose);
-        return 1;
+        log_to_file_only("StartAsyncTCPClose: Close already pending for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
+        return 1; // Indicate already pending
     }
-     if (gTCPReleasePending && gStreamBeingReleased == streamToClose) {
-         log_message("Error (StartAsyncTCPClose): Cannot close, stream 0x%lX release is pending.", (unsigned long)streamToClose);
-         return inProgress;
+
+    // Mark connection as inactive *before* initiating close
+    gIsConnectionActive = false;
+    gCurrentConnectionIP = 0;
+    gCurrentConnectionPort = 0;
+
+    // Kill any pending receive on this stream before closing
+    if (gTCPRecvPending && gTCPRecvPB.tcpStream == gTCPListenStream) {
+        log_to_file_only("StartAsyncTCPClose: Killing pending receive before closing.");
+        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false); // Async kill, ignore error
+        gTCPRecvPending = false; // Clear flag immediately
     }
+
+    // Prepare the parameter block for TCPClose
     memset(&gTCPClosePB, 0, sizeof(TCPiopb));
-    gTCPClosePB.ioCompletion = nil;
+    gTCPClosePB.ioCompletion = nil; // Use polling
     gTCPClosePB.ioCRefNum = macTCPRefNum;
     gTCPClosePB.csCode = TCPClose;
-    gTCPClosePB.tcpStream = streamToClose;
-    gTCPClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction;
-    gTCPClosePB.csParam.close.ulpTimeoutValue = kTCPDefaultTimeout;
+    gTCPClosePB.tcpStream = gTCPListenStream;
+    // Set ULP timeout for close operation (optional, 0 = default/infinite)
+    gTCPClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
+    gTCPClosePB.csParam.close.ulpTimeoutValue = kTCPDefaultTimeout; // Use default (0)
     if (abortConnection) {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = AbortTrue;
+        gTCPClosePB.csParam.close.ulpTimeoutAction = AbortTrue; // Abort immediately
         log_to_file_only("StartAsyncTCPClose: Using Abort action.");
     } else {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = 0;
+        gTCPClosePB.csParam.close.ulpTimeoutAction = 0; // Graceful close (default action)
         log_to_file_only("StartAsyncTCPClose: Using Graceful close action.");
     }
-    gTCPClosePB.csParam.close.userDataPtr = nil;
-    gTCPClosePending = true;
+    gTCPClosePB.csParam.close.userDataPtr = nil; // No user data
+
+    // Issue the asynchronous call
+    gTCPClosePending = true; // Set flag *before* calling
     err = PBControlAsync((ParmBlkPtr)&gTCPClosePB);
     if (err != noErr) {
-        log_message("Error (StartAsyncTCPClose): PBControlAsync(TCPClose) failed immediately for stream 0x%lX. Error: %d", (unsigned long)streamToClose, err);
-        gTCPClosePending = false;
-        gNeedToReListen = true;
+        log_message("Error (StartAsyncTCPClose): PBControlAsync(TCPClose) failed immediately for stream 0x%lX. Error: %d", (unsigned long)gTCPListenStream, err);
+        gTCPClosePending = false; // Clear flag on immediate failure
+        gNeedToReListen = true; // Flag to re-listen since close failed
         return err;
     }
-    log_to_file_only("StartAsyncTCPClose: Initiated async TCPClose for listener stream 0x%lX.", (unsigned long)streamToClose);
-    return 1;
+
+    log_to_file_only("StartAsyncTCPClose: Initiated async TCPClose for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
+    return 1; // Indicate call initiated successfully (pending)
 }
-static OSErr StartAsyncTCPRelease(short macTCPRefNum, StreamPtr streamToRelease) {
-    OSErr err;
-    if (streamToRelease == NULL) {
-        log_message("Error (StartAsyncTCPRelease): Cannot release NULL stream.");
-        return invalidStreamPtr;
-    }
-    if (streamToRelease != gTCPListenStream) {
-        log_message("Error (StartAsyncTCPRelease): Attempt to release non-listener stream 0x%lX.", (unsigned long)streamToRelease);
-        return invalidStreamPtr;
-    }
-    if (gTCPReleasePending && gStreamBeingReleased == streamToRelease) {
-         log_to_file_only("StartAsyncTCPRelease: Release already pending for listener stream 0x%lX.", (unsigned long)streamToRelease);
-         return 1;
-    }
-    if (gTCPReleasePending) {
-         log_message("Warning (StartAsyncTCPRelease): Overwriting pending release for stream 0x%lX with new release request for listener stream 0x%lX.",
-                     (unsigned long)gStreamBeingReleased, (unsigned long)streamToRelease);
-    }
-    if (gTCPListenPending || gTCPRecvPending || gTCPClosePending) {
-         log_message("Warning (StartAsyncTCPRelease): Releasing stream 0x%lX while other operations pending (Listen: %d, Recv: %d, Close: %d).",
-                     (unsigned long)streamToRelease, gTCPListenPending, gTCPRecvPending, gTCPClosePending);
-    }
-    memset(&gTCPReleasePB, 0, sizeof(TCPiopb));
-    gTCPReleasePB.ioCompletion = nil;
-    gTCPReleasePB.ioCRefNum = macTCPRefNum;
-    gTCPReleasePB.csCode = TCPRelease;
-    gTCPReleasePB.tcpStream = streamToRelease;
-    gTCPReleasePending = true;
-    gStreamBeingReleased = streamToRelease;
-    err = PBControlAsync((ParmBlkPtr)&gTCPReleasePB);
-    if (err != noErr) {
-        log_message("Error (StartAsyncTCPRelease): PBControlAsync(TCPRelease) failed immediately for listener stream 0x%lX. Error: %d", (unsigned long)streamToRelease, err);
-        gTCPReleasePending = false;
-        gStreamBeingReleased = NULL;
-        return err;
-    }
-    log_to_file_only("StartAsyncTCPRelease: Initiated async release for listener stream 0x%lX.", (unsigned long)streamToRelease);
-    return 1;
-}
+
+
+// Process data received in gTCPRecvBuffer
 static void ProcessTCPReceive(short macTCPRefNum) {
     char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN];
+    char senderIPStrFromPayload[INET_ADDRSTRLEN]; // Parsed from message
     char senderUsername[32];
     char msgType[32];
     char content[BUFFER_SIZE];
     unsigned short dataLength;
+
+    // Define the callbacks structure for the shared logic
     static tcp_platform_callbacks_t mac_callbacks = {
         .add_or_update_peer = mac_tcp_add_or_update_peer,
         .display_text_message = mac_tcp_display_text_message,
         .mark_peer_inactive = mac_tcp_mark_peer_inactive
     };
+
+    // Sanity checks
     if (!gIsConnectionActive || gTCPListenStream == NULL) {
         log_message("Warning (ProcessTCPReceive): Called when connection not active or listener stream is NULL.");
         return;
     }
+    // Ensure the completed PB matches the listener stream
     if (gTCPRecvPB.tcpStream != gTCPListenStream) {
         log_message("CRITICAL Warning (ProcessTCPReceive): Received data for unexpected stream 0x%lX, expected 0x%lX. Ignoring and closing.",
                     (unsigned long)gTCPRecvPB.tcpStream, (unsigned long)gTCPListenStream);
-        gIsConnectionActive = false;
-        gCurrentConnectionIP = 0;
-        gCurrentConnectionPort = 0;
-        StartAsyncTCPClose(macTCPRefNum, gTCPListenStream, true);
+        StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
         return;
     }
-    dataLength = gTCPRecvPB.csParam.receive.rcvBuffLen;
+
+    dataLength = gTCPRecvPB.csParam.receive.rcvBuffLen; // Get actual bytes received
     if (dataLength > 0) {
+        // Get the sender's IP string from the connection info
         OSErr addrErr = AddrToStr(gCurrentConnectionIP, senderIPStrFromConnection);
         if (addrErr != noErr) {
+            // Fallback formatting if AddrToStr fails
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu",
                     (gCurrentConnectionIP >> 24) & 0xFF, (gCurrentConnectionIP >> 16) & 0xFF,
                     (gCurrentConnectionIP >> 8) & 0xFF, gCurrentConnectionIP & 0xFF);
             log_to_file_only("ProcessTCPReceive: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.",
                          addrErr, (unsigned long)gCurrentConnectionIP, senderIPStrFromConnection);
         }
+
+        // Parse the received data using the shared protocol function
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
+            // Successfully parsed, call the shared logic handler
             log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (Payload IP: %s).",
                        msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
-            handle_received_tcp_message(senderIPStrFromConnection,
+
+            handle_received_tcp_message(senderIPStrFromConnection, // Use IP from connection info
                                         senderUsername,
                                         msgType,
                                         content,
                                         &mac_callbacks,
-                                        NULL);
+                                        NULL); // No platform context needed here
+
+            // Check if the message requires closing the connection (e.g., QUIT)
             if (strcmp(msgType, MSG_QUIT) == 0) {
-                 log_message("Connection to %s finishing due to QUIT.", senderIPStrFromConnection);
-                 gIsConnectionActive = false;
-                 gCurrentConnectionIP = 0;
-                 gCurrentConnectionPort = 0;
-                 StartAsyncTCPClose(macTCPRefNum, gTCPListenStream, true);
-                 if(gTCPRecvPending && gTCPRecvPB.tcpStream == gTCPListenStream) {
-                     log_to_file_only("ProcessTCPReceive (QUIT): Cancelling pending receive.");
-                     PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
-                     gTCPRecvPending = false;
-                 }
+                 log_message("Connection to %s finishing due to received QUIT.", senderIPStrFromConnection);
+                 // Initiate close (abort=true since peer is quitting anyway)
+                 StartAsyncTCPClose(macTCPRefNum, true);
+                 // gIsConnectionActive is set to false inside StartAsyncTCPClose
             }
         } else {
+            // Parsing failed
             log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
+            // Consider closing connection if parsing fails repeatedly? For now, just log.
         }
     } else {
+        // Received 0 bytes - often indicates graceful close initiation by peer
         log_to_file_only("ProcessTCPReceive: Received 0 bytes. Connection likely closing.");
+        // Don't need to explicitly close here; HandleReceiveCompletion handles connectionClosing error
     }
+}
+
+
+// --- Low-Level Synchronous TCP Helpers (Copied & Adapted) ---
+
+// Creates a TCP stream synchronously.
+static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen)
+{
+    OSErr err;
+    TCPiopb pbCreate;
+
+    if (streamPtr == NULL || connectionBuffer == NULL) return paramErr;
+
+    memset(&pbCreate, 0, sizeof(TCPiopb));
+    pbCreate.ioCompletion = nil; // Synchronous
+    pbCreate.ioCRefNum = macTCPRefNum;
+    pbCreate.csCode = TCPCreate;
+    pbCreate.tcpStream = 0L; // Will be filled in by MacTCP
+    pbCreate.csParam.create.rcvBuff = connectionBuffer; // Internal buffer for MacTCP
+    pbCreate.csParam.create.rcvBuffLen = connBufferLen;
+    pbCreate.csParam.create.notifyProc = nil; // No ASR needed for sync operations
+    pbCreate.csParam.create.userDataPtr = nil;
+
+    err = PBControlSync((ParmBlkPtr)&pbCreate);
+
+    if (err == noErr) {
+        *streamPtr = pbCreate.tcpStream;
+        if (*streamPtr == NULL) {
+            log_message("Error (LowTCPCreateSync): PBControlSync succeeded but returned NULL stream.");
+            err = ioErr; // Indicate an unexpected issue
+        }
+    } else {
+        *streamPtr = NULL;
+    }
+    return err;
+}
+
+// Opens a TCP connection synchronously using TCPActiveOpen.
+static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost,
+                                      tcp_port remotePort, ip_addr *localHost, tcp_port *localPort,
+                                      GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL; // Allocate PB dynamically for sync calls using polling
+
+    if (giveTime == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) {
+        log_message("Error (LowTCPOpenConnectionSync): Failed to allocate PB.");
+        return memFullErr;
+    }
+
+    // Prepare PB for TCPActiveOpen
+    pBlock->ioCompletion = nil; // Use polling
+    pBlock->ioCRefNum = gMacTCPRefNum; // Use global driver refnum
+    pBlock->csCode = TCPActiveOpen;
+    pBlock->ioResult = 1; // Initialize ioResult to indicate pending
+    pBlock->tcpStream = streamPtr;
+    // Set ULP timeout
+    pBlock->csParam.open.ulpTimeoutValue = timeoutTicks;
+    pBlock->csParam.open.ulpTimeoutAction = AbortTrue; // Abort if timeout occurs
+    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
+    pBlock->csParam.open.commandTimeoutValue = 0; // No timeout for the command itself
+    // Set remote host and port
+    pBlock->csParam.open.remoteHost = remoteHost;
+    pBlock->csParam.open.remotePort = remotePort;
+    // Let MacTCP choose local port and IP
+    pBlock->csParam.open.localPort = 0;
+    pBlock->csParam.open.localHost = 0;
+
+    // Issue async call and poll for completion
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_message("Error (LowTCPOpenConnectionSync): PBControlAsync failed immediately: %d", err);
+        DisposePtr((Ptr)pBlock);
+        return err;
+    }
+
+    // Poll ioResult until it's <= 0 (completed or error)
+    while (pBlock->ioResult > 0) {
+        giveTime(); // Yield to other processes
+    }
+
+    err = pBlock->ioResult; // Get final result
+
+    // If successful, optionally return assigned local host/port
+    if (err == noErr) {
+        if (localHost) *localHost = pBlock->csParam.open.localHost;
+        if (localPort) *localPort = pBlock->csParam.open.localPort;
+    }
+
+    DisposePtr((Ptr)pBlock); // Clean up allocated PB
+    return err;
+}
+
+// Sends data synchronously using TCPSend.
+static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent,
+                            Ptr wdsPtr, GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL;
+
+    if (giveTime == NULL || wdsPtr == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) {
+        log_message("Error (LowTCPSendSync): Failed to allocate PB.");
+        return memFullErr;
+    }
+
+    // Prepare PB for TCPSend
+    pBlock->ioCompletion = nil; // Use polling
+    pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->csCode = TCPSend;
+    pBlock->ioResult = 1; // Indicate pending
+    pBlock->tcpStream = streamPtr;
+    // Set ULP timeout
+    pBlock->csParam.send.ulpTimeoutValue = timeoutTicks;
+    pBlock->csParam.send.ulpTimeoutAction = AbortTrue;
+    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
+    // Set send flags and data pointer
+    pBlock->csParam.send.pushFlag = push;
+    pBlock->csParam.send.urgentFlag = urgent;
+    pBlock->csParam.send.wdsPtr = wdsPtr; // Pointer to Write Data Structure array
+
+    // Issue async call and poll for completion
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_message("Error (LowTCPSendSync): PBControlAsync failed immediately: %d", err);
+        DisposePtr((Ptr)pBlock);
+        return err;
+    }
+
+    // Poll ioResult
+    while (pBlock->ioResult > 0) {
+        giveTime();
+    }
+
+    err = pBlock->ioResult; // Get final result
+    DisposePtr((Ptr)pBlock); // Clean up PB
+    return err;
+}
+
+// Aborts a TCP connection synchronously using TCPAbort.
+static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL;
+
+    if (giveTime == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) {
+        log_message("Error (LowTCPAbortSync): Failed to allocate PB.");
+        return memFullErr;
+    }
+
+    // Prepare PB for TCPAbort
+    pBlock->ioCompletion = nil; // Use polling
+    pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->csCode = TCPAbort;
+    pBlock->ioResult = 1; // Indicate pending
+    pBlock->tcpStream = streamPtr;
+
+    // Issue async call and poll for completion
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        // Abort might fail if connection doesn't exist, often not critical
+        log_to_file_only("Info (LowTCPAbortSync): PBControlAsync failed immediately: %d", err);
+        // Don't necessarily return error here unless it's unexpected
+        if (err != connectionDoesntExist && err != invalidStreamPtr) {
+             log_message("Warning (LowTCPAbortSync): Unexpected immediate error: %d", err);
+        }
+        DisposePtr((Ptr)pBlock);
+        // Return noErr generally, as abort is best-effort cleanup
+        return noErr; // Or return err if strict error checking needed
+    }
+
+    // Poll ioResult
+    while (pBlock->ioResult > 0) {
+        giveTime();
+    }
+
+    err = pBlock->ioResult; // Get final result
+    if (err != noErr && err != connectionDoesntExist && err != invalidStreamPtr) {
+         log_message("Warning (LowTCPAbortSync): Abort completed with error: %d", err);
+    }
+
+    DisposePtr((Ptr)pBlock); // Clean up PB
+    // Return noErr generally for abort
+    return noErr; // Or return err if strict error checking needed
+}
+
+// Releases a TCP stream synchronously using TCPRelease.
+static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr)
+{
+    OSErr err;
+    TCPiopb pbRelease;
+
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    memset(&pbRelease, 0, sizeof(TCPiopb));
+    pbRelease.ioCompletion = nil; // Synchronous
+    pbRelease.ioCRefNum = macTCPRefNum;
+    pbRelease.csCode = TCPRelease;
+    pbRelease.tcpStream = streamPtr;
+    // No csParam needed for TCPRelease
+
+    err = PBControlSync((ParmBlkPtr)&pbRelease);
+    // Release might fail if stream is invalid, log but don't halt cleanup
+    if (err != noErr && err != invalidStreamPtr) {
+         log_message("Warning (LowTCPReleaseSync): PBControlSync(TCPRelease) failed: %d", err);
+    } else if (err == invalidStreamPtr) {
+         log_to_file_only("Info (LowTCPReleaseSync): Attempted to release invalid stream 0x%lX.", (unsigned long)streamPtr);
+         err = noErr; // Treat invalid stream on release as success (it's already gone)
+    }
+    return err;
 }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,229 +1,811 @@
+//====================================
+// FILE: ./classic_mac/tcp.c
+//====================================
+
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
-#include "dialog.h"
+#include "dialog.h" // For updating UI if needed
 #include "dialog_peerlist.h"
-#include "network.h"
+#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem
 #include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
-#include <Memory.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#define kTCPRecvBufferSize 8192
-#define kTCPListenInternalBufferSize 8192
-#define kTCPSenderInternalBufferSize 2048
-#define kTCPListenRetryDelayTicks 60
-#define kShutdownConnectTimeoutTicks 180
-#define kShutdownSendTimeoutTicks 120
-#define kRuntimeConnectTimeoutTicks 300
-#define kRuntimeSendTimeoutTicks 180
-#define AbortTrue 1
+#include <Memory.h> // For NewPtrClear, DisposePtr, BlockMoveData
+#include <string.h> // For memset, strcmp, strlen
+#include <stdio.h>  // For sprintf
+#include <stdlib.h> // For size_t if needed
+#include <Events.h> // For TickCount, Delay
+#include <OSUtils.h> // For Delay
+
+// --- Constants ---
+#define kTCPRecvBufferSize 8192           // Buffer for receiving data on listener stream
+#define kTCPListenInternalBufferSize 8192 // Internal buffer for the listener stream
+#define kTCPSendInternalBufferSize 2048   // Internal buffer for temporary sender streams
+#define kTCPListenRetryDelayTicks 60      // Delay before retrying listen after certain errors
+#define kConnectTimeoutTicks 300          // Timeout for TCPActiveOpen (5 sec)
+#define kSendTimeoutTicks 180             // Timeout for TCPSend (3 sec)
+#define kCloseTimeoutTicks 120            // Timeout for TCPClose (2 sec)
+#define kQuitLoopDelayTicks 15            // Delay+Yield between QUIT sends (approx 1/4 sec)
+#define kMacTCPTimeoutErr (-23014)        // MacTCP ULP timeout error code
+#define AbortTrue 1                       // ULP Timeout Action: Abort connection
+
+// --- Globals ---
+
+// Listener Stream (for incoming connections)
 static StreamPtr gTCPListenStream = NULL;
 static Ptr gTCPListenInternalBuffer = NULL;
-static Ptr gTCPRecvBuffer = NULL;
-static TCPiopb gTCPListenPB;
-static TCPiopb gTCPRecvPB;
-static TCPiopb gTCPClosePB;
-static Boolean gTCPListenPending = false;
-static Boolean gTCPRecvPending = false;
-static Boolean gTCPClosePending = false;
-static Boolean gNeedToReListen = false;
-ip_addr gCurrentConnectionIP = 0;
-tcp_port gCurrentConnectionPort = 0;
-Boolean gIsConnectionActive = false;
-static OSErr StartAsyncTCPListen(short macTCPRefNum);
-static OSErr StartAsyncTCPRecv(short macTCPRefNum);
-static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection);
-static void ProcessTCPReceive(short macTCPRefNum);
-static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult);
-static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult);
-static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult);
+static Ptr gTCPRecvBuffer = NULL;           // Receive buffer for listener stream
+static TCPiopb gListenPB;                   // For TCPPassiveOpen
+static TCPiopb gRecvPB;                     // For TCPRcv
+static TCPiopb gClosePB;                    // For TCPClose (incoming connection)
+// static TCPiopb gListenReleasePB;         // Release is synchronous, no PB needed
+
+// Listener State Machine
+static TCPListenerState gListenerState = TCP_LSTATE_UNINITIALIZED;
+static TCPiopb *gListenPendingOpPB = NULL; // PB for the listener's current async operation
+static Boolean gNeedToListen = false;      // Flag: should start listening when idle?
+
+// Incoming connection details
+static ip_addr gPeerIP = 0;
+static tcp_port gPeerPort = 0;
+
+
+// --- Forward Declarations ---
+static OSErr StartListening(void);
+static OSErr StartRecv(void);
+static OSErr StartCloseIncoming(void); // Close the accepted incoming connection gracefully
+
+static void HandleListenComplete(OSErr ioResult);
+static void HandleRecvComplete(OSErr ioResult);
+static void HandleCloseIncomingComplete(OSErr ioResult);
+
+static void ProcessTCPReceive(void);
+static OSErr KillListenerPendingOperation(const char* callerContext);
+
+// Low-level sync helpers
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
-static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, ip_addr *localHost, tcp_port *localPort, GiveTimePtr giveTime);
-static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent, Ptr wdsPtr, GiveTimePtr giveTime);
+static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
+static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
 static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
+
+// Internal synchronous send helper using temporary stream
+static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
+                                 const char *messageBuffer, int messageLen,
+                                 SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
+                                 GiveTimePtr giveTime);
+
+
+// --- Shared Logic Callbacks (implementation unchanged) ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
     (void)platform_context;
     int addResult = AddOrUpdatePeer(ip, username);
     if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
-        if (gMainWindow != NULL && gPeerListHandle != NULL) {
-            UpdatePeerDisplayList(true);
-        }
+        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     } else if (addResult < 0) {
         log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context;
-    (void)ip;
+    (void)platform_context; (void)ip;
     char displayMsg[BUFFER_SIZE + 100];
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
-        AppendToMessagesTE(displayMsg);
-        AppendToMessagesTE("\r");
+        AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r");
         log_message("Message from %s@%s: %s", username, ip, message_content);
     } else {
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context;
-    if (!ip) return;
+    (void)platform_context; if (!ip) return;
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
-        if (gMainWindow != NULL && gPeerListHandle != NULL) {
-            UpdatePeerDisplayList(true);
-        }
+        if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     }
 }
-OSErr InitTCPListener(short macTCPRefNum) {
+
+// --- Public Functions ---
+
+OSErr InitTCP(short macTCPRefNum) {
     OSErr err;
-    StreamPtr tempListenStream = NULL;
+    // Only initialize Listener stream here
     log_message("Initializing TCP Listener Stream...");
     if (macTCPRefNum == 0) return paramErr;
-    if (gTCPListenStream != NULL) {
-        log_message("Error (InitTCPListener): Already initialized?");
+    if (gTCPListenStream != NULL || gListenerState != TCP_LSTATE_UNINITIALIZED) {
+        log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gListenerState);
         return streamAlreadyOpen;
     }
+
+    // Allocate Listener buffers
     gTCPListenInternalBuffer = NewPtrClear(kTCPListenInternalBufferSize);
-     if (gTCPListenInternalBuffer == NULL) {
-        log_message("Fatal Error: Could not allocate TCP listen internal buffer (%ld bytes).", (long)kTCPListenInternalBufferSize);
-        return memFullErr;
-    }
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
-    if (gTCPRecvBuffer == NULL) {
-        log_message("Fatal Error: Could not allocate TCP receive buffer (%ld bytes).", (long)kTCPRecvBufferSize);
-        DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
+
+    if (gTCPListenInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
+        log_message("Fatal Error: Could not allocate Listener TCP buffers.");
+        if (gTCPListenInternalBuffer) DisposePtr(gTCPListenInternalBuffer);
+        if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer);
+        gTCPListenInternalBuffer = gTCPRecvBuffer = NULL;
         return memFullErr;
     }
-    log_message("Allocated TCP buffers (ListenInternal: %ld, Recv: %ld).",
+    log_message("Allocated Listener TCP buffers (Internal: %ld, Recv: %ld).",
                 (long)kTCPListenInternalBufferSize, (long)kTCPRecvBufferSize);
+
+    // Create Listener Stream
     log_message("Creating Listener Stream...");
-    err = LowTCPCreateSync(macTCPRefNum, &tempListenStream, gTCPListenInternalBuffer, kTCPListenInternalBufferSize);
-    if (err != noErr || tempListenStream == NULL) {
+    err = LowTCPCreateSync(macTCPRefNum, &gTCPListenStream, gTCPListenInternalBuffer, kTCPListenInternalBufferSize);
+    if (err != noErr || gTCPListenStream == NULL) {
         log_message("Error: Failed to create Listener Stream: %d", err);
-        CleanupTCPListener(macTCPRefNum);
+        CleanupTCP(macTCPRefNum); // Clean up allocated buffers
         return err;
     }
-    gTCPListenStream = tempListenStream;
-    log_message("Listener Stream created successfully (StreamPtr: 0x%lX).", (unsigned long)gTCPListenStream);
-    gNeedToReListen = false;
-    gIsConnectionActive = false;
-    gTCPListenPending = false;
-    gTCPRecvPending = false;
-    gTCPClosePending = false;
-    err = StartAsyncTCPListen(macTCPRefNum);
-    if (err != noErr && err != 1) {
+    log_message("Listener Stream created (0x%lX).", (unsigned long)gTCPListenStream);
+
+    // Initialize state
+    gListenerState = TCP_LSTATE_IDLE;
+    gListenPendingOpPB = NULL;
+    gNeedToListen = true; // Start by wanting to listen
+
+    // Initiate the first listen
+    err = StartListening();
+    if (err != noErr && err != 1) { // 1 means pending
          log_message("Error: Failed to start initial async TCP listen: %d. Cleaning up.", err);
-         CleanupTCPListener(macTCPRefNum);
+         CleanupTCP(macTCPRefNum);
          return err;
     }
+
     log_message("Initial asynchronous TCP listen STARTING on port %d.", PORT_TCP);
     return noErr;
 }
-void CleanupTCPListener(short macTCPRefNum) {
-    OSErr relErr;
-    log_message("Cleaning up TCP Listener Stream...");
+
+void CleanupTCP(short macTCPRefNum) {
+    OSErr killErr = noErr;
+    log_message("Cleaning up TCP Listener Stream..."); // Only listener now
+
+    // --- Cleanup Listener Stream ---
     StreamPtr listenStreamToRelease = gTCPListenStream;
-    gTCPListenStream = NULL;
-    if (gTCPListenPending && gTCPListenPB.tcpStream == listenStreamToRelease) {
-        PBKillIO((ParmBlkPtr)&gTCPListenPB, false);
-        log_to_file_only("CleanupTCPListener: Killed pending Listen IO.");
+    gTCPListenStream = NULL; // Prevent further use
+
+    // Kill pending listener operation
+    if (gListenPendingOpPB != NULL) {
+        log_message("Cleanup: Killing pending listener operation (State: %d)...", gListenerState);
+        killErr = PBKillIO((ParmBlkPtr)gListenPendingOpPB, false); // Async kill
+        if (killErr != noErr) log_message("Warning: PBKillIO failed for listener: %d", killErr);
+        gListenPendingOpPB = NULL;
     }
-    if (gTCPRecvPending && gTCPRecvPB.tcpStream == listenStreamToRelease) {
-        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
-        log_to_file_only("CleanupTCPListener: Killed pending Receive IO.");
-    }
-    if (gTCPClosePending && gTCPClosePB.tcpStream == listenStreamToRelease) {
-        PBKillIO((ParmBlkPtr)&gTCPClosePB, false);
-        log_to_file_only("CleanupTCPListener: Killed pending Close IO.");
-    }
-    gTCPListenPending = false;
-    gTCPRecvPending = false;
-    gTCPClosePending = false;
-    gNeedToReListen = false;
-    gIsConnectionActive = false;
-    gCurrentConnectionIP = 0;
-    gCurrentConnectionPort = 0;
+
+    // Release listener stream synchronously
     if (listenStreamToRelease != NULL && macTCPRefNum != 0) {
-        log_message("Attempting synchronous release of listener stream 0x%lX...", (unsigned long)listenStreamToRelease);
-        relErr = LowTCPReleaseSync(macTCPRefNum, listenStreamToRelease);
-        if (relErr != noErr) {
-             log_message("Warning (CleanupTCPListener): Synchronous TCPRelease failed: %d", relErr);
-        } else {
-             log_to_file_only("CleanupTCPListener: Synchronous TCPRelease successful.");
-        }
+        log_message("Attempting sync release of listener stream 0x%lX...", (unsigned long)listenStreamToRelease);
+        OSErr relErr = LowTCPReleaseSync(macTCPRefNum, listenStreamToRelease);
+        if (relErr != noErr) log_message("Warning: Sync release failed for listener: %d", relErr);
+        else log_to_file_only("Sync release successful for listener.");
     } else if (listenStreamToRelease != NULL) {
-        log_message("Warning (CleanupTCPListener): Cannot release stream, MacTCP refnum is 0.");
+        log_message("Warning: Cannot release listener stream, MacTCP refnum is 0.");
     }
+
+    // Reset listener state
+    gListenerState = TCP_LSTATE_UNINITIALIZED;
+    gListenPendingOpPB = NULL;
+    gNeedToListen = false;
+    gPeerIP = 0; gPeerPort = 0;
+
+    // --- Dispose Buffers ---
     if (gTCPRecvBuffer != NULL) {
-        log_message("Disposing TCP receive buffer at 0x%lX.", (unsigned long)gTCPRecvBuffer);
-        DisposePtr(gTCPRecvBuffer);
-        gTCPRecvBuffer = NULL;
+        log_message("Disposing TCP receive buffer.");
+        DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL;
     }
      if (gTCPListenInternalBuffer != NULL) {
-        log_message("Disposing TCP listen internal buffer at 0x%lX.", (unsigned long)gTCPListenInternalBuffer);
-        DisposePtr(gTCPListenInternalBuffer);
-        gTCPListenInternalBuffer = NULL;
+        log_message("Disposing TCP listener internal buffer.");
+        DisposePtr(gTCPListenInternalBuffer); gTCPListenInternalBuffer = NULL;
     }
-    log_message("TCP Listener Stream cleanup finished.");
+    // No sender buffer/stream to clean up here
+
+    log_message("TCP Stream cleanup finished.");
 }
-void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP) {
+
+
+void PollTCPListener(short macTCPRefNum) {
     OSErr ioResult;
-    if (gTCPListenPending) {
-        ioResult = gTCPListenPB.ioResult;
-        if (ioResult <= 0) {
-            gTCPListenPending = false;
-            HandleListenerCompletion(macTCPRefNum, ioResult);
-        }
+    TCPListenerState previousState;
+
+    // If listener stream is gone or in error state, do nothing
+    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_UNINITIALIZED || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) {
+        return;
     }
-    if (gTCPRecvPending && gIsConnectionActive) {
-        if (gTCPRecvPB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
-            ioResult = gTCPRecvPB.ioResult;
-            if (ioResult <= 0) {
-                gTCPRecvPending = false;
-                HandleReceiveCompletion(macTCPRefNum, ioResult);
-            }
-        } else if (gTCPRecvPending) {
-             log_message("Warning (PollTCPListener): Receive pending but stream pointer mismatch or NULL. Clearing flag.");
-             gTCPRecvPending = false;
-        }
+
+    // Check if we need to start listening
+    if (gListenPendingOpPB == NULL && gListenerState == TCP_LSTATE_IDLE && gNeedToListen) {
+        log_to_file_only("PollListener: Stream idle and needs to listen. Starting listen.");
+        StartListening(); // Ignore error, will retry on next poll if fails
+        return; // Don't check completion immediately
     }
-    if (gTCPClosePending) {
-        if (gTCPClosePB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
-            ioResult = gTCPClosePB.ioResult;
-            if (ioResult <= 0) {
-                gTCPClosePending = false;
-                HandleCloseCompletion(macTCPRefNum, ioResult);
-            }
-        } else if (gTCPClosePending) {
-             log_message("Warning (PollTCPListener): Async Close pending but stream pointer mismatch or NULL. Clearing flag.");
-             gTCPClosePending = false;
+
+    // Check if a listener operation is pending
+    if (gListenPendingOpPB != NULL) {
+        ioResult = gListenPendingOpPB->ioResult;
+
+        if (ioResult > 0) {
+            // Still pending, do nothing
+            return;
         }
-    }
-    if (gNeedToReListen && gTCPListenStream != NULL &&
-        !gTCPListenPending && !gTCPRecvPending && !gTCPClosePending && !gIsConnectionActive)
-    {
-        log_to_file_only("PollTCPListener: Conditions met to attempt re-issuing listen.");
-        gNeedToReListen = false;
-        OSErr err = StartAsyncTCPListen(macTCPRefNum);
-        if (err != noErr && err != 1) {
-            log_message("Error (PollTCPListener): Attempt to re-issue listen failed immediately. Error: %d. Will retry later.", err);
-            gNeedToReListen = true;
-        } else {
-            log_to_file_only("PollTCPListener: Re-issued Async TCPPassiveOpen successfully (or already pending).");
+
+        // --- Listener Operation Completed (Success or Error) ---
+        log_to_file_only("PollListener: Pending operation (State: %d) completed with result: %d", gListenerState, ioResult);
+
+        // Capture state *before* clearing gListenPendingOpPB and calling handler
+        previousState = gListenerState;
+        gListenPendingOpPB = NULL; // Clear pending operation pointer
+
+        // Call the appropriate handler based on the state *when the operation was started*
+        switch (previousState) {
+            case TCP_LSTATE_LISTENING:
+                HandleListenComplete(ioResult);
+                break;
+            case TCP_LSTATE_RECEIVING:
+                HandleRecvComplete(ioResult);
+                break;
+            case TCP_LSTATE_CLOSING:
+                HandleCloseIncomingComplete(ioResult);
+                break;
+            // Should not have pending ops in these states
+            case TCP_LSTATE_IDLE:
+            case TCP_LSTATE_UNINITIALIZED:
+            case TCP_LSTATE_ERROR:
+            case TCP_LSTATE_RELEASING:
+                 log_message("PollListener: CRITICAL - Operation completed but listener was in unexpected state %d!", previousState);
+                 gListenerState = TCP_LSTATE_IDLE;
+                 gNeedToListen = true;
+                break;
         }
-    } else if (gNeedToReListen && gTCPListenStream == NULL) {
-        log_message("Warning (PollTCPListener): Need to re-listen but stream is NULL. Cannot proceed.");
-        gNeedToReListen = false;
     }
 }
+
+// Public function to get listener state
+TCPListenerState GetTCPListenerState(void) {
+    return gListenerState;
+}
+
+
+// Sends a text message SYNCHRONOUSLY using a temporary stream.
+OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
+    OSErr err = noErr;
+    ip_addr targetIP = 0;
+    char messageBuffer[BUFFER_SIZE]; // Local buffer for formatted message
+    int formattedLen;
+
+    log_to_file_only("TCP_SendTextMessageSync: Attempting to send TEXT to %s", peerIP);
+
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
+
+    // Parse IP
+    err = ParseIPv4(peerIP, &targetIP);
+    if (err != noErr || targetIP == 0) {
+        log_message("Error (SendText): Could not parse peer IP '%s'.", peerIP);
+        return paramErr;
+    }
+
+    // Format message into local buffer
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT,
+                                  gMyUsername, gMyLocalIPStr, message);
+    if (formattedLen <= 0) {
+        log_message("Error (SendText): Failed to format TEXT message for %s.", peerIP);
+        return paramErr;
+    }
+
+    // Use the internal helper that manages a temporary stream
+    err = InternalSyncTCPSend(targetIP, PORT_TCP, messageBuffer, formattedLen,
+                              kConnectTimeoutTicks, kSendTimeoutTicks, giveTime);
+
+    if (err == noErr) log_message("Successfully sent TEXT message to %s.", peerIP);
+    else log_message("Failed to send TEXT message to %s (Error: %d).", peerIP, err);
+
+    return err;
+}
+
+
+// Sends QUIT messages SYNCHRONOUSLY using temporary streams with delay.
+OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
+    int i;
+    OSErr lastErr = noErr;
+    char quitMessageBuffer[BUFFER_SIZE]; // Local buffer
+    int formattedLen;
+    int activePeerCount = 0;
+    int sentCount = 0;
+    unsigned long dummyTimer; // For Delay
+
+    log_message("TCP_SendQuitMessagesSync: Starting...");
+
+    if (gMacTCPRefNum == 0) return notOpenErr;
+    if (giveTime == NULL) return paramErr;
+
+    // Format the QUIT message once
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT,
+                                  gMyUsername, gMyLocalIPStr, "");
+    if (formattedLen <= 0) {
+        log_message("Error (SendQuit): Failed to format QUIT message.");
+        return paramErr;
+    }
+
+    // Count active peers
+    for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
+    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
+    if (activePeerCount == 0) return noErr;
+
+    // Iterate through peers
+    for (i = 0; i < MAX_PEERS; ++i) {
+        if (gPeerManager.peers[i].active) {
+            ip_addr currentTargetIP = 0;
+            OSErr parseErr, sendErr;
+
+            log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s",
+                        gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
+
+            // Parse IP
+            parseErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
+            if (parseErr != noErr || currentTargetIP == 0) {
+                log_message("Error (SendQuit): Could not parse peer IP '%s'. Skipping.", gPeerManager.peers[i].ip);
+                lastErr = parseErr;
+                continue;
+            }
+
+            // Use the internal helper that manages a temporary stream
+            sendErr = InternalSyncTCPSend(currentTargetIP, PORT_TCP, quitMessageBuffer, formattedLen,
+                                          kConnectTimeoutTicks, kSendTimeoutTicks, giveTime); // Use standard timeouts
+
+            if (sendErr == noErr) {
+                log_message("Successfully sent QUIT to %s.", gPeerManager.peers[i].ip);
+                sentCount++;
+            } else {
+                log_message("Error sending QUIT to %s: %d", gPeerManager.peers[i].ip, sendErr);
+                lastErr = sendErr;
+            }
+
+            // *** ADD YIELD AND DELAY BETWEEN PEERS ***
+            log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
+            giveTime(); // Basic yield
+            Delay(kQuitLoopDelayTicks, &dummyTimer); // Add specific delay
+
+        } // end if peer active
+    } // end for loop
+
+    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
+    return lastErr;
+}
+
+
+// --- Private Listener State Machine Helpers ---
+
+// Kill the currently pending listener operation, if any.
+static OSErr KillListenerPendingOperation(const char* callerContext) {
+    OSErr killErr = noErr;
+    if (gListenPendingOpPB != NULL) {
+        TCPListenerState stateBeforeKill = gListenerState;
+        log_message("Info (%s): Attempting to kill pending listener operation (State: %d)...", callerContext, stateBeforeKill);
+
+        killErr = PBKillIO((ParmBlkPtr)gListenPendingOpPB, false); // Async kill
+
+        if (killErr == noErr) {
+            log_to_file_only("Info (%s): PBKillIO initiated successfully for listener.", callerContext);
+            // Assume kill works, clear state
+            gListenPendingOpPB = NULL;
+            gListenerState = TCP_LSTATE_IDLE;
+            return noErr;
+        } else {
+            log_message("Error (%s): PBKillIO failed immediately for listener: %d. State left as %d.", callerContext, killErr, stateBeforeKill);
+            return killErr;
+        }
+    }
+    return noErr; // Nothing to kill
+}
+
+
+// Initiate TCPPassiveOpen on the listener stream
+static OSErr StartListening(void) {
+    OSErr err;
+    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
+    if (gListenPendingOpPB != NULL || gListenerState != TCP_LSTATE_IDLE) {
+        log_to_file_only("StartListening: Cannot start, pending op exists or state (%d) not IDLE.", gListenerState);
+        return inProgress;
+    }
+
+    log_to_file_only("StartListening: Initiating TCPPassiveOpen...");
+    memset(&gListenPB, 0, sizeof(TCPiopb));
+    gListenPB.ioCompletion = nil;
+    gListenPB.ioCRefNum = gMacTCPRefNum;
+    gListenPB.csCode = TCPPassiveOpen;
+    gListenPB.tcpStream = gTCPListenStream;
+    gListenPB.csParam.open.validityFlags = 0;
+    gListenPB.csParam.open.localPort = PORT_TCP;
+    gListenPB.csParam.open.localHost = 0L;
+    gListenPB.csParam.open.remoteHost = 0L;
+    gListenPB.csParam.open.remotePort = 0;
+
+    gListenerState = TCP_LSTATE_LISTENING; // Set state *before* async call
+    gListenPendingOpPB = &gListenPB;
+    err = PBControlAsync((ParmBlkPtr)&gListenPB);
+    if (err != noErr) {
+        log_message("Error (StartListening): PBControlAsync failed immediately: %d", err);
+        gListenPendingOpPB = NULL;
+        gListenerState = TCP_LSTATE_IDLE; // Revert state
+        gNeedToListen = true; // Ensure retry
+        return err;
+    }
+    return 1; // Pending
+}
+
+// Initiate TCPRcv on the listener stream
+static OSErr StartRecv(void) {
+    OSErr err;
+    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
+    // Should be called when connection is established (state LISTENING after completion)
+     if (gListenPendingOpPB != NULL || (gListenerState != TCP_LSTATE_LISTENING && gListenerState != TCP_LSTATE_RECEIVING)) {
+        log_message("StartRecv: Cannot start, pending op exists or state (%d) invalid.", gListenerState);
+        return (gListenPendingOpPB != NULL) ? inProgress : paramErr;
+    }
+     if (gTCPRecvBuffer == NULL) return invalidBufPtr;
+
+    log_to_file_only("StartRecv: Initiating TCPRcv...");
+    memset(&gRecvPB, 0, sizeof(TCPiopb));
+    gRecvPB.ioCompletion = nil;
+    gRecvPB.ioCRefNum = gMacTCPRefNum;
+    gRecvPB.csCode = TCPRcv;
+    gRecvPB.tcpStream = gTCPListenStream;
+    gRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;
+    gRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize;
+    gRecvPB.csParam.receive.commandTimeoutValue = 0;
+
+    gListenerState = TCP_LSTATE_RECEIVING; // Set state *before* async call
+    gListenPendingOpPB = &gRecvPB;
+    err = PBControlAsync((ParmBlkPtr)&gRecvPB);
+    if (err != noErr) {
+        log_message("Error (StartRecv): PBControlAsync failed immediately: %d", err);
+        gListenPendingOpPB = NULL;
+        gListenerState = TCP_LSTATE_IDLE; // Revert state? Or CLOSING? Go IDLE.
+        gNeedToListen = true;
+        return err;
+    }
+    return 1; // Pending
+}
+
+// Initiate TCPClose on the listener stream (for incoming connection)
+static OSErr StartCloseIncoming(void) {
+    OSErr err;
+    if (gTCPListenStream == NULL || gListenerState == TCP_LSTATE_ERROR || gListenerState == TCP_LSTATE_RELEASING) return invalidStreamPtr;
+    // Can be called after Recv error or processing QUIT
+
+    // Kill pending Recv if any
+    err = KillListenerPendingOperation("StartCloseIncoming");
+    if (err != noErr) {
+        log_message("Error (StartCloseIncoming): Failed to kill prior operation (%d). Cannot initiate close.", err);
+        gListenerState = TCP_LSTATE_ERROR;
+        return err;
+    }
+    // State should now be IDLE
+
+    log_to_file_only("StartCloseIncoming: Initiating TCPClose (graceful)...");
+    memset(&gClosePB, 0, sizeof(TCPiopb));
+    gClosePB.ioCompletion = nil;
+    gClosePB.ioCRefNum = gMacTCPRefNum;
+    gClosePB.csCode = TCPClose;
+    gClosePB.tcpStream = gTCPListenStream;
+    gClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction;
+    gClosePB.csParam.close.ulpTimeoutValue = kCloseTimeoutTicks;
+    gClosePB.csParam.close.ulpTimeoutAction = AbortTrue; // Abort if close times out
+
+    gListenerState = TCP_LSTATE_CLOSING; // Set state *before* async call
+    gListenPendingOpPB = &gClosePB;
+    err = PBControlAsync((ParmBlkPtr)&gClosePB);
+    if (err != noErr) {
+        log_message("Error (StartCloseIncoming): PBControlAsync failed immediately: %d. Assuming closed.", err);
+        gListenPendingOpPB = NULL;
+        gListenerState = TCP_LSTATE_IDLE; // Revert state to IDLE
+        gNeedToListen = true; // Try listening again
+        return noErr; // Goal (closed) likely achieved
+    }
+    return 1; // Pending
+}
+
+// --- Listener State Completion Handlers ---
+
+static void HandleListenComplete(OSErr ioResult) {
+    if (ioResult == noErr) {
+        // Connection indication received
+        gPeerIP = gListenPB.csParam.open.remoteHost;
+        gPeerPort = gListenPB.csParam.open.remotePort;
+        char senderIPStr[INET_ADDRSTRLEN];
+        AddrToStr(gPeerIP, senderIPStr);
+        log_message("HandleListenComplete: Connection Indication from %s:%u.", senderIPStr, gPeerPort);
+
+        // Start receiving data
+        OSErr err = StartRecv();
+        if (err != noErr && err != 1) { // 1=pending
+            log_message("Error (HandleListenComplete): Failed to start receive: %d. Closing incoming.", err);
+            StartCloseIncoming(); // Close gracefully
+        }
+        // State is now RECEIVING (set by StartRecv) or CLOSING
+    } else {
+        // Handle errors
+        const char *errMsg = "Unknown Error";
+        Boolean isConnectionExists = (ioResult == connectionExists);
+        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
+        Boolean isReqAborted = (ioResult == reqAborted);
+        if (isConnectionExists) errMsg = "connectionExists (-23007)";
+        else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
+        else if (isReqAborted) errMsg = "reqAborted (-23015)";
+
+        if (isReqAborted) {
+             log_to_file_only("HandleListenComplete: Listen aborted (result %d).", ioResult);
+             gListenerState = TCP_LSTATE_IDLE; // Ensure state is IDLE
+        } else {
+            log_message("Error (HandleListenComplete): TCPPassiveOpen failed: %d (%s)", ioResult, errMsg);
+            gListenerState = TCP_LSTATE_IDLE; // Go back to idle
+            if (isInvalidStream) {
+                 log_message("CRITICAL: Listener Stream invalid. Setting state to ERROR.");
+                 gListenerState = TCP_LSTATE_ERROR;
+                 gNeedToListen = false;
+            } else {
+                 gNeedToListen = true; // Try listening again later
+                 if (isConnectionExists) {
+                     unsigned long dummyTimer;
+                     Delay(kTCPListenRetryDelayTicks, &dummyTimer);
+                 }
+            }
+        }
+    }
+}
+
+static void HandleRecvComplete(OSErr ioResult) {
+     if (ioResult == noErr) {
+        // Data received successfully
+        ProcessTCPReceive(); // Process data in gTCPRecvBuffer
+
+        // If ProcessTCPReceive didn't trigger a close, start next receive
+        if (gListenerState == TCP_LSTATE_RECEIVING) { // Check state hasn't changed
+            OSErr err = StartRecv();
+             if (err != noErr && err != 1) {
+                 log_message("Error (HandleRecvComplete): Failed to start next receive: %d. Closing.", err);
+                 StartCloseIncoming();
+             }
+             // State remains RECEIVING (set by StartRecv) or CLOSING
+        } else {
+             log_to_file_only("HandleRecvComplete: State changed during processing (now %d). Not starting new receive.", gListenerState);
+        }
+    } else if (ioResult == connectionClosing) {
+         // Peer initiated graceful close
+         char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+         log_message("HandleRecvComplete: Connection closing gracefully from %s.", peerIPStr);
+         ProcessTCPReceive(); // Process any final data
+         gListenerState = TCP_LSTATE_IDLE; // Go back to idle
+         gNeedToListen = true; // Listen again
+    } else {
+         // Handle receive errors
+         char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+         const char *errMsg = "Unknown Error";
+         Boolean isConnTerminated = (ioResult == connectionTerminated);
+         Boolean isInvalidStream = (ioResult == invalidStreamPtr);
+         Boolean isReqAborted = (ioResult == reqAborted);
+         if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
+         else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
+         else if (isReqAborted) errMsg = "reqAborted (-23015)";
+
+        if (isReqAborted) {
+            log_to_file_only("HandleRecvComplete: Receive aborted (result %d).", ioResult);
+            gListenerState = TCP_LSTATE_IDLE;
+        } else {
+            log_message("Error (HandleRecvComplete): Receive failed from %s: %d (%s).", peerIPStr, ioResult, errMsg);
+            if (isInvalidStream) {
+                 log_message("CRITICAL: Listener Stream invalid. Setting state to ERROR.");
+                 gListenerState = TCP_LSTATE_ERROR;
+                 gNeedToListen = false;
+            } else {
+                 // For other errors (like terminated), close our end gracefully
+                 StartCloseIncoming();
+                 // State is now CLOSING
+            }
+        }
+    }
+}
+
+static void HandleCloseIncomingComplete(OSErr ioResult) {
+    // Graceful close of incoming connection completed (or failed)
+    if (ioResult == noErr) {
+        log_to_file_only("HandleCloseIncomingComplete: Graceful close completed.");
+    } else {
+        log_message("Warning (HandleCloseIncomingComplete): Graceful close failed: %d", ioResult);
+    }
+    gListenerState = TCP_LSTATE_IDLE; // Connection is closed, return to idle
+    gNeedToListen = true; // Try listening again
+}
+
+
+// Process data received in gTCPRecvBuffer
+static void ProcessTCPReceive(void) {
+    char senderIPStrFromConnection[INET_ADDRSTRLEN];
+    char senderIPStrFromPayload[INET_ADDRSTRLEN];
+    char senderUsername[32];
+    char msgType[32];
+    char content[BUFFER_SIZE];
+    unsigned short dataLength;
+
+    static tcp_platform_callbacks_t mac_callbacks = {
+        .add_or_update_peer = mac_tcp_add_or_update_peer,
+        .display_text_message = mac_tcp_display_text_message,
+        .mark_peer_inactive = mac_tcp_mark_peer_inactive
+    };
+
+    // Use the static gRecvPB directly here.
+    dataLength = gRecvPB.csParam.receive.rcvBuffLen;
+
+    if (dataLength > 0) {
+        OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
+        if (addrErr != noErr) {
+            sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
+            log_to_file_only("ProcessTCPReceive: AddrToStr failed (%d). Using fallback '%s'.", addrErr, senderIPStrFromConnection);
+        }
+
+        if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
+            log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection);
+            handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL);
+
+            // If QUIT received, initiate close immediately
+            if (strcmp(msgType, MSG_QUIT) == 0) {
+                 log_message("ProcessTCPReceive: QUIT received from %s. Initiating close.", senderIPStrFromConnection);
+                 StartCloseIncoming(); // Close gracefully
+            }
+        } else {
+            log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
+        }
+    } else {
+        log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing).");
+    }
+}
+
+
+// --- Low-Level Synchronous TCP Helpers ---
+
+// Creates a TCP stream synchronously. (Unchanged)
+static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen)
+{
+    OSErr err; TCPiopb pbCreate;
+    if (streamPtr == NULL || connectionBuffer == NULL) return paramErr;
+    memset(&pbCreate, 0, sizeof(TCPiopb));
+    pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum;
+    pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L;
+    pbCreate.csParam.create.rcvBuff = connectionBuffer;
+    pbCreate.csParam.create.rcvBuffLen = connBufferLen;
+    pbCreate.csParam.create.notifyProc = nil;
+    err = PBControlSync((ParmBlkPtr)&pbCreate);
+    if (err == noErr) {
+        *streamPtr = pbCreate.tcpStream;
+        if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): NULL stream."); err = ioErr; }
+    } else { *streamPtr = NULL; }
+    return err;
+}
+
+// Opens a TCP connection synchronously using TCPActiveOpen.
+// Uses polling with giveTime.
+static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL;
+
+    if (giveTime == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) { log_message("Error (LowTCPOpenConnectionSync): Failed alloc PB."); return memFullErr; }
+
+    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->csCode = TCPActiveOpen; pBlock->ioResult = 1;
+    pBlock->tcpStream = streamPtr;
+    pBlock->csParam.open.ulpTimeoutValue = timeoutTicks;
+    pBlock->csParam.open.ulpTimeoutAction = AbortTrue;
+    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction;
+    pBlock->csParam.open.commandTimeoutValue = 0;
+    pBlock->csParam.open.remoteHost = remoteHost;
+    pBlock->csParam.open.remotePort = remotePort;
+    pBlock->csParam.open.localPort = 0; pBlock->csParam.open.localHost = 0;
+
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_message("Error (LowTCPOpenConnectionSync): PBControlAsync failed: %d", err);
+        DisposePtr((Ptr)pBlock); return err;
+    }
+    while (pBlock->ioResult > 0) { giveTime(); } // Poll
+    err = pBlock->ioResult;
+    DisposePtr((Ptr)pBlock);
+    return err;
+}
+
+// Sends data synchronously using TCPSend.
+// Uses polling with giveTime.
+static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL;
+
+    if (giveTime == NULL || wdsPtr == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) { log_message("Error (LowTCPSendSync): Failed alloc PB."); return memFullErr; }
+
+    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->csCode = TCPSend; pBlock->ioResult = 1;
+    pBlock->tcpStream = streamPtr;
+    pBlock->csParam.send.ulpTimeoutValue = timeoutTicks;
+    pBlock->csParam.send.ulpTimeoutAction = AbortTrue;
+    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction;
+    pBlock->csParam.send.pushFlag = push;
+    pBlock->csParam.send.urgentFlag = false; // Assuming not urgent
+    pBlock->csParam.send.wdsPtr = wdsPtr;
+
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_message("Error (LowTCPSendSync): PBControlAsync failed: %d", err);
+        DisposePtr((Ptr)pBlock); return err;
+    }
+    while (pBlock->ioResult > 0) { giveTime(); } // Poll
+    err = pBlock->ioResult;
+    DisposePtr((Ptr)pBlock);
+    return err;
+}
+
+// Aborts a TCP connection synchronously using TCPAbort.
+// Uses polling with giveTime.
+static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime)
+{
+    OSErr err;
+    TCPiopb *pBlock = NULL;
+
+    if (giveTime == NULL) return paramErr;
+    if (streamPtr == NULL) return invalidStreamPtr;
+
+    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
+    if (pBlock == NULL) { log_message("Error (LowTCPAbortSync): Failed alloc PB."); return memFullErr; }
+
+    pBlock->ioCompletion = nil; pBlock->ioCRefNum = gMacTCPRefNum;
+    pBlock->csCode = TCPAbort; pBlock->ioResult = 1;
+    pBlock->tcpStream = streamPtr;
+
+    err = PBControlAsync((ParmBlkPtr)pBlock);
+    if (err != noErr) {
+        log_to_file_only("Info (LowTCPAbortSync): PBControlAsync failed: %d", err);
+        DisposePtr((Ptr)pBlock);
+        // Return noErr generally, as abort is best-effort cleanup
+        return (err == connectionDoesntExist || err == invalidStreamPtr) ? noErr : err;
+    }
+    while (pBlock->ioResult > 0) { giveTime(); } // Poll
+    err = pBlock->ioResult;
+    if (err != noErr && err != connectionDoesntExist && err != invalidStreamPtr) {
+         log_message("Warning (LowTCPAbortSync): Abort completed with error: %d", err);
+    }
+    DisposePtr((Ptr)pBlock);
+    // Return noErr generally for abort, unless unexpected error occurred
+    return (err == connectionDoesntExist || err == invalidStreamPtr || err == noErr) ? noErr : err;
+}
+
+// Releases a TCP stream synchronously. (Unchanged)
+static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr)
+{
+    OSErr err; TCPiopb pbRelease;
+    if (streamPtr == NULL) return invalidStreamPtr;
+    memset(&pbRelease, 0, sizeof(TCPiopb));
+    pbRelease.ioCompletion = nil; pbRelease.ioCRefNum = macTCPRefNum;
+    pbRelease.csCode = TCPRelease; pbRelease.tcpStream = streamPtr;
+    err = PBControlSync((ParmBlkPtr)&pbRelease);
+    if (err != noErr && err != invalidStreamPtr) { log_message("Warning (LowTCPReleaseSync): Failed: %d", err); }
+    else if (err == invalidStreamPtr) { log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid.", (unsigned long)streamPtr); err = noErr; }
+    return err;
+}
+
+// Internal function to perform a complete synchronous send operation using a temporary stream
 static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
                                  const char *messageBuffer, int messageLen,
                                  SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
@@ -234,642 +816,69 @@ static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
     StreamPtr tempStream = NULL;
     Ptr tempConnBuffer = NULL;
     struct wdsEntry sendWDS[2];
+
     log_to_file_only("InternalSyncTCPSend: To IP %lu:%u (%d bytes)", (unsigned long)targetIP, targetPort, messageLen);
-    tempConnBuffer = NewPtrClear(kTCPSenderInternalBufferSize);
+
+    // 1. Allocate temporary buffer for the temporary stream
+    tempConnBuffer = NewPtrClear(kTCPSendInternalBufferSize);
     if (tempConnBuffer == NULL) {
         log_message("Error (InternalSyncTCPSend): Failed to allocate temporary connection buffer.");
         return memFullErr;
     }
-    err = LowTCPCreateSync(gMacTCPRefNum, &tempStream, tempConnBuffer, kTCPSenderInternalBufferSize);
+
+    // 2. Create temporary stream
+    err = LowTCPCreateSync(gMacTCPRefNum, &tempStream, tempConnBuffer, kTCPSendInternalBufferSize);
     if (err != noErr || tempStream == NULL) {
         log_message("Error (InternalSyncTCPSend): LowTCPCreateSync failed: %d", err);
-        DisposePtr(tempConnBuffer);
+        DisposePtr(tempConnBuffer); // Clean up buffer
         return err;
     }
     log_to_file_only("InternalSyncTCPSend: Temp stream 0x%lX created.", (unsigned long)tempStream);
+
+    // 3. Connect using the temporary stream
     log_to_file_only("InternalSyncTCPSend: Connecting temp stream 0x%lX...", (unsigned long)tempStream);
-    err = LowTCPOpenConnectionSync(tempStream, connectTimeoutTicks, targetIP, targetPort, NULL, NULL, giveTime);
+    err = LowTCPOpenConnectionSync(tempStream, connectTimeoutTicks, targetIP, targetPort, giveTime);
     if (err == noErr) {
         log_to_file_only("InternalSyncTCPSend: Connected successfully.");
+
+        // 4. Send data
         sendWDS[0].length = messageLen;
-        sendWDS[0].ptr = (Ptr)messageBuffer;
-        sendWDS[1].length = 0;
-        sendWDS[1].ptr = NULL;
+        sendWDS[0].ptr = (Ptr)messageBuffer; // Cast away const, WDS expects Ptr
+        sendWDS[1].length = 0; sendWDS[1].ptr = NULL; // Terminator for WDS array
+
         log_to_file_only("InternalSyncTCPSend: Sending data...");
-        err = LowTCPSendSync(tempStream, sendTimeoutTicks, true, false, (Ptr)sendWDS, giveTime);
+        err = LowTCPSendSync(tempStream, sendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
         if (err == noErr) {
             log_to_file_only("InternalSyncTCPSend: Send successful.");
         } else {
             log_message("Error (InternalSyncTCPSend): LowTCPSendSync failed: %d", err);
-            finalErr = err;
+            finalErr = err; // Record send error
         }
+
+        // 5. Abort connection (no need for graceful close for one-shot send)
         log_to_file_only("InternalSyncTCPSend: Aborting connection...");
         OSErr abortErr = LowTCPAbortSync(tempStream, giveTime);
         if (abortErr != noErr) {
             log_message("Warning (InternalSyncTCPSend): LowTCPAbortSync failed: %d", abortErr);
-            if (finalErr == noErr) finalErr = abortErr;
+            if (finalErr == noErr) finalErr = abortErr; // Record abort error if no prior error
         }
+
     } else {
         log_message("Error (InternalSyncTCPSend): LowTCPOpenConnectionSync failed: %d", err);
-        finalErr = err;
+        finalErr = err; // Record connect error
     }
+
+    // 6. Release the temporary stream (regardless of errors)
     log_to_file_only("InternalSyncTCPSend: Releasing temp stream 0x%lX...", (unsigned long)tempStream);
     OSErr releaseErr = LowTCPReleaseSync(gMacTCPRefNum, tempStream);
     if (releaseErr != noErr) {
         log_message("Warning (InternalSyncTCPSend): LowTCPReleaseSync failed: %d", releaseErr);
-        if (finalErr == noErr) finalErr = releaseErr;
+        if (finalErr == noErr) finalErr = releaseErr; // Record release error if no prior error
     }
+
+    // 7. Dispose the temporary connection buffer
     DisposePtr(tempConnBuffer);
+
     log_to_file_only("InternalSyncTCPSend: Finished. Final status: %d", finalErr);
     return finalErr;
-}
-OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
-    OSErr err = noErr;
-    ip_addr targetIP = 0;
-    char messageBuffer[BUFFER_SIZE];
-    int formattedLen;
-    log_to_file_only("TCP_SendTextMessageSync: Attempting to send TEXT to %s", peerIP);
-    if (gMacTCPRefNum == 0) {
-        log_message("Error (TCP_SendTextMessageSync): MacTCP not initialized.");
-        return notOpenErr;
-    }
-    if (peerIP == NULL || message == NULL || giveTime == NULL) {
-        return paramErr;
-    }
-    err = ParseIPv4(peerIP, &targetIP);
-    if (err != noErr || targetIP == 0) {
-        log_message("Error (TCP_SendTextMessageSync): Could not parse peer IP string '%s'.", peerIP);
-        return paramErr;
-    }
-    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT,
-                                  gMyUsername, gMyLocalIPStr, message);
-    if (formattedLen <= 0) {
-        log_message("Error (TCP_SendTextMessageSync): Failed to format TEXT message for %s.", peerIP);
-        return paramErr;
-    }
-    err = InternalSyncTCPSend(targetIP, PORT_TCP, messageBuffer, formattedLen,
-                              kRuntimeConnectTimeoutTicks, kRuntimeSendTimeoutTicks, giveTime);
-    if (err == noErr) {
-        log_message("Successfully sent TEXT message to %s.", peerIP);
-    } else {
-        log_message("Failed to send TEXT message to %s (Error: %d).", peerIP, err);
-    }
-    return err;
-}
-OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
-    int i;
-    OSErr lastErr = noErr;
-    char quitMessageBuffer[BUFFER_SIZE];
-    int formattedLen;
-    int activePeerCount = 0;
-    int sentCount = 0;
-    log_message("TCP_SendQuitMessagesSync: Starting...");
-    if (gMacTCPRefNum == 0) {
-        log_message("TCP_SendQuitMessagesSync: Cannot send, MacTCP not initialized.");
-        return notOpenErr;
-    }
-     if (giveTime == NULL) {
-        return paramErr;
-    }
-    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT,
-                                  gMyUsername, gMyLocalIPStr, "");
-    if (formattedLen <= 0) {
-        log_message("Error (TCP_SendQuitMessagesSync): Failed to format QUIT message.");
-        return paramErr;
-    }
-    for (i = 0; i < MAX_PEERS; ++i) {
-        if (gPeerManager.peers[i].active) {
-            activePeerCount++;
-        }
-    }
-    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
-    for (i = 0; i < MAX_PEERS; ++i) {
-        if (gPeerManager.peers[i].active) {
-            ip_addr targetIP = 0;
-            OSErr parseErr, sendErr;
-            log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s",
-                        gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-            parseErr = ParseIPv4(gPeerManager.peers[i].ip, &targetIP);
-            if (parseErr != noErr || targetIP == 0) {
-                log_message("Error: Could not parse peer IP string '%s'. Skipping.", gPeerManager.peers[i].ip);
-                lastErr = parseErr;
-                continue;
-            }
-            sendErr = InternalSyncTCPSend(targetIP, PORT_TCP, quitMessageBuffer, formattedLen,
-                                          kShutdownConnectTimeoutTicks, kShutdownSendTimeoutTicks, giveTime);
-            if (sendErr == noErr) {
-                log_message("Successfully sent QUIT to %s.", gPeerManager.peers[i].ip);
-                sentCount++;
-            } else {
-                log_message("Error sending QUIT to %s: %d", gPeerManager.peers[i].ip, sendErr);
-                lastErr = sendErr;
-            }
-            giveTime();
-        }
-    }
-    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers.", sentCount, activePeerCount);
-    return lastErr;
-}
-static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult) {
-    StreamPtr completedListenerStream = gTCPListenPB.tcpStream;
-    if (completedListenerStream != gTCPListenStream || gTCPListenStream == NULL) {
-        log_message("Warning (HandleListenerCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
-                    (unsigned long)completedListenerStream, (unsigned long)gTCPListenStream);
-        return;
-    }
-    if (ioResult == noErr) {
-        ip_addr acceptedIP = gTCPListenPB.csParam.open.remoteHost;
-        tcp_port acceptedPort = gTCPListenPB.csParam.open.remotePort;
-        char senderIPStr[INET_ADDRSTRLEN];
-        AddrToStr(acceptedIP, senderIPStr);
-        log_message("TCP Connection Indication from %s:%u on listener stream 0x%lX.",
-                    senderIPStr, acceptedPort, (unsigned long)completedListenerStream);
-        if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
-             log_message("Warning: New connection indication while listener stream busy (Active: %d, RecvPending: %d, ClosePending: %d). Setting flag to re-listen later.",
-                         gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-             gNeedToReListen = true;
-        } else {
-            gCurrentConnectionIP = acceptedIP;
-            gCurrentConnectionPort = acceptedPort;
-            gIsConnectionActive = true;
-            OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-            if (err != noErr && err != 1) {
-                log_message("Error (HandleListenerCompletion): Failed to start first TCPRcv on listener stream. Error: %d. Closing connection state.", err);
-                gIsConnectionActive = false;
-                gCurrentConnectionIP = 0;
-                gCurrentConnectionPort = 0;
-                gNeedToReListen = true;
-            } else {
-                 log_to_file_only("HandleListenerCompletion: First TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-            }
-        }
-    } else {
-        const char *errMsg = "Unknown Error";
-        Boolean isConnectionExists = (ioResult == connectionExists);
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-        Boolean isReqAborted = (ioResult == reqAborted);
-        if (isConnectionExists) errMsg = "connectionExists (-23007)";
-        else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-        else if (isReqAborted) errMsg = "reqAborted (-23015)";
-        if (isConnectionExists) {
-             log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with transient error: %d (%s). Will retry after delay.", ioResult, errMsg);
-             unsigned long dummyTimer;
-             Delay(kTCPListenRetryDelayTicks, &dummyTimer);
-             gNeedToReListen = true;
-        } else if (isReqAborted) {
-             log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
-        } else {
-            log_message("Error (HandleListenerCompletion): TCPPassiveOpen completed with error: %d (%s)", ioResult, errMsg);
-            if (isInvalidStream) {
-                 log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid. It will be cleaned up.", (unsigned long)gTCPListenStream);
-                 gTCPListenStream = NULL;
-                 gNeedToReListen = false;
-            } else {
-                 gNeedToReListen = true;
-            }
-        }
-    }
-}
-static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult) {
-    StreamPtr completedRecvStream = gTCPRecvPB.tcpStream;
-    if (completedRecvStream != gTCPListenStream || gTCPListenStream == NULL) {
-         log_message("Warning (HandleReceiveCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
-                     (unsigned long)completedRecvStream, (unsigned long)gTCPListenStream);
-         return;
-    }
-     if (!gIsConnectionActive) {
-         if (ioResult == noErr) {
-             log_to_file_only("Warning (HandleReceiveCompletion): Receive completed successfully but connection no longer marked active. Data processed, not re-issuing receive.");
-             ProcessTCPReceive(macTCPRefNum);
-         } else {
-             log_to_file_only("Warning (HandleReceiveCompletion): Receive completed with error %d, connection already inactive.", ioResult);
-         }
-         if (ioResult != reqAborted) {
-            gNeedToReListen = true;
-         }
-         return;
-     }
-    if (ioResult == noErr) {
-        ProcessTCPReceive(macTCPRefNum);
-        if (gIsConnectionActive && gTCPListenStream != NULL) {
-            OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-             if (err != noErr && err != 1) {
-                 log_message("Error (HandleReceiveCompletion): Failed to start next async TCP receive after successful receive. Error: %d. Closing connection.", err);
-                 StartAsyncTCPClose(macTCPRefNum, true);
-             } else {
-                 log_to_file_only("HandleReceiveCompletion: Successfully re-issued TCPRcv on stream 0x%lX.", (unsigned long)gTCPListenStream);
-             }
-        } else {
-             log_to_file_only("HandleReceiveCompletion: Connection stream closed/inactive or stream became NULL during processing. Not starting new receive.");
-             if (gTCPListenStream != NULL && !gTCPClosePending) {
-                 gNeedToReListen = true;
-             }
-        }
-    } else if (ioResult == connectionClosing) {
-         char senderIPStr[INET_ADDRSTRLEN];
-         AddrToStr(gCurrentConnectionIP, senderIPStr);
-         log_message("TCP Connection closing gracefully from %s (Stream: 0x%lX).", senderIPStr, (unsigned long)completedRecvStream);
-         ProcessTCPReceive(macTCPRefNum);
-         gIsConnectionActive = false;
-         gCurrentConnectionIP = 0;
-         gCurrentConnectionPort = 0;
-         gNeedToReListen = true;
-    } else {
-         char senderIPStr[INET_ADDRSTRLEN];
-         AddrToStr(gCurrentConnectionIP, senderIPStr);
-         const char *errMsg = "Unknown Error";
-         Boolean isConnTerminated = (ioResult == connectionTerminated);
-         Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-         Boolean isReqAborted = (ioResult == reqAborted);
-         if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
-         else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-         else if (isReqAborted) errMsg = "reqAborted (-23015)";
-        if (isReqAborted) {
-            log_to_file_only("HandleReceiveCompletion: Async TCPRcv completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
-        } else {
-            log_message("Error (HandleReceiveCompletion): Async TCPRcv completed with error: %d (%s) from %s (Stream: 0x%lX).", ioResult, errMsg, senderIPStr, (unsigned long)completedRecvStream);
-        }
-        gIsConnectionActive = false;
-        gCurrentConnectionIP = 0;
-        gCurrentConnectionPort = 0;
-        if (isInvalidStream) {
-             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during receive. It will be cleaned up.", (unsigned long)gTCPListenStream);
-             gTCPListenStream = NULL;
-             gNeedToReListen = false;
-        } else if (!isReqAborted) {
-             gNeedToReListen = true;
-        }
-    }
-}
-static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult) {
-    StreamPtr closedStream = gTCPClosePB.tcpStream;
-    if (closedStream != gTCPListenStream || gTCPListenStream == NULL) {
-         log_message("Warning (HandleCloseCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
-                     (unsigned long)closedStream, (unsigned long)gTCPListenStream);
-         return;
-    }
-    gIsConnectionActive = false;
-    gCurrentConnectionIP = 0;
-    gCurrentConnectionPort = 0;
-    if (ioResult == noErr) {
-        log_to_file_only("HandleCloseCompletion: Async TCPClose completed successfully for stream 0x%lX.", (unsigned long)closedStream);
-    } else {
-        const char *errMsg = "Unknown Error";
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
-        Boolean isReqAborted = (ioResult == reqAborted);
-        if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
-        else if (isReqAborted) errMsg = "reqAborted (-23015)";
-        if (isReqAborted) {
-             log_to_file_only("HandleCloseCompletion: Async TCPClose completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
-        } else {
-            log_message("Error (HandleCloseCompletion): Async TCPClose for stream 0x%lX completed with error: %d (%s)", (unsigned long)closedStream, ioResult, errMsg);
-        }
-        if (isInvalidStream) {
-             log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during close. It will be cleaned up.", (unsigned long)gTCPListenStream);
-             gTCPListenStream = NULL;
-             gNeedToReListen = false;
-             return;
-        }
-    }
-    if (ioResult != reqAborted) {
-        log_to_file_only("HandleCloseCompletion: Setting flag to re-listen.");
-        gNeedToReListen = true;
-    }
-}
-static OSErr StartAsyncTCPListen(short macTCPRefNum) {
-    OSErr err;
-    if (gTCPListenStream == NULL) {
-        log_message("Error (StartAsyncTCPListen): Cannot listen, gTCPListenStream is NULL.");
-        return invalidStreamPtr;
-    }
-    if (gTCPListenPending) {
-        log_to_file_only("StartAsyncTCPListen: Listen already pending on stream 0x%lX.", (unsigned long)gTCPListenStream);
-        return 1;
-    }
-    if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
-        log_message("Error (StartAsyncTCPListen): Cannot listen, stream 0x%lX is busy (Active: %d, RecvPending: %d, ClosePending: %d).",
-                    (unsigned long)gTCPListenStream, gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-        return inProgress;
-    }
-    memset(&gTCPListenPB, 0, sizeof(TCPiopb));
-    gTCPListenPB.ioCompletion = nil;
-    gTCPListenPB.ioCRefNum = macTCPRefNum;
-    gTCPListenPB.csCode = TCPPassiveOpen;
-    gTCPListenPB.tcpStream = gTCPListenStream;
-    gTCPListenPB.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    gTCPListenPB.csParam.open.ulpTimeoutValue = kTCPDefaultTimeout;
-    gTCPListenPB.csParam.open.ulpTimeoutAction = AbortTrue;
-    gTCPListenPB.csParam.open.commandTimeoutValue = 0;
-    gTCPListenPB.csParam.open.localPort = PORT_TCP;
-    gTCPListenPB.csParam.open.localHost = 0L;
-    gTCPListenPB.csParam.open.remoteHost = 0L;
-    gTCPListenPB.csParam.open.remotePort = 0;
-    gTCPListenPB.csParam.open.userDataPtr = nil;
-    gTCPListenPending = true;
-    err = PBControlAsync((ParmBlkPtr)&gTCPListenPB);
-    if (err != noErr) {
-        log_message("Error (StartAsyncTCPListen): PBControlAsync(TCPPassiveOpen) failed immediately. Error: %d", err);
-        gTCPListenPending = false;
-        return err;
-    }
-    log_to_file_only("StartAsyncTCPListen: Async TCPPassiveOpen initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1;
-}
-static OSErr StartAsyncTCPRecv(short macTCPRefNum) {
-    OSErr err;
-    if (gTCPListenStream == NULL) {
-        log_message("Error (StartAsyncTCPRecv): Cannot receive, gTCPListenStream is NULL.");
-        return invalidStreamPtr;
-     }
-    if (gTCPRecvBuffer == NULL) {
-         log_message("Error (StartAsyncTCPRecv): Cannot receive, gTCPRecvBuffer is NULL.");
-         return invalidBufPtr;
-    }
-    if (gTCPRecvPending) {
-         log_to_file_only("StartAsyncTCPRecv: Receive already pending on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return 1;
-    }
-    if (!gIsConnectionActive) {
-         log_to_file_only("Warning (StartAsyncTCPRecv): Cannot receive, connection not marked active on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return connectionDoesntExist;
-    }
-    if (gTCPListenPending || gTCPClosePending) {
-         log_message("Error (StartAsyncTCPRecv): Cannot receive, stream 0x%lX has other pending operations (Listen: %d, Close: %d).",
-                     (unsigned long)gTCPListenStream, gTCPListenPending, gTCPClosePending);
-         return inProgress;
-    }
-    memset(&gTCPRecvPB, 0, sizeof(TCPiopb));
-    gTCPRecvPB.ioCompletion = nil;
-    gTCPRecvPB.ioCRefNum = macTCPRefNum;
-    gTCPRecvPB.csCode = TCPRcv;
-    gTCPRecvPB.tcpStream = gTCPListenStream;
-    gTCPRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;
-    gTCPRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize;
-    gTCPRecvPB.csParam.receive.commandTimeoutValue = 0;
-    gTCPRecvPB.csParam.receive.userDataPtr = nil;
-    gTCPRecvPending = true;
-    err = PBControlAsync((ParmBlkPtr)&gTCPRecvPB);
-    if (err != noErr) {
-        log_message("Error (StartAsyncTCPRecv): PBControlAsync(TCPRcv) failed immediately. Error: %d", err);
-        gTCPRecvPending = false;
-        StartAsyncTCPClose(macTCPRefNum, true);
-        return err;
-    }
-    log_to_file_only("StartAsyncTCPRecv: Async TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1;
-}
-static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection) {
-    OSErr err;
-    if (gTCPListenStream == NULL) {
-        log_message("Error (StartAsyncTCPClose): Cannot close NULL stream.");
-        return invalidStreamPtr;
-    }
-    if (gTCPClosePending) {
-        log_to_file_only("StartAsyncTCPClose: Close already pending for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-        return 1;
-    }
-    gIsConnectionActive = false;
-    gCurrentConnectionIP = 0;
-    gCurrentConnectionPort = 0;
-    if (gTCPRecvPending && gTCPRecvPB.tcpStream == gTCPListenStream) {
-        log_to_file_only("StartAsyncTCPClose: Killing pending receive before closing.");
-        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
-        gTCPRecvPending = false;
-    }
-    memset(&gTCPClosePB, 0, sizeof(TCPiopb));
-    gTCPClosePB.ioCompletion = nil;
-    gTCPClosePB.ioCRefNum = macTCPRefNum;
-    gTCPClosePB.csCode = TCPClose;
-    gTCPClosePB.tcpStream = gTCPListenStream;
-    gTCPClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction;
-    gTCPClosePB.csParam.close.ulpTimeoutValue = kTCPDefaultTimeout;
-    if (abortConnection) {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = AbortTrue;
-        log_to_file_only("StartAsyncTCPClose: Using Abort action.");
-    } else {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = 0;
-        log_to_file_only("StartAsyncTCPClose: Using Graceful close action.");
-    }
-    gTCPClosePB.csParam.close.userDataPtr = nil;
-    gTCPClosePending = true;
-    err = PBControlAsync((ParmBlkPtr)&gTCPClosePB);
-    if (err != noErr) {
-        log_message("Error (StartAsyncTCPClose): PBControlAsync(TCPClose) failed immediately for stream 0x%lX. Error: %d", (unsigned long)gTCPListenStream, err);
-        gTCPClosePending = false;
-        gNeedToReListen = true;
-        return err;
-    }
-    log_to_file_only("StartAsyncTCPClose: Initiated async TCPClose for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1;
-}
-static void ProcessTCPReceive(short macTCPRefNum) {
-    char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN];
-    char senderUsername[32];
-    char msgType[32];
-    char content[BUFFER_SIZE];
-    unsigned short dataLength;
-    static tcp_platform_callbacks_t mac_callbacks = {
-        .add_or_update_peer = mac_tcp_add_or_update_peer,
-        .display_text_message = mac_tcp_display_text_message,
-        .mark_peer_inactive = mac_tcp_mark_peer_inactive
-    };
-    if (!gIsConnectionActive || gTCPListenStream == NULL) {
-        log_message("Warning (ProcessTCPReceive): Called when connection not active or listener stream is NULL.");
-        return;
-    }
-    if (gTCPRecvPB.tcpStream != gTCPListenStream) {
-        log_message("CRITICAL Warning (ProcessTCPReceive): Received data for unexpected stream 0x%lX, expected 0x%lX. Ignoring and closing.",
-                    (unsigned long)gTCPRecvPB.tcpStream, (unsigned long)gTCPListenStream);
-        StartAsyncTCPClose(macTCPRefNum, true);
-        return;
-    }
-    dataLength = gTCPRecvPB.csParam.receive.rcvBuffLen;
-    if (dataLength > 0) {
-        OSErr addrErr = AddrToStr(gCurrentConnectionIP, senderIPStrFromConnection);
-        if (addrErr != noErr) {
-            sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu",
-                    (gCurrentConnectionIP >> 24) & 0xFF, (gCurrentConnectionIP >> 16) & 0xFF,
-                    (gCurrentConnectionIP >> 8) & 0xFF, gCurrentConnectionIP & 0xFF);
-            log_to_file_only("ProcessTCPReceive: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.",
-                         addrErr, (unsigned long)gCurrentConnectionIP, senderIPStrFromConnection);
-        }
-        if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
-            log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (Payload IP: %s).",
-                       msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
-            handle_received_tcp_message(senderIPStrFromConnection,
-                                        senderUsername,
-                                        msgType,
-                                        content,
-                                        &mac_callbacks,
-                                        NULL);
-            if (strcmp(msgType, MSG_QUIT) == 0) {
-                 log_message("Connection to %s finishing due to received QUIT.", senderIPStrFromConnection);
-                 StartAsyncTCPClose(macTCPRefNum, true);
-            }
-        } else {
-            log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
-        }
-    } else {
-        log_to_file_only("ProcessTCPReceive: Received 0 bytes. Connection likely closing.");
-    }
-}
-static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen)
-{
-    OSErr err;
-    TCPiopb pbCreate;
-    if (streamPtr == NULL || connectionBuffer == NULL) return paramErr;
-    memset(&pbCreate, 0, sizeof(TCPiopb));
-    pbCreate.ioCompletion = nil;
-    pbCreate.ioCRefNum = macTCPRefNum;
-    pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L;
-    pbCreate.csParam.create.rcvBuff = connectionBuffer;
-    pbCreate.csParam.create.rcvBuffLen = connBufferLen;
-    pbCreate.csParam.create.notifyProc = nil;
-    pbCreate.csParam.create.userDataPtr = nil;
-    err = PBControlSync((ParmBlkPtr)&pbCreate);
-    if (err == noErr) {
-        *streamPtr = pbCreate.tcpStream;
-        if (*streamPtr == NULL) {
-            log_message("Error (LowTCPCreateSync): PBControlSync succeeded but returned NULL stream.");
-            err = ioErr;
-        }
-    } else {
-        *streamPtr = NULL;
-    }
-    return err;
-}
-static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost,
-                                      tcp_port remotePort, ip_addr *localHost, tcp_port *localPort,
-                                      GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-    if (giveTime == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) {
-        log_message("Error (LowTCPOpenConnectionSync): Failed to allocate PB.");
-        return memFullErr;
-    }
-    pBlock->ioCompletion = nil;
-    pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPActiveOpen;
-    pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-    pBlock->csParam.open.ulpTimeoutValue = timeoutTicks;
-    pBlock->csParam.open.ulpTimeoutAction = AbortTrue;
-    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction;
-    pBlock->csParam.open.commandTimeoutValue = 0;
-    pBlock->csParam.open.remoteHost = remoteHost;
-    pBlock->csParam.open.remotePort = remotePort;
-    pBlock->csParam.open.localPort = 0;
-    pBlock->csParam.open.localHost = 0;
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_message("Error (LowTCPOpenConnectionSync): PBControlAsync failed immediately: %d", err);
-        DisposePtr((Ptr)pBlock);
-        return err;
-    }
-    while (pBlock->ioResult > 0) {
-        giveTime();
-    }
-    err = pBlock->ioResult;
-    if (err == noErr) {
-        if (localHost) *localHost = pBlock->csParam.open.localHost;
-        if (localPort) *localPort = pBlock->csParam.open.localPort;
-    }
-    DisposePtr((Ptr)pBlock);
-    return err;
-}
-static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent,
-                            Ptr wdsPtr, GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-    if (giveTime == NULL || wdsPtr == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) {
-        log_message("Error (LowTCPSendSync): Failed to allocate PB.");
-        return memFullErr;
-    }
-    pBlock->ioCompletion = nil;
-    pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPSend;
-    pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-    pBlock->csParam.send.ulpTimeoutValue = timeoutTicks;
-    pBlock->csParam.send.ulpTimeoutAction = AbortTrue;
-    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction;
-    pBlock->csParam.send.pushFlag = push;
-    pBlock->csParam.send.urgentFlag = urgent;
-    pBlock->csParam.send.wdsPtr = wdsPtr;
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_message("Error (LowTCPSendSync): PBControlAsync failed immediately: %d", err);
-        DisposePtr((Ptr)pBlock);
-        return err;
-    }
-    while (pBlock->ioResult > 0) {
-        giveTime();
-    }
-    err = pBlock->ioResult;
-    DisposePtr((Ptr)pBlock);
-    return err;
-}
-static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime)
-{
-    OSErr err;
-    TCPiopb *pBlock = NULL;
-    if (giveTime == NULL) return paramErr;
-    if (streamPtr == NULL) return invalidStreamPtr;
-    pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
-    if (pBlock == NULL) {
-        log_message("Error (LowTCPAbortSync): Failed to allocate PB.");
-        return memFullErr;
-    }
-    pBlock->ioCompletion = nil;
-    pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->csCode = TCPAbort;
-    pBlock->ioResult = 1;
-    pBlock->tcpStream = streamPtr;
-    err = PBControlAsync((ParmBlkPtr)pBlock);
-    if (err != noErr) {
-        log_to_file_only("Info (LowTCPAbortSync): PBControlAsync failed immediately: %d", err);
-        if (err != connectionDoesntExist && err != invalidStreamPtr) {
-             log_message("Warning (LowTCPAbortSync): Unexpected immediate error: %d", err);
-        }
-        DisposePtr((Ptr)pBlock);
-        return noErr;
-    }
-    while (pBlock->ioResult > 0) {
-        giveTime();
-    }
-    err = pBlock->ioResult;
-    if (err != noErr && err != connectionDoesntExist && err != invalidStreamPtr) {
-         log_message("Warning (LowTCPAbortSync): Abort completed with error: %d", err);
-    }
-    DisposePtr((Ptr)pBlock);
-    return noErr;
-}
-static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr)
-{
-    OSErr err;
-    TCPiopb pbRelease;
-    if (streamPtr == NULL) return invalidStreamPtr;
-    memset(&pbRelease, 0, sizeof(TCPiopb));
-    pbRelease.ioCompletion = nil;
-    pbRelease.ioCRefNum = macTCPRefNum;
-    pbRelease.csCode = TCPRelease;
-    pbRelease.tcpStream = streamPtr;
-    err = PBControlSync((ParmBlkPtr)&pbRelease);
-    if (err != noErr && err != invalidStreamPtr) {
-         log_message("Warning (LowTCPReleaseSync): PBControlSync(TCPRelease) failed: %d", err);
-    } else if (err == invalidStreamPtr) {
-         log_to_file_only("Info (LowTCPReleaseSync): Attempted to release invalid stream 0x%lX.", (unsigned long)streamPtr);
-         err = noErr;
-    }
-    return err;
 }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,7 +1,3 @@
-//====================================
-// FILE: ./classic_mac/tcp.c
-//====================================
-
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
@@ -18,51 +14,40 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <Events.h>
-#include <OSUtils.h> // For Delay
-
-// --- Constants ---
+#include <OSUtils.h>
 #define kTCPRecvBufferSize 8192
 #define kTCPInternalBufferSize 8192
-// *** Aggressively tuned listen poll timeout for UI responsiveness ***
-#define kTCPListenPollTimeoutTicks 5      // Timeout for PassiveOpen poll (approx 1/12th sec)
-#define kTCPRecvPollTimeoutTicks 1        // Short timeout for sync Rcv poll
-#define kTCPStatusPollTimeoutTicks 1      // Short timeout for sync Status poll
-#define kConnectTimeoutTicks 300          // ULP Timeout for TCPActiveOpen (5 sec)
-#define kSendTimeoutTicks 180             // ULP Timeout for TCPSend (3 sec)
-#define kAbortTimeoutTicks 60             // Timeout for abort poll (1 sec)
-#define kQuitLoopDelayTicks 120           // Delay+Yield between QUIT sends (2 sec)
-#define kErrorRetryDelayTicks 120         // Delay after certain recoverable errors (2 sec)
-
+#define kTCPPassiveOpenULPTimeoutSeconds 2
+#define kTCPListenPollTimeoutTicks 5
+#define kTCPRecvPollTimeoutTicks 1
+#define kTCPStatusPollTimeoutTicks 1
+#define kConnectTimeoutTicks 300
+#define kSendTimeoutTicks 180
+#define kAbortTimeoutTicks 60
+#define kQuitLoopDelayTicks 120
+#define kErrorRetryDelayTicks 120
 #define kMacTCPTimeoutErr (-23016)
 #define AbortTrue 1
-
-// --- Globals ---
 static StreamPtr gTCPStream = NULL;
 static Ptr gTCPInternalBuffer = NULL;
 static Ptr gTCPRecvBuffer = NULL;
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static Boolean gIsSending = false;        // Lock for outgoing send operations
-static ip_addr gPeerIP = 0;               // IP of current incoming connection
-static tcp_port gPeerPort = 0;             // Port of current incoming connection
-
-// --- Forward Declarations ---
+static Boolean gIsSending = false;
+static ip_addr gPeerIP = 0;
+static tcp_port gPeerPort = 0;
 static void ProcessTCPReceive(unsigned short dataLength);
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
-static OSErr LowTCPPassiveOpenSyncPoll(SInt8 timeoutTicks, GiveTimePtr giveTime);
+static OSErr LowTCPPassiveOpenSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime);
 static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
 static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
 static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
 static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
-
-// --- Shared Logic Callbacks (implementation unchanged) ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) { (void)platform_context; int addResult = AddOrUpdatePeer(ip, username); if (addResult > 0) { log_message("Peer connected/updated via TCP: %s@%s", username, ip); if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } else if (addResult < 0) { log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip); } return addResult; }
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) { (void)platform_context; (void)ip; char displayMsg[BUFFER_SIZE + 100]; if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) { sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : ""); AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r"); log_message("Message from %s@%s: %s", username, ip, message_content); } else { log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready."); } }
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) { (void)platform_context; if (!ip) return; log_message("Peer %s has sent QUIT notification via TCP.", ip); if (MarkPeerInactive(ip)) { if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true); } }
-
-// --- Public Functions ---
 OSErr InitTCP(short macTCPRefNum) {
     OSErr err;
     log_message("Initializing Single TCP Stream (Sync Poll Strategy)...");
@@ -71,10 +56,8 @@ OSErr InitTCP(short macTCPRefNum) {
         log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
         return streamAlreadyOpen;
     }
-
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
-
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
         log_message("Fatal Error: Could not allocate TCP buffers.");
         if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer);
@@ -83,126 +66,90 @@ OSErr InitTCP(short macTCPRefNum) {
         return memFullErr;
     }
     log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
-
     log_message("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
         log_message("Error: Failed to create TCP Stream: %d", err);
-        CleanupTCP(macTCPRefNum); // Call full cleanup
+        CleanupTCP(macTCPRefNum);
         return err;
     }
     log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
-
     gTCPState = TCP_STATE_IDLE;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
-
     log_message("TCP initialization complete. State: IDLE.");
     return noErr;
 }
-
 void CleanupTCP(short macTCPRefNum) {
     log_message("Cleaning up Single TCP Stream (Sync Poll Strategy)...");
-
-    StreamPtr streamToRelease = gTCPStream; // Capture before nullifying
+    StreamPtr streamToRelease = gTCPStream;
     TCPState stateBeforeCleanup = gTCPState;
-
-    gTCPStream = NULL; // Prevent further use by other functions
+    gTCPStream = NULL;
     gTCPState = TCP_STATE_RELEASING;
-
-    // Abort if connection might still exist (best effort sync poll)
-    // Check state *before* cleanup started. Only abort if it was connected.
     if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN) {
          log_message("Cleanup: Attempting synchronous abort (best effort)...");
-         // Use the captured streamToRelease if gTCPStream was nulled for safety
-         // but LowTCPAbortSyncPoll uses the global gTCPStream.
-         // Temporarily restore gTCPStream for abort if it was nulled too early.
-         // This is tricky. The design of LowTCPAbortSyncPoll relies on gTCPStream.
-         // Let's ensure gTCPStream is valid for LowTCPAbortSyncPoll.
-         if (streamToRelease != NULL) { // Only if there was a stream to begin with
-             StreamPtr currentGlobalStream = gTCPStream; // Should be NULL now
-             gTCPStream = streamToRelease; // Temporarily restore for abort
+         if (streamToRelease != NULL) {
+             StreamPtr currentGlobalStream = gTCPStream;
+             gTCPStream = streamToRelease;
              LowTCPAbortSyncPoll(YieldTimeToSystem);
-             gTCPStream = currentGlobalStream; // Set back to NULL (or whatever it was)
+             gTCPStream = currentGlobalStream;
          }
     }
-
-    // Release stream synchronously
     if (streamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
-        OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease); // Use captured stream
+        OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
         if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr);
         else log_to_file_only("Sync release successful.");
     } else if (streamToRelease != NULL) {
         log_message("Warning: Cannot release stream, MacTCP refnum is 0.");
     }
-
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
-
     if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; }
     if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; }
-
     log_message("TCP cleanup finished.");
 }
-
-
 void PollTCP(GiveTimePtr giveTime) {
     OSErr err;
     unsigned short amountUnread = 0;
-    Byte connectionState = 0; // MacTypes.h Byte
+    Byte connectionState = 0;
     unsigned long dummyTimer;
-
     if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
         return;
     }
-    if (gIsSending) { // Don't interfere with outgoing send operations (which are synchronous)
-        return;
-    }
-
+    if (gIsSending) { return; }
     switch (gTCPState) {
         case TCP_STATE_IDLE:
-            log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll...");
-            gTCPState = TCP_STATE_LISTENING_POLL; // Tentative state
+            log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll (ULP: %ds, AppPoll: %d ticks)...", kTCPPassiveOpenULPTimeoutSeconds, kTCPListenPollTimeoutTicks);
             err = LowTCPPassiveOpenSyncPoll(kTCPListenPollTimeoutTicks, giveTime);
-
             if (err == noErr) {
                 char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr);
                 log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
                 gTCPState = TCP_STATE_CONNECTED_IN;
-                goto CheckConnectedInData; // Check for data in the same poll cycle
+                goto CheckConnectedInData;
             } else if (err == commandTimeout) {
-                log_to_file_only("PollTCP: Passive Open Poll timed out. Returning to IDLE.");
+                log_to_file_only("PollTCP: Passive Open Poll window (%d ticks) timed out. No connection. Returning to IDLE.", kTCPListenPollTimeoutTicks);
                 gTCPState = TCP_STATE_IDLE;
             } else {
                 log_message("PollTCP: Passive Open Poll failed: %d. Returning to IDLE.", err);
                 gTCPState = TCP_STATE_IDLE;
-                if (err == duplicateSocket || err == connectionExists) { // -23007 or -23008
+                if (err == duplicateSocket || err == connectionExists) {
                      log_message("PollTCP: Delaying %d ticks due to error %d.", kErrorRetryDelayTicks, err);
                      Delay(kErrorRetryDelayTicks, &dummyTimer);
                 }
             }
             break;
-
-        case TCP_STATE_LISTENING_POLL: // Should not be reached if LowTCPPassiveOpenSyncPoll is truly synchronous
-             log_message("PollTCP: WARNING - Reached LISTENING_POLL state unexpectedly.");
-             gTCPState = TCP_STATE_IDLE;
-             break;
-
         case TCP_STATE_CONNECTED_IN:
 CheckConnectedInData:
             log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
             err = LowTCPStatusSyncPoll(giveTime, &amountUnread, &connectionState);
-
             if (err != noErr) {
                 log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
-                LowTCPAbortSyncPoll(giveTime); // Best effort abort
+                LowTCPAbortSyncPoll(giveTime);
                 gTCPState = TCP_STATE_IDLE;
                 break;
             }
-
-            // TCP connection states: 8=Established, 10=FIN_WAIT_1, 12=FIN_WAIT_2, 14=CLOSE_WAIT
             if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
                  char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                  log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Assuming closed/aborted. Returning to IDLE.", connectionState, peerIPStr);
@@ -210,32 +157,29 @@ CheckConnectedInData:
                  break;
             }
             log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
-
             if (amountUnread > 0) {
                 unsigned short bytesToRead = kTCPRecvBufferSize;
                 Boolean markFlag = false, urgentFlag = false;
                 log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
                 err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
-
                 if (err == noErr) {
                     log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                     ProcessTCPReceive(bytesToRead);
-                    // Stay in CONNECTED_IN state
                 } else if (err == connectionClosing) {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
-                    ProcessTCPReceive(bytesToRead); // Process final data
-                    gTCPState = TCP_STATE_IDLE;     // Return to idle
+                    ProcessTCPReceive(bytesToRead);
+                    gTCPState = TCP_STATE_IDLE;
                 } else if (err == commandTimeout) {
                      log_to_file_only("PollTCP: Rcv poll timed out despite status showing data?");
-                } else { // e.g., connectionTerminated
+                } else {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
                     LowTCPAbortSyncPoll(giveTime);
                     gTCPState = TCP_STATE_IDLE;
                 }
-            } else { // No data to read
-                 if (connectionState == 14 /*CloseWait*/) {
+            } else {
+                 if (connectionState == 14 ) {
                      char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                      log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Returning to IDLE.", peerIPStr);
                      gTCPState = TCP_STATE_IDLE;
@@ -244,158 +188,93 @@ CheckConnectedInData:
             break;
         default:
             log_message("PollTCP: In unexpected state %d.", gTCPState);
-            gTCPState = TCP_STATE_IDLE; // Try to recover
+            gTCPState = TCP_STATE_IDLE;
             break;
     }
 }
-
-TCPState GetTCPState(void) {
-    return gTCPState;
-}
-
+TCPState GetTCPState(void) { return gTCPState; }
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
-    OSErr err = noErr, finalErr = noErr;
-    ip_addr targetIP = 0;
-    char messageBuffer[BUFFER_SIZE];
-    int formattedLen;
-    struct wdsEntry sendWDS[2];
-
+    OSErr err = noErr, finalErr = noErr; ip_addr targetIP = 0; char messageBuffer[BUFFER_SIZE]; int formattedLen; struct wdsEntry sendWDS[2];
     log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIP);
-
-    if (gMacTCPRefNum == 0) return notOpenErr;
-    if (gTCPStream == NULL) return invalidStreamPtr;
-    if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
-
+    if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (peerIP == NULL || message == NULL || giveTime == NULL) return paramErr;
     if (gIsSending) { log_message("Warning (SendText): Send already in progress."); return streamBusyErr; }
     if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
     gIsSending = true;
-    // No gTCPState change here, send is a sequence of sync calls within this function.
-
-    err = ParseIPv4(peerIP, &targetIP);
-    if (err != noErr || targetIP == 0) { finalErr = paramErr; goto SendTextCleanup; }
-    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message);
-    if (formattedLen <= 0) { finalErr = paramErr; goto SendTextCleanup; }
-
-    log_to_file_only("SendText: Connecting...");
-    err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
+    err = ParseIPv4(peerIP, &targetIP); if (err != noErr || targetIP == 0) { finalErr = paramErr; goto SendTextCleanup; }
+    formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message); if (formattedLen <= 0) { finalErr = paramErr; goto SendTextCleanup; }
+    log_to_file_only("SendText: Connecting..."); err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
-        log_to_file_only("SendText: Connected successfully.");
-        sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer;
-        sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
-        log_to_file_only("SendText: Sending data...");
-        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
-        if (err != noErr) { log_message("Error (SendText): Send failed: %d", err); finalErr = err; }
-        else { log_to_file_only("SendText: Send successful."); }
-        log_to_file_only("SendText: Aborting connection...");
-        OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
+        log_to_file_only("SendText: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)messageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
+        log_to_file_only("SendText: Sending data..."); err = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
+        if (err != noErr) { log_message("Error (SendText): Send failed: %d", err); finalErr = err; } else { log_to_file_only("SendText: Send successful."); }
+        log_to_file_only("SendText: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
         if (abortErr != noErr) { log_message("Warning (SendText): Abort failed: %d", abortErr); if (finalErr == noErr) finalErr = abortErr; }
     } else { log_message("Error (SendText): Connect failed: %d", err); finalErr = err; }
-
-SendTextCleanup:
-    // gTCPState should remain IDLE or be forced to IDLE by abort.
-    gIsSending = false;
-    log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr);
-    return finalErr;
+SendTextCleanup: gIsSending = false; log_to_file_only("TCP_SendTextMessageSync: Released send lock. Final Status: %d.", finalErr); return finalErr;
 }
-
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
-    int i;
-    OSErr lastErr = noErr, currentErr = noErr;
-    char quitMessageBuffer[BUFFER_SIZE];
-    int formattedLen, activePeerCount = 0, sentCount = 0;
-    unsigned long dummyTimer;
-    struct wdsEntry sendWDS[2];
-
+    int i; OSErr lastErr = noErr, currentErr = noErr; char quitMessageBuffer[BUFFER_SIZE]; int formattedLen, activePeerCount = 0, sentCount = 0; unsigned long dummyTimer; struct wdsEntry sendWDS[2];
     log_message("TCP_SendQuitMessagesSync: Starting...");
-    if (gMacTCPRefNum == 0) return notOpenErr;
-    if (gTCPStream == NULL) return invalidStreamPtr;
-    if (giveTime == NULL) return paramErr;
-
+    if (gMacTCPRefNum == 0) return notOpenErr; if (gTCPStream == NULL) return invalidStreamPtr; if (giveTime == NULL) return paramErr;
     if (gIsSending) { log_message("Warning (SendQuit): Send already in progress."); return streamBusyErr; }
     if (gTCPState != TCP_STATE_IDLE) { log_message("Warning (SendQuit): Stream not IDLE (state %d), cannot send.", gTCPState); return streamBusyErr; }
     gIsSending = true;
-
-    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, "");
-    if (formattedLen <= 0) { lastErr = paramErr; goto SendQuitCleanup; }
-
+    formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, ""); if (formattedLen <= 0) { lastErr = paramErr; goto SendQuitCleanup; }
     for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
-    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
-    if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
-
+    log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount); if (activePeerCount == 0) { lastErr = noErr; goto SendQuitCleanup; }
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
-            ip_addr currentTargetIP = 0;
-            currentErr = noErr;
+            ip_addr currentTargetIP = 0; currentErr = noErr;
             if (gTCPState != TCP_STATE_IDLE) { log_message("CRITICAL (SendQuit): State not IDLE (%d) before peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip); lastErr = ioErr; break; }
-
             log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
-            if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip); if (lastErr == noErr) lastErr = currentErr; goto NextPeerDelay; }
-
+            currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP); if (currentErr != noErr || currentTargetIP == 0) { log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip); if (lastErr == noErr) lastErr = currentErr; goto NextPeerDelay; }
             log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip);
             currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
-
-            // *** MODIFIED: Handle -23007 gracefully ***
-            if (currentErr == connectionExists) { // -23007
+            if (currentErr == connectionExists) {
                 log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
-                // Do not set lastErr here, allow other peers to be tried.
             } else if (currentErr == noErr) {
-                log_to_file_only("SendQuit: Connected successfully.");
-                sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer;
-                sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
-                log_to_file_only("SendQuit: Sending data...");
-                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
+                log_to_file_only("SendQuit: Connected successfully."); sendWDS[0].length = formattedLen; sendWDS[0].ptr = (Ptr)quitMessageBuffer; sendWDS[1].length = 0; sendWDS[1].ptr = NULL;
+                log_to_file_only("SendQuit: Sending data..."); currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true, (Ptr)sendWDS, giveTime);
                 if (currentErr == noErr) { log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip); sentCount++; }
                 else { log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr); if (lastErr == noErr) lastErr = currentErr; }
-                log_to_file_only("SendQuit: Aborting connection...");
-                OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
+                log_to_file_only("SendQuit: Aborting connection..."); OSErr abortErr = LowTCPAbortSyncPoll(giveTime);
                 if (abortErr != noErr) { log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr); if (lastErr == noErr) lastErr = abortErr; }
-            } else {
-                log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
-                if (lastErr == noErr) lastErr = currentErr;
-            }
+            } else { log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr); if (lastErr == noErr) lastErr = currentErr; }
         NextPeerDelay:
             log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
             giveTime(); Delay(kQuitLoopDelayTicks, &dummyTimer);
         }
     }
-SendQuitCleanup:
-    log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
-    gIsSending = false;
-    return lastErr;
+SendQuitCleanup: log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr); gIsSending = false; return lastErr;
 }
-
-// --- Private Helpers ---
-// ProcessTCPReceive remains unchanged
 static void ProcessTCPReceive(unsigned short dataLength) { char senderIPStrFromConnection[INET_ADDRSTRLEN], senderIPStrFromPayload[INET_ADDRSTRLEN]; char senderUsername[32], msgType[32], content[BUFFER_SIZE]; static tcp_platform_callbacks_t mac_callbacks = { .add_or_update_peer = mac_tcp_add_or_update_peer, .display_text_message = mac_tcp_display_text_message, .mark_peer_inactive = mac_tcp_mark_peer_inactive }; if (dataLength > 0 && gTCPRecvBuffer != NULL) { OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection); if (addrErr != noErr) sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF); if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0'; else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) { log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s.", msgType, senderUsername, senderIPStrFromConnection); handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL); if (strcmp(msgType, MSG_QUIT) == 0) log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection); } else log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength); } else if (dataLength == 0) log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal)."); else log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL?"); }
-
-// LowLevelSyncPoll remains unchanged
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode) { OSErr err; if (pBlock == NULL || giveTime == NULL) return paramErr; pBlock->ioCompletion = nil; pBlock->ioResult = 1; pBlock->csCode = csCode; err = PBControlAsync((ParmBlkPtr)pBlock); if (err != noErr) { log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err); return err; } while (pBlock->ioResult > 0) { giveTime(); } return pBlock->ioResult; }
-// LowTCPCreateSync remains unchanged
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen) { OSErr err; TCPiopb pbCreate; if (streamPtr == NULL || connectionBuffer == NULL) return paramErr; memset(&pbCreate, 0, sizeof(TCPiopb)); pbCreate.ioCompletion = nil; pbCreate.ioCRefNum = macTCPRefNum; pbCreate.csCode = TCPCreate; pbCreate.tcpStream = 0L; pbCreate.csParam.create.rcvBuff = connectionBuffer; pbCreate.csParam.create.rcvBuffLen = connBufferLen; pbCreate.csParam.create.notifyProc = nil; err = PBControlSync((ParmBlkPtr)&pbCreate); if (err == noErr) { *streamPtr = pbCreate.tcpStream; if (*streamPtr == NULL) { log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream."); err = ioErr; } } else { *streamPtr = NULL; log_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err); } return err; }
-
-// LowTCPPassiveOpenSyncPoll - gPeerIP/Port set here now
-static OSErr LowTCPPassiveOpenSyncPoll(SInt8 timeoutTicks, GiveTimePtr giveTime) {
-    OSErr err; TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr;
-    memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream;
-    pb.csParam.open.commandTimeoutValue = timeoutTicks; pb.csParam.open.validityFlags = 0;
-    pb.csParam.open.localPort = PORT_TCP; pb.csParam.open.localHost = 0L;
-    pb.csParam.open.remoteHost = 0L; pb.csParam.open.remotePort = 0;
+static OSErr LowTCPPassiveOpenSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime) {
+    OSErr err;
+    TCPiopb pb;
+    if (gTCPStream == NULL) return invalidStreamPtr;
+    memset(&pb, 0, sizeof(TCPiopb));
+    pb.ioCRefNum = gMacTCPRefNum;
+    pb.tcpStream = gTCPStream;
+    pb.csParam.open.commandTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
+    pb.csParam.open.validityFlags = timeoutValue;
+    pb.csParam.open.localPort = PORT_TCP;
+    pb.csParam.open.localHost = 0L;
+    pb.csParam.open.remoteHost = 0L;
+    pb.csParam.open.remotePort = 0;
     err = LowLevelSyncPoll(&pb, giveTime, TCPPassiveOpen);
-    if (err == noErr) { gPeerIP = pb.csParam.open.remoteHost; gPeerPort = pb.csParam.open.remotePort; } // Store peer info
-    else { gPeerIP = 0; gPeerPort = 0; }
+    if (err == noErr) {
+        gPeerIP = pb.csParam.open.remoteHost;
+        gPeerPort = pb.csParam.open.remotePort;
+    } else {
+        gPeerIP = 0; gPeerPort = 0;
+    }
     return err;
 }
-
-// LowTCPActiveOpenSyncPoll remains unchanged
 static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.open.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.open.ulpTimeoutAction = AbortTrue; pb.csParam.open.validityFlags = timeoutValue | timeoutAction; pb.csParam.open.commandTimeoutValue = 0; pb.csParam.open.remoteHost = remoteHost; pb.csParam.open.remotePort = remotePort; pb.csParam.open.localPort = 0; pb.csParam.open.localHost = 0; return LowLevelSyncPoll(&pb, giveTime, TCPActiveOpen); }
-// LowTCPSendSyncPoll remains unchanged
 static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) { TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (wdsPtr == NULL) return invalidWDS; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.send.ulpTimeoutValue = ulpTimeoutTicks; pb.csParam.send.ulpTimeoutAction = AbortTrue; pb.csParam.send.validityFlags = timeoutValue | timeoutAction; pb.csParam.send.pushFlag = push; pb.csParam.send.urgentFlag = false; pb.csParam.send.wdsPtr = wdsPtr; return LowLevelSyncPoll(&pb, giveTime, TCPSend); }
-// LowTCPRcvSyncPoll remains unchanged
 static OSErr LowTCPRcvSyncPoll(SInt8 timeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) { OSErr err; TCPiopb pb; unsigned short initialBufferLen; if (gTCPStream == NULL) return invalidStreamPtr; if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return invalidBufPtr; if (markFlag == NULL || urgentFlag == NULL) return paramErr; initialBufferLen = *bufferLen; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; pb.csParam.receive.commandTimeoutValue = timeoutTicks; pb.csParam.receive.rcvBuff = buffer; pb.csParam.receive.rcvBuffLen = initialBufferLen; err = LowLevelSyncPoll(&pb, giveTime, TCPRcv); *bufferLen = pb.csParam.receive.rcvBuffLen; *markFlag = pb.csParam.receive.markFlag; *urgentFlag = pb.csParam.receive.urgentFlag; return err; }
-// LowTCPStatusSyncPoll remains unchanged
 static OSErr LowTCPStatusSyncPoll(GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) return invalidStreamPtr; if (amtUnread == NULL || connState == NULL) return paramErr; memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPStatus); if (err == noErr) { *amtUnread = pb.csParam.status.amtUnreadData; *connState = pb.csParam.status.connectionState; } else { *amtUnread = 0; *connState = 0; log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err); if (err == invalidStreamPtr) err = connectionDoesntExist; } return err; }
-// LowTCPAbortSyncPoll remains unchanged
 static OSErr LowTCPAbortSyncPoll(GiveTimePtr giveTime) { OSErr err; TCPiopb pb; if (gTCPStream == NULL) { log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort."); return noErr; } memset(&pb, 0, sizeof(TCPiopb)); pb.ioCRefNum = gMacTCPRefNum; pb.tcpStream = gTCPStream; err = LowLevelSyncPoll(&pb, giveTime, TCPAbort); if (err == connectionDoesntExist || err == invalidStreamPtr) { log_to_file_only("LowTCPAbortSyncPoll: Abort completed (conn not exist/invalid stream). Result: %d", err); err = noErr; } else if (err != noErr) { log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed: %d", err); } else { log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful."); } return err; }
-// LowTCPReleaseSync remains unchanged
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr) { OSErr err; TCPiopb pbRelease; if (streamPtr == NULL) return invalidStreamPtr; memset(&pbRelease, 0, sizeof(TCPiopb)); pbRelease.ioCompletion = nil; pbRelease.ioCRefNum = macTCPRefNum; pbRelease.csCode = TCPRelease; pbRelease.tcpStream = streamPtr; err = PBControlSync((ParmBlkPtr)&pbRelease); if (err != noErr && err != invalidStreamPtr) { log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err); } else if (err == invalidStreamPtr) { log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid.", (unsigned long)streamPtr); err = noErr; } return err; }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -6,6 +6,7 @@
 #include "dialog_peerlist.h"
 #include "network.h"
 #include "../shared/messaging_logic.h"
+
 #include <Devices.h>
 #include <Errors.h>
 #include <MacTypes.h>
@@ -14,18 +15,32 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <Events.h>
-#include <OSUtils.h>
+#include <OSUtils.h> // For Delay
+
+// Buffer sizes
 #define kTCPRecvBufferSize 8192
-#define kTCPInternalBufferSize 8192
-#define kTCPPassiveOpenULPTimeoutSeconds 2
-#define kTCPListenPollTimeoutTicks 150
-#define kTCPRecvPollTimeoutTicks 1
-#define kTCPStatusPollTimeoutTicks 1
-#define kConnectTimeoutTicks 300
-#define kSendTimeoutTicks 180
-#define kAbortTimeoutTicks 60
-#define kQuitLoopDelayTicks 120
-#define kErrorRetryDelayTicks 120
+#define kTCPInternalBufferSize 8192 // For TCPCreate's internal connection buffer
+
+// Timeouts for MacTCP ULP (User Level Protocol)
+#define kTCPPassiveOpenULPTimeoutSeconds 2 // How long MacTCP waits for a connection on PassiveOpen
+#define kConnectULPTimeoutSeconds 5      // ULP timeout for ActiveOpen (was kConnectTimeoutTicks / 60)
+#define kSendULPTimeoutSeconds 3         // ULP timeout for Send (was kSendTimeoutTicks / 60)
+#define kAbortULPTimeoutSeconds 1        // ULP timeout for Abort (was kAbortTimeoutTicks / 60)
+
+// Timeouts for application-level polling of synchronous operations (LowLevelSyncPoll)
+// These are how long *our app* waits for a MacTCP async call (that we are treating synchronously)
+// to complete. These should generally be slightly longer than the corresponding ULP timeout.
+#define kTCPRecvPollTimeoutTicks 1       // Short poll for receive when data is expected
+#define kTCPStatusPollTimeoutTicks 1     // Short poll for status
+#define kConnectPollTimeoutTicks (kConnectULPTimeoutSeconds * 60 + 30) // e.g., 5*60 + 30 = 330
+#define kSendPollTimeoutTicks (kSendULPTimeoutSeconds * 60 + 30)       // e.g., 3*60 + 30 = 210
+#define kAbortPollTimeoutTicks (kAbortULPTimeoutSeconds * 60 + 30)     // e.g., 1*60 + 30 = 90
+
+// Delays
+#define kErrorRetryDelayTicks 120        // Delay after certain recoverable errors
+#define kQuitLoopDelayTicks 120          // Delay between sending QUIT messages in the loop
+
+// MacTCP specific error codes (for clarity, some might be defined in MacTCP.h already)
 #define kMacTCPTimeoutErr (-23016)
 #define kDuplicateSocketErr (-23017)
 #define kConnectionExistsErr (-23007)
@@ -34,26 +49,41 @@
 #define kInvalidStreamPtrErr (-23010)
 #define kInvalidWDSErr (-23014)
 #define kInvalidBufPtrErr (-23013)
+#define kRequestAbortedErr (-23006) // Important for this change
+
 #define AbortTrue 1
+
+// --- Static Globals for TCP Management ---
 static StreamPtr gTCPStream = NULL;
-static Ptr gTCPInternalBuffer = NULL;
-static Ptr gTCPRecvBuffer = NULL;
+static Ptr gTCPInternalBuffer = NULL; // Buffer for TCPCreate
+static Ptr gTCPRecvBuffer = NULL;     // Buffer for TCPRcv
+
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static Boolean gIsSending = false;
+static Boolean gIsSending = false; // Prevents re-entrant send operations
+
+// For asynchronous passive open
+static TCPiopb gTCPPassiveOpenPB;
+static Boolean gPassiveOpenPBInitialized = false; // To ensure PB is zeroed once
+
+// Information about the currently connected peer (for incoming connections)
 static ip_addr gPeerIP = 0;
 static tcp_port gPeerPort = 0;
+
+
+// --- Forward Declarations ---
 static void ProcessTCPReceive(unsigned short dataLength);
-static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks);
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt16 appPollTimeoutTicks);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
-static OSErr LowTCPPassiveOpenSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime);
-static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicks, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
-static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicks, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
-static OSErr LowTCPRcvSyncPoll(SInt8 pollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
-static OSErr LowTCPStatusSyncPoll(SInt8 pollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
-static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicks, GiveTimePtr giveTime);
+static OSErr LowTCPActiveOpenSyncPoll(Byte ulpTimeoutSeconds, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime);
+static OSErr LowTCPSendSyncPoll(Byte ulpTimeoutSeconds, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime);
+static OSErr LowTCPRcvSyncPoll(SInt16 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime);
+static OSErr LowTCPStatusSyncPoll(SInt16 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
+static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
+
+// --- Platform Callbacks for Shared Messaging Logic ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused
     int addResult = AddOrUpdatePeer(ip, username);
     if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
@@ -63,10 +93,12 @@ static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void
     }
     return addResult;
 }
+
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context;
-    (void)ip;
+    (void)platform_context; // Unused
+    (void)ip; // IP is available via gPeerIP if needed, but username is primary for display
     char displayMsg[BUFFER_SIZE + 100];
+
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
@@ -76,24 +108,30 @@ static void mac_tcp_display_text_message(const char* username, const char* ip, c
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
+
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context;
+    (void)platform_context; // Unused
     if (!ip) return;
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     }
 }
+
+// --- Public TCP API ---
 OSErr InitTCP(short macTCPRefNum) {
     OSErr err;
-    log_message("Initializing Single TCP Stream (Sync Poll Strategy)...");
+    log_message("Initializing Single TCP Stream (Async Passive Open / Sync Poll Strategy)...");
+
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
         log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
-        return streamAlreadyOpen;
+        return streamAlreadyOpen; // Or some other appropriate error
     }
+
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
+
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
         log_message("Fatal Error: Could not allocate TCP buffers.");
         if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer);
@@ -102,262 +140,414 @@ OSErr InitTCP(short macTCPRefNum) {
         return memFullErr;
     }
     log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
+
     log_message("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
         log_message("Error: Failed to create TCP Stream: %d", err);
-        CleanupTCP(macTCPRefNum);
+        CleanupTCP(macTCPRefNum); // Clean up allocated buffers
         return err;
     }
     log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
+
+    // Initialize the static parameter block for passive open
+    memset(&gTCPPassiveOpenPB, 0, sizeof(TCPiopb));
+    gTCPPassiveOpenPB.ioCompletion = nil; // Important for async calls
+    gTCPPassiveOpenPB.ioCRefNum = gMacTCPRefNum;
+    gTCPPassiveOpenPB.tcpStream = gTCPStream;
+    gPassiveOpenPBInitialized = true;
+
+
     gTCPState = TCP_STATE_IDLE;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
+
     log_message("TCP initialization complete. State: IDLE.");
     return noErr;
 }
+
 void CleanupTCP(short macTCPRefNum) {
-    log_message("Cleaning up Single TCP Stream (Sync Poll Strategy)...");
+    log_message("Cleaning up Single TCP Stream...");
     StreamPtr streamToRelease = gTCPStream;
     TCPState stateBeforeCleanup = gTCPState;
-    gTCPState = TCP_STATE_RELEASING;
-    gTCPStream = NULL;
-    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_LISTENING_POLL) {
+
+    gTCPState = TCP_STATE_RELEASING; // Prevent PollTCP from initiating new operations
+    gTCPStream = NULL; // Mark stream as unusable by PollTCP immediately
+
+    if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_PASSIVE_OPEN_PENDING) {
          log_message("Cleanup: Attempting synchronous abort (best effort)...");
          if (streamToRelease != NULL) {
-             StreamPtr currentGlobalStream = gTCPStream;
+             StreamPtr currentGlobalStream = gTCPStream; 
              gTCPStream = streamToRelease;
-             LowTCPAbortSyncPoll(kAbortTimeoutTicks, YieldTimeToSystem);
-             gTCPStream = currentGlobalStream;
+             LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, YieldTimeToSystem);
+             gTCPStream = currentGlobalStream; 
          }
     }
+
     if (streamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
         OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
         if (relErr != noErr) log_message("Warning: Sync release failed: %d", relErr);
         else log_to_file_only("Sync release successful.");
     } else if (streamToRelease != NULL) {
-        log_message("Warning: Cannot release stream, MacTCP refnum is 0 or stream already NULLed.");
+        log_message("Warning: Cannot release stream, MacTCP refnum is 0.");
     }
+
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
     gPeerIP = 0; gPeerPort = 0;
+    gPassiveOpenPBInitialized = false;
+
+
     if (gTCPRecvBuffer != NULL) { DisposePtr(gTCPRecvBuffer); gTCPRecvBuffer = NULL; }
     if (gTCPInternalBuffer != NULL) { DisposePtr(gTCPInternalBuffer); gTCPInternalBuffer = NULL; }
+
     log_message("TCP cleanup finished.");
 }
+
 void PollTCP(GiveTimePtr giveTime) {
     OSErr err;
     unsigned short amountUnread = 0;
     Byte connectionState = 0;
-    unsigned long dummyTimer;
+    unsigned long dummyTimer; // For Delay
+
     if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
         return;
     }
-    if (gIsSending) { return; }
+
+    if (gIsSending) { 
+        giveTime(); 
+        return;
+    }
+
     switch (gTCPState) {
         case TCP_STATE_IDLE:
-            log_to_file_only("PollTCP: State IDLE. Attempting Passive Open Poll (ULP: %ds, AppPoll: %d ticks)...", kTCPPassiveOpenULPTimeoutSeconds, kTCPListenPollTimeoutTicks);
-            err = LowTCPPassiveOpenSyncPoll(kTCPListenPollTimeoutTicks, giveTime);
+            log_to_file_only("PollTCP: State IDLE. Attempting ASYNC Passive Open (ULP: %ds)...", kTCPPassiveOpenULPTimeoutSeconds);
+            if (!gPassiveOpenPBInitialized) {
+                log_message("PollTCP CRITICAL: gTCPPassiveOpenPB not initialized!");
+                gTCPState = TCP_STATE_ERROR; 
+                break;
+            }
+            
+            gTCPPassiveOpenPB.csCode = TCPPassiveOpen;
+            gTCPPassiveOpenPB.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
+            gTCPPassiveOpenPB.csParam.open.ulpTimeoutAction = AbortTrue;
+            gTCPPassiveOpenPB.csParam.open.validityFlags = timeoutValue | timeoutAction;
+            gTCPPassiveOpenPB.csParam.open.localPort = PORT_TCP;
+            gTCPPassiveOpenPB.csParam.open.localHost = 0L; 
+            gTCPPassiveOpenPB.csParam.open.remoteHost = 0L; 
+            gTCPPassiveOpenPB.csParam.open.remotePort = 0;  
+            gTCPPassiveOpenPB.csParam.open.tosFlags = 0;
+            gTCPPassiveOpenPB.csParam.open.precedence = 0;
+            gTCPPassiveOpenPB.csParam.open.dontFrag = false;
+            gTCPPassiveOpenPB.csParam.open.timeToLive = 0;
+            gTCPPassiveOpenPB.csParam.open.security = 0;
+            gTCPPassiveOpenPB.csParam.open.optionCnt = 0;
+            gTCPPassiveOpenPB.csParam.open.commandTimeoutValue = 0; 
+
+            gTCPPassiveOpenPB.ioResult = 1; 
+
+            err = PBControlAsync((ParmBlkPtr)&gTCPPassiveOpenPB);
             if (err == noErr) {
+                log_to_file_only("PollTCP: Async TCPPassiveOpen initiated.");
+                gTCPState = TCP_STATE_PASSIVE_OPEN_PENDING;
+            } else {
+                log_message("PollTCP: PBControlAsync(TCPPassiveOpen) failed immediately: %d. Retrying after delay.", err);
+                gTCPState = TCP_STATE_IDLE; 
+                Delay(kErrorRetryDelayTicks, &dummyTimer);
+            }
+            break;
+
+        case TCP_STATE_PASSIVE_OPEN_PENDING:
+            giveTime(); 
+            if (gTCPPassiveOpenPB.ioResult == 1) { 
+                return;
+            }
+
+            if (gTCPPassiveOpenPB.ioResult == noErr) {
+                gPeerIP = gTCPPassiveOpenPB.csParam.open.remoteHost;
+                gPeerPort = gTCPPassiveOpenPB.csParam.open.remotePort;
                 char senderIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, senderIPStr);
                 log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
                 gTCPState = TCP_STATE_CONNECTED_IN;
-                goto CheckConnectedInData;
-            } else if (err == commandTimeout) {
-                log_to_file_only("PollTCP: Passive Open Poll window (%d ticks) timed out. No connection. Returning to IDLE.", kTCPListenPollTimeoutTicks);
-                gTCPState = TCP_STATE_IDLE;
-            } else if (err == kDuplicateSocketErr || err == kConnectionExistsErr) {
-                log_message("PollTCP: Passive Open Poll failed with %d. Attempting to Abort stream to reset.", err);
-                OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
-                if (abortErr == noErr) {
-                    log_message("PollTCP: Abort successful after Passive Open failure. Will retry passive open.");
+                goto CheckConnectedInData; 
+            } else { 
+                err = gTCPPassiveOpenPB.ioResult;
+                // Check if the error is kRequestAbortedErr, which might happen if a send operation aborted us
+                if (err == kRequestAbortedErr) {
+                    log_message("PollTCP: Async Passive Open was aborted (err %d), likely by a send operation. Returning to IDLE.", err);
                 } else {
-                    log_message("PollTCP: CRITICAL - Abort FAILED (%d) after Passive Open failure. TCP might be stuck.", abortErr);
+                    log_message("PollTCP: Async Passive Open failed: %d.", err);
                 }
-                gTCPState = TCP_STATE_IDLE;
-                log_message("PollTCP: Delaying %d ticks due to error %d before retrying passive open.", kErrorRetryDelayTicks, err);
-                Delay(kErrorRetryDelayTicks, &dummyTimer);
-            } else {
-                log_message("PollTCP: Passive Open Poll failed with other error: %d. Returning to IDLE.", err);
-                gTCPState = TCP_STATE_IDLE;
+                
+                if (err == kDuplicateSocketErr || err == kConnectionExistsErr) {
+                    log_message("PollTCP: Attempting Abort to clear stream after Passive Open failure (%d).", err);
+                    LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime); 
+                }
+                gTCPState = TCP_STATE_IDLE; 
+                Delay(kErrorRetryDelayTicks, &dummyTimer); 
             }
             break;
+
         case TCP_STATE_CONNECTED_IN:
-CheckConnectedInData:
+CheckConnectedInData: 
             log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
             err = LowTCPStatusSyncPoll(kTCPStatusPollTimeoutTicks, giveTime, &amountUnread, &connectionState);
             if (err != noErr) {
                 log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
-                LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 gTCPState = TCP_STATE_IDLE;
                 break;
             }
+
             if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
                  char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
-                 log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Assuming closed/aborted. Returning to IDLE.", connectionState, peerIPStr);
+                 log_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Aborting and returning to IDLE.", connectionState, peerIPStr);
+                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                  gTCPState = TCP_STATE_IDLE;
                  break;
             }
+
             log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
+
             if (amountUnread > 0) {
-                unsigned short bytesToRead = kTCPRecvBufferSize;
+                unsigned short bytesToRead = kTCPRecvBufferSize; 
                 Boolean markFlag = false, urgentFlag = false;
+
                 log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
                 err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
+
                 if (err == noErr) {
                     log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                     ProcessTCPReceive(bytesToRead);
-                } else if (err == kConnectionClosingErr) {
+                } else if (err == kConnectionClosingErr) { 
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
                     if (bytesToRead > 0) ProcessTCPReceive(bytesToRead);
+                    LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                     gTCPState = TCP_STATE_IDLE;
                 } else if (err == commandTimeout) {
                      log_to_file_only("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
-                } else {
+                } else { 
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
-                    LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                    LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                     gTCPState = TCP_STATE_IDLE;
                 }
-            } else {
-                 if (connectionState == 14 ) {
+            } else { 
+                 if (connectionState == 14 ) { 
                      char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
-                     log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Returning to IDLE.", peerIPStr);
-                     LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                     log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Aborting to clean up. Returning to IDLE.", peerIPStr);
+                     LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                      gTCPState = TCP_STATE_IDLE;
+                 } else if (connectionState != 8) { 
+                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
+                     log_to_file_only("PollTCP: Peer %s in closing state %d with no data. Waiting for MacTCP.", peerIPStr, connectionState);
                  }
             }
             break;
+
         default:
             log_message("PollTCP: In unexpected state %d.", gTCPState);
-            gTCPState = TCP_STATE_IDLE;
+            gTCPState = TCP_STATE_IDLE; 
             break;
     }
 }
+
 TCPState GetTCPState(void) { return gTCPState; }
+
 OSErr TCP_SendTextMessageSync(const char *peerIPStr, const char *message, GiveTimePtr giveTime) {
     OSErr err = noErr, finalErr = noErr;
     ip_addr targetIP = 0;
-    char messageBuffer[BUFFER_SIZE];
+    char messageBuffer[BUFFER_SIZE]; 
     int formattedLen;
-    struct wdsEntry sendWDS[2];
+    struct wdsEntry sendWDS[2];     
+
     log_to_file_only("TCP_SendTextMessageSync: Request to send TEXT to %s", peerIPStr);
+
     if (gMacTCPRefNum == 0) return notOpenErr;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    if (gTCPStream == NULL && gTCPState != TCP_STATE_RELEASING && gTCPState != TCP_STATE_UNINITIALIZED) {
+        // Allow if stream is NULL only if we are already deep in cleanup.
+        // Otherwise, this is an error.
+        if (gTCPStream == NULL) { // Check again because state might change
+             log_message("Error (SendText): gTCPStream is NULL and not in deep cleanup.");
+             return kInvalidStreamPtrErr;
+        }
+    }
     if (peerIPStr == NULL || message == NULL || giveTime == NULL) return paramErr;
+
+    // --- Modification: Interrupt pending passive open if necessary ---
+    if (gTCPState == TCP_STATE_PASSIVE_OPEN_PENDING) {
+        log_message("SendText: Stream was in PASSIVE_OPEN_PENDING. Aborting pending listen to allow send.");
+        OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
+        if (abortErr == noErr) {
+            log_to_file_only("SendText: Abort of pending passive open successful.");
+        } else {
+            log_message("SendText: Abort of pending passive open FAILED: %d. Send may fail.", abortErr);
+            // If abort fails, the stream state is uncertain. Returning error.
+            return (abortErr == commandTimeout) ? streamBusyErr : abortErr;
+        }
+        gTCPState = TCP_STATE_IDLE; 
+        // gTCPPassiveOpenPB.ioResult will be set to an error by MacTCP due to the abort.
+        // PollTCP will handle this when it next checks that PB if it gets a chance.
+    }
+    // --- End Modification ---
+
     if (gIsSending) {
         log_message("Warning (SendText): Send already in progress.");
         return streamBusyErr;
     }
+    // This check is now more critical. If after attempting to abort a passive open,
+    // the state is still not IDLE (e.g., an incoming connection completed *just* before abort),
+    // then we cannot send.
     if (gTCPState != TCP_STATE_IDLE) {
-        log_message("Warning (SendText): Stream not IDLE (state %d), cannot send.", gTCPState);
+        log_message("Warning (SendText): Stream not IDLE (state %d) after attempting to clear. Cannot send now.", gTCPState);
         return streamBusyErr;
     }
-    gIsSending = true;
+
+    gIsSending = true; 
+
     err = ParseIPv4(peerIPStr, &targetIP);
     if (err != noErr || targetIP == 0) {
         log_message("Error (SendText): Invalid peer IP '%s'.", peerIPStr);
         finalErr = paramErr;
         goto SendTextCleanup;
     }
+
     formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT, gMyUsername, gMyLocalIPStr, message);
     if (formattedLen <= 0) {
         log_message("Error (SendText): format_message failed.");
         finalErr = paramErr;
         goto SendTextCleanup;
     }
+
     log_to_file_only("SendText: Connecting to %s...", peerIPStr);
-    err = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, targetIP, PORT_TCP, giveTime);
+    err = LowTCPActiveOpenSyncPoll(kConnectULPTimeoutSeconds, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
         log_to_file_only("SendText: Connected successfully to %s.", peerIPStr);
-        sendWDS[0].length = formattedLen;
+
+        sendWDS[0].length = formattedLen; 
         sendWDS[0].ptr = (Ptr)messageBuffer;
         sendWDS[1].length = 0;
         sendWDS[1].ptr = NULL;
+
         log_to_file_only("SendText: Sending data (%d bytes)...", formattedLen);
-        err = LowTCPSendSyncPoll(kSendTimeoutTicks, true , (Ptr)sendWDS, giveTime);
+        err = LowTCPSendSyncPoll(kSendULPTimeoutSeconds, true , (Ptr)sendWDS, giveTime);
         if (err != noErr) {
             log_message("Error (SendText): Send failed to %s: %d", peerIPStr, err);
             finalErr = err;
         } else {
             log_to_file_only("SendText: Send successful to %s.", peerIPStr);
         }
+
         log_to_file_only("SendText: Aborting connection to %s...", peerIPStr);
-        OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+        OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
         if (abortErr != noErr) {
             log_message("Warning (SendText): Abort failed for %s: %d", peerIPStr, abortErr);
-            if (finalErr == noErr) finalErr = abortErr;
+            if (finalErr == noErr) finalErr = abortErr; 
         }
     } else {
         log_message("Error (SendText): Connect to %s failed: %d", peerIPStr, err);
         finalErr = err;
     }
+
 SendTextCleanup:
-    gIsSending = false;
-    gTCPState = TCP_STATE_IDLE;
+    gIsSending = false; 
+    gTCPState = TCP_STATE_IDLE; 
     log_to_file_only("TCP_SendTextMessageSync to %s: Released send lock. Final Status: %d.", peerIPStr, finalErr);
     return finalErr;
 }
+
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
     int i;
     OSErr lastErr = noErr, currentErr = noErr;
-    char quitMessageBuffer[BUFFER_SIZE];
+    char quitMessageBuffer[BUFFER_SIZE]; 
     int formattedLen, activePeerCount = 0, sentCount = 0;
     unsigned long dummyTimer;
-    struct wdsEntry sendWDS[2];
+    struct wdsEntry sendWDS[2];         
+
     log_message("TCP_SendQuitMessagesSync: Starting...");
+
     if (gMacTCPRefNum == 0) return notOpenErr;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+     if (gTCPStream == NULL && gTCPState != TCP_STATE_RELEASING && gTCPState != TCP_STATE_UNINITIALIZED) {
+        if (gTCPStream == NULL) {
+             log_message("Error (SendQuit): gTCPStream is NULL and not in deep cleanup.");
+             return kInvalidStreamPtrErr;
+        }
+    }
     if (giveTime == NULL) return paramErr;
+
+    // --- Modification: Interrupt pending passive open if necessary ---
+    if (gTCPState == TCP_STATE_PASSIVE_OPEN_PENDING) {
+        log_message("SendQuit: Stream was in PASSIVE_OPEN_PENDING. Aborting pending listen to allow send.");
+        OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
+        if (abortErr == noErr) {
+            log_to_file_only("SendQuit: Abort of pending passive open successful.");
+        } else {
+            log_message("SendQuit: Abort of pending passive open FAILED: %d. Send may fail.", abortErr);
+            return (abortErr == commandTimeout) ? streamBusyErr : abortErr;
+        }
+        gTCPState = TCP_STATE_IDLE;
+    }
+    // --- End Modification ---
+
     if (gIsSending) {
         log_message("Warning (SendQuit): Send already in progress.");
         return streamBusyErr;
     }
     if (gTCPState != TCP_STATE_IDLE) {
-        log_message("Warning (SendQuit): Stream not IDLE (state %d). Cannot send QUIT now. Peer might be connecting.", gTCPState);
+        log_message("Warning (SendQuit): Stream not IDLE (state %d) after attempting to clear. Cannot send QUIT now.", gTCPState);
         return streamBusyErr;
     }
-    gIsSending = true;
+
+    gIsSending = true; 
+
     formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT, gMyUsername, gMyLocalIPStr, "");
     if (formattedLen <= 0) {
         log_message("Error (SendQuit): format_message for QUIT failed.");
         lastErr = paramErr;
         goto SendQuitCleanup;
     }
+
     for (i = 0; i < MAX_PEERS; ++i) if (gPeerManager.peers[i].active) activePeerCount++;
     log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
+
     if (activePeerCount == 0) {
         lastErr = noErr;
         goto SendQuitCleanup;
     }
+
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
             ip_addr currentTargetIP = 0;
-            currentErr = noErr;
+            currentErr = noErr; 
+
             if (gTCPState != TCP_STATE_IDLE) {
                 log_message("CRITICAL (SendQuit): State became non-IDLE (%d) during QUIT loop for peer %s. Aborting loop.", gTCPState, gPeerManager.peers[i].ip);
-                if (lastErr == noErr) lastErr = ioErr;
+                if (lastErr == noErr) lastErr = ioErr; 
                 break;
             }
+
             log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
             currentErr = ParseIPv4(gPeerManager.peers[i].ip, &currentTargetIP);
             if (currentErr != noErr || currentTargetIP == 0) {
                 log_message("Error (SendQuit): Could not parse IP '%s'. Skipping.", gPeerManager.peers[i].ip);
                 if (lastErr == noErr) lastErr = currentErr;
-                goto NextPeerDelay;
+                goto NextPeerDelay; 
             }
+
             log_to_file_only("SendQuit: Connecting to %s...", gPeerManager.peers[i].ip);
-            currentErr = LowTCPActiveOpenSyncPoll(kConnectTimeoutTicks, currentTargetIP, PORT_TCP, giveTime);
+            currentErr = LowTCPActiveOpenSyncPoll(kConnectULPTimeoutSeconds, currentTargetIP, PORT_TCP, giveTime);
             if (currentErr == noErr) {
                 log_to_file_only("SendQuit: Connected successfully to %s.", gPeerManager.peers[i].ip);
+
                 sendWDS[0].length = formattedLen;
                 sendWDS[0].ptr = (Ptr)quitMessageBuffer;
                 sendWDS[1].length = 0;
                 sendWDS[1].ptr = NULL;
+
                 log_to_file_only("SendQuit: Sending data to %s...", gPeerManager.peers[i].ip);
-                currentErr = LowTCPSendSyncPoll(kSendTimeoutTicks, true , (Ptr)sendWDS, giveTime);
+                currentErr = LowTCPSendSyncPoll(kSendULPTimeoutSeconds, true, (Ptr)sendWDS, giveTime);
                 if (currentErr == noErr) {
                     log_to_file_only("SendQuit: Send successful for %s.", gPeerManager.peers[i].ip);
                     sentCount++;
@@ -365,8 +555,9 @@ OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
                     log_message("Error (SendQuit): Send failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
                     if (lastErr == noErr) lastErr = currentErr;
                 }
+
                 log_to_file_only("SendQuit: Aborting connection to %s...", gPeerManager.peers[i].ip);
-                OSErr abortErr = LowTCPAbortSyncPoll(kAbortTimeoutTicks, giveTime);
+                OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 if (abortErr != noErr) {
                     log_message("Warning (SendQuit): Abort failed for %s: %d", gPeerManager.peers[i].ip, abortErr);
                     if (lastErr == noErr) lastErr = abortErr;
@@ -374,45 +565,56 @@ OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
             } else {
                 log_message("Error (SendQuit): Connect failed for %s: %d", gPeerManager.peers[i].ip, currentErr);
                 if (lastErr == noErr) lastErr = currentErr;
-                if (currentErr == kConnectionExistsErr) {
-                     log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely just disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
+                if (currentErr == kConnectionExistsErr) { 
+                     log_message("SendQuit: Connect to %s failed with -23007 (connectionExists). Peer likely disconnected or in TIME_WAIT. Skipping QUIT.", gPeerManager.peers[i].ip);
                 }
             }
         NextPeerDelay:
             log_to_file_only("SendQuit: Yielding/Delaying (%d ticks) after peer %s...", kQuitLoopDelayTicks, gPeerManager.peers[i].ip);
-            giveTime();
+            giveTime(); 
             Delay(kQuitLoopDelayTicks, &dummyTimer);
         }
     }
+
 SendQuitCleanup:
-    gIsSending = false;
-    gTCPState = TCP_STATE_IDLE;
+    gIsSending = false; 
+    gTCPState = TCP_STATE_IDLE; 
     log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers. Last error: %d.", sentCount, activePeerCount, lastErr);
     return lastErr;
 }
+
+
+// --- Internal Helper Functions ---
+
 static void ProcessTCPReceive(unsigned short dataLength) {
     char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN];
+    char senderIPStrFromPayload[INET_ADDRSTRLEN]; 
     char senderUsername[32];
     char msgType[32];
-    char content[BUFFER_SIZE];
+    char content[BUFFER_SIZE]; 
+
     static tcp_platform_callbacks_t mac_callbacks = {
         .add_or_update_peer = mac_tcp_add_or_update_peer,
         .display_text_message = mac_tcp_display_text_message,
         .mark_peer_inactive = mac_tcp_mark_peer_inactive
     };
+
     if (dataLength > 0 && gTCPRecvBuffer != NULL) {
         OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
-        if (addrErr != noErr) {
+        if (addrErr != noErr) { 
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
             log_to_file_only("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
         }
+
         if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0';
         else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0';
+
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
             log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
                              msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
+
             handle_received_tcp_message(senderIPStrFromConnection, senderUsername, msgType, content, &mac_callbacks, NULL);
+
             if (strcmp(msgType, MSG_QUIT) == 0) {
                 log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
             }
@@ -425,47 +627,73 @@ static void ProcessTCPReceive(unsigned short dataLength) {
         log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
     }
 }
-static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt8 appPollTimeoutTicks) {
+
+static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt16 appPollTimeoutTicks) {
     OSErr err;
     unsigned long startTime = TickCount();
+
     if (pBlock == NULL || giveTime == NULL) return paramErr;
-    pBlock->ioCompletion = nil;
+    if (gMacTCPRefNum == 0) return notOpenErr; 
+    
+    // Check gTCPStream validity unless we are creating or releasing the stream itself.
+    // For release, pBlock->tcpStream is used directly.
+    if (csCode != TCPCreate && csCode != TCPRelease) {
+        if (gTCPStream == NULL) {
+            log_message("Error (LowLevelSyncPoll %d): gTCPStream is NULL.", csCode);
+            return kInvalidStreamPtrErr;
+        }
+        // Ensure the PB uses the global stream for most operations
+        pBlock->tcpStream = gTCPStream;
+    } else if (csCode == TCPRelease && pBlock->tcpStream == NULL) {
+        // If releasing, the pBlock MUST have a valid stream pointer
+        log_message("Error (LowLevelSyncPoll TCPRelease): pBlock->tcpStream is NULL.");
+        return kInvalidStreamPtrErr;
+    }
+
+
+    pBlock->ioCompletion = nil; 
     pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->tcpStream = gTCPStream;
-    pBlock->ioResult = 1;
+    pBlock->ioResult = 1; 
     pBlock->csCode = csCode;
+
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
         log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
         return err;
     }
-    while (pBlock->ioResult > 0) {
-        giveTime();
+
+    while (pBlock->ioResult > 0) { 
+        giveTime(); 
         if (appPollTimeoutTicks > 0 && (TickCount() - startTime) >= (unsigned long)appPollTimeoutTicks) {
             log_to_file_only("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
             return commandTimeout;
         }
     }
-    return pBlock->ioResult;
+    return pBlock->ioResult; 
 }
+
+
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr rcvBuff, unsigned long rcvBuffLen) {
     OSErr err;
-    TCPiopb pbCreate;
+    TCPiopb pbCreate; 
+
     if (streamPtrOut == NULL || rcvBuff == NULL) return paramErr;
+
     memset(&pbCreate, 0, sizeof(TCPiopb));
     pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L;
+    pbCreate.tcpStream = 0L; 
     pbCreate.csParam.create.rcvBuff = rcvBuff;
     pbCreate.csParam.create.rcvBuffLen = rcvBuffLen;
-    pbCreate.csParam.create.notifyProc = nil;
+    pbCreate.csParam.create.notifyProc = nil; 
+
     err = PBControlSync((ParmBlkPtr)&pbCreate);
     if (err == noErr) {
         *streamPtrOut = pbCreate.tcpStream;
         if (*streamPtrOut == NULL) {
             log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
-            err = ioErr;
+            err = ioErr; 
         }
     } else {
         *streamPtrOut = NULL;
@@ -473,119 +701,120 @@ static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr r
     }
     return err;
 }
-static OSErr LowTCPPassiveOpenSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime) {
-    OSErr err;
-    TCPiopb pbOpen;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+
+static OSErr LowTCPActiveOpenSyncPoll(Byte ulpTimeoutSeconds, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
+    TCPiopb pbOpen; 
+    SInt16 pollTimeout;
+
+    // gTCPStream must be valid here, checked by LowLevelSyncPoll
     memset(&pbOpen, 0, sizeof(TCPiopb));
-    pbOpen.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
-    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
-    pbOpen.csParam.open.commandTimeoutValue = 2;
-    pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    pbOpen.csParam.open.localPort = PORT_TCP;
-    pbOpen.csParam.open.localHost = 0L;
-    pbOpen.csParam.open.remoteHost = 0L;
-    pbOpen.csParam.open.remotePort = 0;
-    pbOpen.csParam.open.tosFlags = 0;
-    pbOpen.csParam.open.precedence = 0;
-    pbOpen.csParam.open.dontFrag = false;
-    pbOpen.csParam.open.timeToLive = 0;
-    pbOpen.csParam.open.security = 0;
-    pbOpen.csParam.open.optionCnt = 0;
-    err = LowLevelSyncPoll(&pbOpen, giveTime, TCPPassiveOpen, appPollTimeoutTicks);
-    if (err == noErr) {
-        gPeerIP = pbOpen.csParam.open.remoteHost;
-        gPeerPort = pbOpen.csParam.open.remotePort;
-    } else {
-        gPeerIP = 0; gPeerPort = 0;
-    }
-    return err;
-}
-static OSErr LowTCPActiveOpenSyncPoll(SInt8 ulpTimeoutTicksForCall, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
-    TCPiopb pbOpen;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
-    memset(&pbOpen, 0, sizeof(TCPiopb));
-    pbOpen.csParam.open.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60);
-    if (pbOpen.csParam.open.ulpTimeoutValue == 0) pbOpen.csParam.open.ulpTimeoutValue = 1;
+    // pbOpen.tcpStream will be set by LowLevelSyncPoll if gTCPStream is valid
+
+    pbOpen.csParam.open.ulpTimeoutValue = ulpTimeoutSeconds;
     pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
     pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    pbOpen.csParam.open.commandTimeoutValue = 0;
+    pbOpen.csParam.open.commandTimeoutValue = 0; 
     pbOpen.csParam.open.remoteHost = remoteHost;
     pbOpen.csParam.open.remotePort = remotePort;
-    pbOpen.csParam.open.localPort = 0;
-    pbOpen.csParam.open.localHost = 0L;
-    pbOpen.csParam.open.tosFlags = 0;
-    pbOpen.csParam.open.precedence = 0;
-    pbOpen.csParam.open.dontFrag = false;
-    pbOpen.csParam.open.timeToLive = 0;
-    pbOpen.csParam.open.security = 0;
-    pbOpen.csParam.open.optionCnt = 0;
-    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60;
-    return LowLevelSyncPoll(&pbOpen, giveTime, TCPActiveOpen, appPollTimeout);
+    pbOpen.csParam.open.localPort = 0;  
+    pbOpen.csParam.open.localHost = 0L; 
+
+    pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30; 
+    return LowLevelSyncPoll(&pbOpen, giveTime, TCPActiveOpen, pollTimeout);
 }
-static OSErr LowTCPSendSyncPoll(SInt8 ulpTimeoutTicksForCall, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) {
-    TCPiopb pbSend;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+
+static OSErr LowTCPSendSyncPoll(Byte ulpTimeoutSeconds, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) {
+    TCPiopb pbSend; 
+    SInt16 pollTimeout;
+
     if (wdsPtr == NULL) return kInvalidWDSErr;
+    // gTCPStream must be valid, checked by LowLevelSyncPoll
+
     memset(&pbSend, 0, sizeof(TCPiopb));
-    pbSend.csParam.send.ulpTimeoutValue = (Byte)(ulpTimeoutTicksForCall / 60);
-    if (pbSend.csParam.send.ulpTimeoutValue == 0) pbSend.csParam.send.ulpTimeoutValue = 1;
+    // pbSend.tcpStream will be set by LowLevelSyncPoll
+
+    pbSend.csParam.send.ulpTimeoutValue = ulpTimeoutSeconds;
     pbSend.csParam.send.ulpTimeoutAction = AbortTrue;
     pbSend.csParam.send.validityFlags = timeoutValue | timeoutAction;
     pbSend.csParam.send.pushFlag = push;
     pbSend.csParam.send.urgentFlag = false;
     pbSend.csParam.send.wdsPtr = wdsPtr;
-    SInt8 appPollTimeout = ulpTimeoutTicksForCall + 60;
-    return LowLevelSyncPoll(&pbSend, giveTime, TCPSend, appPollTimeout);
+
+    pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
+    return LowLevelSyncPoll(&pbSend, giveTime, TCPSend, pollTimeout);
 }
-static OSErr LowTCPRcvSyncPoll(SInt8 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) {
+
+static OSErr LowTCPRcvSyncPoll(SInt16 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) {
     OSErr err;
-    TCPiopb pbRcv;
+    TCPiopb pbRcv; 
     unsigned short initialBufferLen;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+
     if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return kInvalidBufPtrErr;
     if (markFlag == NULL || urgentFlag == NULL) return paramErr;
-    initialBufferLen = *bufferLen;
+    // gTCPStream must be valid, checked by LowLevelSyncPoll
+
+    initialBufferLen = *bufferLen; 
+
     memset(&pbRcv, 0, sizeof(TCPiopb));
-    pbRcv.csParam.receive.commandTimeoutValue = 1;
+    // pbRcv.tcpStream will be set by LowLevelSyncPoll
+
+    pbRcv.csParam.receive.commandTimeoutValue = 1; 
     pbRcv.csParam.receive.rcvBuff = buffer;
     pbRcv.csParam.receive.rcvBuffLen = initialBufferLen;
+
     err = LowLevelSyncPoll(&pbRcv, giveTime, TCPRcv, appPollTimeoutTicks);
-    *bufferLen = pbRcv.csParam.receive.rcvBuffLen;
+
+    *bufferLen = pbRcv.csParam.receive.rcvBuffLen; 
     *markFlag = pbRcv.csParam.receive.markFlag;
     *urgentFlag = pbRcv.csParam.receive.urgentFlag;
+
     return err;
 }
-static OSErr LowTCPStatusSyncPoll(SInt8 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) {
+
+static OSErr LowTCPStatusSyncPoll(SInt16 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) {
     OSErr err;
-    TCPiopb pbStat;
-    if (gTCPStream == NULL) return kInvalidStreamPtrErr;
+    TCPiopb pbStat; 
+
     if (amtUnread == NULL || connState == NULL) return paramErr;
+    // gTCPStream must be valid, checked by LowLevelSyncPoll
+
     memset(&pbStat, 0, sizeof(TCPiopb));
+    // pbStat.tcpStream will be set by LowLevelSyncPoll
+
     err = LowLevelSyncPoll(&pbStat, giveTime, TCPStatus, appPollTimeoutTicks);
+
     if (err == noErr) {
         *amtUnread = pbStat.csParam.status.amtUnreadData;
         *connState = pbStat.csParam.status.connectionState;
     } else {
         *amtUnread = 0;
-        *connState = 0;
+        *connState = 0; 
         log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
         if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr;
     }
     return err;
 }
-static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicksForAbort, GiveTimePtr giveTime) {
+
+static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime) {
     OSErr err;
-    TCPiopb pbAbort;
+    TCPiopb pbAbort; 
+    SInt16 pollTimeout;
+
+    // Check gTCPStream here because LowLevelSyncPoll might be too late if it's already NULL
     if (gTCPStream == NULL) {
         log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
-        return noErr;
+        return noErr; 
     }
+    
     memset(&pbAbort, 0, sizeof(TCPiopb));
-    err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, ulpTimeoutTicksForAbort);
-    if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr) {
-        log_to_file_only("LowTCPAbortSyncPoll: Abort completed (connection doesn't exist or stream invalid). Result: %d. Considered OK for reset.", err);
-        err = noErr;
+    // pbAbort.tcpStream will be set by LowLevelSyncPoll using gTCPStream
+
+    pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
+    err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, pollTimeout);
+
+    if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr || err == kRequestAbortedErr) {
+        log_to_file_only("LowTCPAbortSyncPoll: Abort completed (err %d). Considered OK for reset.", err);
+        err = noErr; 
     } else if (err != noErr) {
         log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
     } else {
@@ -593,21 +822,25 @@ static OSErr LowTCPAbortSyncPoll(SInt8 ulpTimeoutTicksForAbort, GiveTimePtr give
     }
     return err;
 }
+
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease) {
     OSErr err;
-    TCPiopb pbRelease;
+    TCPiopb pbRelease; 
+
     if (streamToRelease == NULL) return kInvalidStreamPtrErr;
+
     memset(&pbRelease, 0, sizeof(TCPiopb));
     pbRelease.ioCompletion = nil;
     pbRelease.ioCRefNum = macTCPRefNum;
     pbRelease.csCode = TCPRelease;
-    pbRelease.tcpStream = streamToRelease;
+    pbRelease.tcpStream = streamToRelease; // Use the passed-in stream
+
     err = PBControlSync((ParmBlkPtr)&pbRelease);
-    if (err != noErr && err != kInvalidStreamPtrErr) {
+    if (err != noErr && err != kInvalidStreamPtrErr) { 
         log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
     } else if (err == kInvalidStreamPtrErr) {
         log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
-        err = noErr;
+        err = noErr; 
     }
     return err;
 }

--- a/classic_mac/tcp.c
+++ b/classic_mac/tcp.c
@@ -1,51 +1,39 @@
-//====================================
-// FILE: ./classic_mac/tcp.c
-//====================================
-
 #include "tcp.h"
 #include "logging.h"
 #include "protocol.h"
 #include "peer_mac.h"
-#include "dialog.h" // For updating UI if needed
+#include "dialog.h"
 #include "dialog_peerlist.h"
-#include "network.h" // For gMacTCPRefNum, gMyUsername, gMyLocalIPStr, ParseIPv4, YieldTimeToSystem
+#include "network.h"
 #include "../shared/messaging_logic.h"
 #include <Devices.h>
 #include <Errors.h>
-#include <Memory.h> // For NewPtrClear, DisposePtr
-#include <string.h> // For memset, strcmp
-#include <stdio.h>  // For sprintf
-#include <stdlib.h> // For size_t if needed
-
-// --- Constants ---
-#define kTCPRecvBufferSize 8192           // Buffer for receiving data on the listener stream
-#define kTCPListenInternalBufferSize 8192 // Internal buffer needed by MacTCP for the listener stream
-#define kTCPSenderInternalBufferSize 2048 // Smaller internal buffer for temporary sender streams
-#define kTCPListenRetryDelayTicks 60      // Delay before retrying listen after certain errors
-#define kShutdownConnectTimeoutTicks 180  // Timeout for connecting when sending QUIT (3 sec)
-#define kShutdownSendTimeoutTicks 120     // Timeout for sending QUIT data (2 sec)
-#define kRuntimeConnectTimeoutTicks 300   // Timeout for connecting when sending TEXT (5 sec)
-#define kRuntimeSendTimeoutTicks 180      // Timeout for sending TEXT data (3 sec)
-#define AbortTrue 1                       // ULP Timeout Action: Abort connection
-
-// --- Listener Stream Globals ---
-static StreamPtr gTCPListenStream = NULL;         // The persistent stream for listening
-static Ptr gTCPListenInternalBuffer = NULL; // MacTCP's internal buffer for the listener
-static Ptr gTCPRecvBuffer = NULL;           // Our buffer for received data on the listener
-static TCPiopb gTCPListenPB;                // PB for TCPPassiveOpen (listen)
-static TCPiopb gTCPRecvPB;                  // PB for TCPRcv (receive data)
-static TCPiopb gTCPClosePB;                 // PB for TCPClose (close accepted connection)
-
-// --- Listener State ---
-static Boolean gTCPListenPending = false;   // Is TCPPassiveOpen pending?
-static Boolean gTCPRecvPending = false;     // Is TCPRcv pending?
-static Boolean gTCPClosePending = false;    // Is TCPClose pending?
-static Boolean gNeedToReListen = false;     // Flag to re-issue listen after connection ends/fails
-ip_addr gCurrentConnectionIP = 0;           // IP of peer connected to listener stream
-tcp_port gCurrentConnectionPort = 0;       // Port of peer connected to listener stream
-Boolean gIsConnectionActive = false;        // Is listener stream currently handling an active connection?
-
-// --- Forward Declarations ---
+#include <Memory.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#define kTCPRecvBufferSize 8192
+#define kTCPListenInternalBufferSize 8192
+#define kTCPSenderInternalBufferSize 2048
+#define kTCPListenRetryDelayTicks 60
+#define kShutdownConnectTimeoutTicks 180
+#define kShutdownSendTimeoutTicks 120
+#define kRuntimeConnectTimeoutTicks 300
+#define kRuntimeSendTimeoutTicks 180
+#define AbortTrue 1
+static StreamPtr gTCPListenStream = NULL;
+static Ptr gTCPListenInternalBuffer = NULL;
+static Ptr gTCPRecvBuffer = NULL;
+static TCPiopb gTCPListenPB;
+static TCPiopb gTCPRecvPB;
+static TCPiopb gTCPClosePB;
+static Boolean gTCPListenPending = false;
+static Boolean gTCPRecvPending = false;
+static Boolean gTCPClosePending = false;
+static Boolean gNeedToReListen = false;
+ip_addr gCurrentConnectionIP = 0;
+tcp_port gCurrentConnectionPort = 0;
+Boolean gIsConnectionActive = false;
 static OSErr StartAsyncTCPListen(short macTCPRefNum);
 static OSErr StartAsyncTCPRecv(short macTCPRefNum);
 static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection);
@@ -53,72 +41,56 @@ static void ProcessTCPReceive(short macTCPRefNum);
 static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult);
 static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult);
 static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult);
-
-// --- Low-Level Synchronous TCP Helper Functions ---
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen);
 static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost, tcp_port remotePort, ip_addr *localHost, tcp_port *localPort, GiveTimePtr giveTime);
 static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent, Ptr wdsPtr, GiveTimePtr giveTime);
 static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr);
-
-// --- Shared Logic Callbacks ---
 static int mac_tcp_add_or_update_peer(const char* ip, const char* username, void* platform_context) {
-    (void)platform_context; // Unused context
+    (void)platform_context;
     int addResult = AddOrUpdatePeer(ip, username);
     if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
         if (gMainWindow != NULL && gPeerListHandle != NULL) {
-            UpdatePeerDisplayList(true); // Update UI if a new peer is seen
+            UpdatePeerDisplayList(true);
         }
     } else if (addResult < 0) {
         log_message("Peer list full, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
-
 static void mac_tcp_display_text_message(const char* username, const char* ip, const char* message_content, void* platform_context) {
-    (void)platform_context; // Unused context
-    (void)ip; // IP address is available if needed, but username is primary display info
-    char displayMsg[BUFFER_SIZE + 100]; // Ensure buffer is large enough
-
+    (void)platform_context;
+    (void)ip;
+    char displayMsg[BUFFER_SIZE + 100];
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
-        // Format message for display
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
-        AppendToMessagesTE("\r"); // Add newline
+        AppendToMessagesTE("\r");
         log_message("Message from %s@%s: %s", username, ip, message_content);
     } else {
-        // Log if UI isn't ready
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
-
 static void mac_tcp_mark_peer_inactive(const char* ip, void* platform_context) {
-    (void)platform_context; // Unused context
+    (void)platform_context;
     if (!ip) return;
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
-        // Update UI if peer is successfully marked inactive
         if (gMainWindow != NULL && gPeerListHandle != NULL) {
             UpdatePeerDisplayList(true);
         }
     }
 }
-
-// --- Public Functions ---
-
 OSErr InitTCPListener(short macTCPRefNum) {
     OSErr err;
     StreamPtr tempListenStream = NULL;
-
     log_message("Initializing TCP Listener Stream...");
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPListenStream != NULL) {
         log_message("Error (InitTCPListener): Already initialized?");
-        return streamAlreadyOpen; // Already initialized
+        return streamAlreadyOpen;
     }
-
-    // Allocate buffers
     gTCPListenInternalBuffer = NewPtrClear(kTCPListenInternalBufferSize);
      if (gTCPListenInternalBuffer == NULL) {
         log_message("Fatal Error: Could not allocate TCP listen internal buffer (%ld bytes).", (long)kTCPListenInternalBufferSize);
@@ -132,28 +104,22 @@ OSErr InitTCPListener(short macTCPRefNum) {
     }
     log_message("Allocated TCP buffers (ListenInternal: %ld, Recv: %ld).",
                 (long)kTCPListenInternalBufferSize, (long)kTCPRecvBufferSize);
-
-    // Create the persistent listener stream
     log_message("Creating Listener Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &tempListenStream, gTCPListenInternalBuffer, kTCPListenInternalBufferSize);
     if (err != noErr || tempListenStream == NULL) {
         log_message("Error: Failed to create Listener Stream: %d", err);
-        CleanupTCPListener(macTCPRefNum); // Clean up allocated buffers
+        CleanupTCPListener(macTCPRefNum);
         return err;
     }
     gTCPListenStream = tempListenStream;
     log_message("Listener Stream created successfully (StreamPtr: 0x%lX).", (unsigned long)gTCPListenStream);
-
-    // Initialize state variables
     gNeedToReListen = false;
     gIsConnectionActive = false;
     gTCPListenPending = false;
     gTCPRecvPending = false;
     gTCPClosePending = false;
-
-    // Start the first asynchronous listen
     err = StartAsyncTCPListen(macTCPRefNum);
-    if (err != noErr && err != 1) { // 1 means already pending (shouldn't happen here)
+    if (err != noErr && err != 1) {
          log_message("Error: Failed to start initial async TCP listen: %d. Cleaning up.", err);
          CleanupTCPListener(macTCPRefNum);
          return err;
@@ -161,17 +127,13 @@ OSErr InitTCPListener(short macTCPRefNum) {
     log_message("Initial asynchronous TCP listen STARTING on port %d.", PORT_TCP);
     return noErr;
 }
-
 void CleanupTCPListener(short macTCPRefNum) {
     OSErr relErr;
     log_message("Cleaning up TCP Listener Stream...");
-
-    StreamPtr listenStreamToRelease = gTCPListenStream; // Capture current stream pointer
-    gTCPListenStream = NULL; // Prevent further use
-
-    // Kill any pending operations on the listener stream
+    StreamPtr listenStreamToRelease = gTCPListenStream;
+    gTCPListenStream = NULL;
     if (gTCPListenPending && gTCPListenPB.tcpStream == listenStreamToRelease) {
-        PBKillIO((ParmBlkPtr)&gTCPListenPB, false); // Async kill, ignore error
+        PBKillIO((ParmBlkPtr)&gTCPListenPB, false);
         log_to_file_only("CleanupTCPListener: Killed pending Listen IO.");
     }
     if (gTCPRecvPending && gTCPRecvPB.tcpStream == listenStreamToRelease) {
@@ -182,8 +144,6 @@ void CleanupTCPListener(short macTCPRefNum) {
         PBKillIO((ParmBlkPtr)&gTCPClosePB, false);
         log_to_file_only("CleanupTCPListener: Killed pending Close IO.");
     }
-
-    // Reset state flags
     gTCPListenPending = false;
     gTCPRecvPending = false;
     gTCPClosePending = false;
@@ -191,13 +151,10 @@ void CleanupTCPListener(short macTCPRefNum) {
     gIsConnectionActive = false;
     gCurrentConnectionIP = 0;
     gCurrentConnectionPort = 0;
-
-    // Release the stream synchronously if it exists and driver is open
     if (listenStreamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting synchronous release of listener stream 0x%lX...", (unsigned long)listenStreamToRelease);
         relErr = LowTCPReleaseSync(macTCPRefNum, listenStreamToRelease);
         if (relErr != noErr) {
-             // Log warning, but proceed with buffer cleanup
              log_message("Warning (CleanupTCPListener): Synchronous TCPRelease failed: %d", relErr);
         } else {
              log_to_file_only("CleanupTCPListener: Synchronous TCPRelease successful.");
@@ -205,8 +162,6 @@ void CleanupTCPListener(short macTCPRefNum) {
     } else if (listenStreamToRelease != NULL) {
         log_message("Warning (CleanupTCPListener): Cannot release stream, MacTCP refnum is 0.");
     }
-
-    // Dispose buffers
     if (gTCPRecvBuffer != NULL) {
         log_message("Disposing TCP receive buffer at 0x%lX.", (unsigned long)gTCPRecvBuffer);
         DisposePtr(gTCPRecvBuffer);
@@ -217,45 +172,34 @@ void CleanupTCPListener(short macTCPRefNum) {
         DisposePtr(gTCPListenInternalBuffer);
         gTCPListenInternalBuffer = NULL;
     }
-
     log_message("TCP Listener Stream cleanup finished.");
 }
-
 void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP) {
     OSErr ioResult;
-
-    // Check for completed Listen operation
     if (gTCPListenPending) {
         ioResult = gTCPListenPB.ioResult;
-        if (ioResult <= 0) { // Completed (success or error)
-            gTCPListenPending = false; // Clear flag *before* handling
+        if (ioResult <= 0) {
+            gTCPListenPending = false;
             HandleListenerCompletion(macTCPRefNum, ioResult);
         }
     }
-
-    // Check for completed Receive operation (only if connection is active)
     if (gTCPRecvPending && gIsConnectionActive) {
-        // Defensive check: Ensure the completion is for the correct stream
         if (gTCPRecvPB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
             ioResult = gTCPRecvPB.ioResult;
-            if (ioResult <= 0) { // Completed
-                gTCPRecvPending = false; // Clear flag *before* handling
+            if (ioResult <= 0) {
+                gTCPRecvPending = false;
                 HandleReceiveCompletion(macTCPRefNum, ioResult);
             }
         } else if (gTCPRecvPending) {
-             // Should not happen if state is managed correctly, but log defensively
              log_message("Warning (PollTCPListener): Receive pending but stream pointer mismatch or NULL. Clearing flag.");
              gTCPRecvPending = false;
         }
     }
-
-    // Check for completed Close operation
     if (gTCPClosePending) {
-        // Defensive check: Ensure the completion is for the correct stream
         if (gTCPClosePB.tcpStream == gTCPListenStream && gTCPListenStream != NULL) {
             ioResult = gTCPClosePB.ioResult;
-            if (ioResult <= 0) { // Completed
-                gTCPClosePending = false; // Clear flag *before* handling
+            if (ioResult <= 0) {
+                gTCPClosePending = false;
                 HandleCloseCompletion(macTCPRefNum, ioResult);
             }
         } else if (gTCPClosePending) {
@@ -263,28 +207,23 @@ void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP) {
              gTCPClosePending = false;
         }
     }
-
-    // Check if we need to re-issue the listen command
     if (gNeedToReListen && gTCPListenStream != NULL &&
         !gTCPListenPending && !gTCPRecvPending && !gTCPClosePending && !gIsConnectionActive)
     {
         log_to_file_only("PollTCPListener: Conditions met to attempt re-issuing listen.");
-        gNeedToReListen = false; // Clear flag *before* attempting
+        gNeedToReListen = false;
         OSErr err = StartAsyncTCPListen(macTCPRefNum);
-        if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen here)
+        if (err != noErr && err != 1) {
             log_message("Error (PollTCPListener): Attempt to re-issue listen failed immediately. Error: %d. Will retry later.", err);
-            gNeedToReListen = true; // Set flag again to retry on next poll
+            gNeedToReListen = true;
         } else {
             log_to_file_only("PollTCPListener: Re-issued Async TCPPassiveOpen successfully (or already pending).");
         }
     } else if (gNeedToReListen && gTCPListenStream == NULL) {
-        // This indicates a serious problem, listener stream was likely released due to error
         log_message("Warning (PollTCPListener): Need to re-listen but stream is NULL. Cannot proceed.");
-        gNeedToReListen = false; // Stop trying if stream is gone
+        gNeedToReListen = false;
     }
 }
-
-// Internal function to perform a complete synchronous send operation using a temporary stream
 static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
                                  const char *messageBuffer, int messageLen,
                                  SInt8 connectTimeoutTicks, SInt8 sendTimeoutTicks,
@@ -295,83 +234,61 @@ static OSErr InternalSyncTCPSend(ip_addr targetIP, tcp_port targetPort,
     StreamPtr tempStream = NULL;
     Ptr tempConnBuffer = NULL;
     struct wdsEntry sendWDS[2];
-
     log_to_file_only("InternalSyncTCPSend: To IP %lu:%u (%d bytes)", (unsigned long)targetIP, targetPort, messageLen);
-
-    // 1. Allocate temporary buffer for the temporary stream
     tempConnBuffer = NewPtrClear(kTCPSenderInternalBufferSize);
     if (tempConnBuffer == NULL) {
         log_message("Error (InternalSyncTCPSend): Failed to allocate temporary connection buffer.");
         return memFullErr;
     }
-
-    // 2. Create temporary stream
     err = LowTCPCreateSync(gMacTCPRefNum, &tempStream, tempConnBuffer, kTCPSenderInternalBufferSize);
     if (err != noErr || tempStream == NULL) {
         log_message("Error (InternalSyncTCPSend): LowTCPCreateSync failed: %d", err);
-        DisposePtr(tempConnBuffer); // Clean up buffer
+        DisposePtr(tempConnBuffer);
         return err;
     }
     log_to_file_only("InternalSyncTCPSend: Temp stream 0x%lX created.", (unsigned long)tempStream);
-
-    // 3. Connect using the temporary stream
     log_to_file_only("InternalSyncTCPSend: Connecting temp stream 0x%lX...", (unsigned long)tempStream);
     err = LowTCPOpenConnectionSync(tempStream, connectTimeoutTicks, targetIP, targetPort, NULL, NULL, giveTime);
     if (err == noErr) {
         log_to_file_only("InternalSyncTCPSend: Connected successfully.");
-
-        // 4. Send data
         sendWDS[0].length = messageLen;
-        sendWDS[0].ptr = (Ptr)messageBuffer; // Cast away const, WDS expects Ptr
-        sendWDS[1].length = 0; // Terminator for WDS array
+        sendWDS[0].ptr = (Ptr)messageBuffer;
+        sendWDS[1].length = 0;
         sendWDS[1].ptr = NULL;
-
         log_to_file_only("InternalSyncTCPSend: Sending data...");
         err = LowTCPSendSync(tempStream, sendTimeoutTicks, true, false, (Ptr)sendWDS, giveTime);
         if (err == noErr) {
             log_to_file_only("InternalSyncTCPSend: Send successful.");
         } else {
             log_message("Error (InternalSyncTCPSend): LowTCPSendSync failed: %d", err);
-            finalErr = err; // Record send error
+            finalErr = err;
         }
-
-        // 5. Abort connection (no need for graceful close for one-shot send)
         log_to_file_only("InternalSyncTCPSend: Aborting connection...");
         OSErr abortErr = LowTCPAbortSync(tempStream, giveTime);
         if (abortErr != noErr) {
             log_message("Warning (InternalSyncTCPSend): LowTCPAbortSync failed: %d", abortErr);
-            if (finalErr == noErr) finalErr = abortErr; // Record abort error if no prior error
+            if (finalErr == noErr) finalErr = abortErr;
         }
-
     } else {
         log_message("Error (InternalSyncTCPSend): LowTCPOpenConnectionSync failed: %d", err);
-        finalErr = err; // Record connect error
+        finalErr = err;
     }
-
-    // 6. Release the temporary stream (regardless of errors)
     log_to_file_only("InternalSyncTCPSend: Releasing temp stream 0x%lX...", (unsigned long)tempStream);
     OSErr releaseErr = LowTCPReleaseSync(gMacTCPRefNum, tempStream);
     if (releaseErr != noErr) {
         log_message("Warning (InternalSyncTCPSend): LowTCPReleaseSync failed: %d", releaseErr);
-        if (finalErr == noErr) finalErr = releaseErr; // Record release error if no prior error
+        if (finalErr == noErr) finalErr = releaseErr;
     }
-
-    // 7. Dispose the temporary connection buffer
     DisposePtr(tempConnBuffer);
-
     log_to_file_only("InternalSyncTCPSend: Finished. Final status: %d", finalErr);
     return finalErr;
 }
-
-
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime) {
     OSErr err = noErr;
     ip_addr targetIP = 0;
     char messageBuffer[BUFFER_SIZE];
     int formattedLen;
-
     log_to_file_only("TCP_SendTextMessageSync: Attempting to send TEXT to %s", peerIP);
-
     if (gMacTCPRefNum == 0) {
         log_message("Error (TCP_SendTextMessageSync): MacTCP not initialized.");
         return notOpenErr;
@@ -379,46 +296,34 @@ OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimeP
     if (peerIP == NULL || message == NULL || giveTime == NULL) {
         return paramErr;
     }
-
-    // Parse the destination IP address
     err = ParseIPv4(peerIP, &targetIP);
     if (err != noErr || targetIP == 0) {
         log_message("Error (TCP_SendTextMessageSync): Could not parse peer IP string '%s'.", peerIP);
         return paramErr;
     }
-
-    // Format the message using the shared protocol function
     formattedLen = format_message(messageBuffer, BUFFER_SIZE, MSG_TEXT,
                                   gMyUsername, gMyLocalIPStr, message);
     if (formattedLen <= 0) {
         log_message("Error (TCP_SendTextMessageSync): Failed to format TEXT message for %s.", peerIP);
-        return paramErr; // Or a more specific error
+        return paramErr;
     }
-
-    // Use the internal synchronous send function
     err = InternalSyncTCPSend(targetIP, PORT_TCP, messageBuffer, formattedLen,
                               kRuntimeConnectTimeoutTicks, kRuntimeSendTimeoutTicks, giveTime);
-
     if (err == noErr) {
         log_message("Successfully sent TEXT message to %s.", peerIP);
     } else {
         log_message("Failed to send TEXT message to %s (Error: %d).", peerIP, err);
     }
-
     return err;
 }
-
-
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
     int i;
-    OSErr lastErr = noErr; // Track the last error encountered
+    OSErr lastErr = noErr;
     char quitMessageBuffer[BUFFER_SIZE];
     int formattedLen;
     int activePeerCount = 0;
     int sentCount = 0;
-
     log_message("TCP_SendQuitMessagesSync: Starting...");
-
     if (gMacTCPRefNum == 0) {
         log_message("TCP_SendQuitMessagesSync: Cannot send, MacTCP not initialized.");
         return notOpenErr;
@@ -426,348 +331,252 @@ OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime) {
      if (giveTime == NULL) {
         return paramErr;
     }
-
-    // Format the QUIT message once
     formattedLen = format_message(quitMessageBuffer, BUFFER_SIZE, MSG_QUIT,
                                   gMyUsername, gMyLocalIPStr, "");
     if (formattedLen <= 0) {
         log_message("Error (TCP_SendQuitMessagesSync): Failed to format QUIT message.");
-        return paramErr; // Or a more specific error
+        return paramErr;
     }
-
-    // Count active peers first (for logging)
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
             activePeerCount++;
         }
     }
     log_message("TCP_SendQuitMessagesSync: Found %d active peers to notify.", activePeerCount);
-
-    // Iterate through peers and send QUIT using temporary streams
     for (i = 0; i < MAX_PEERS; ++i) {
         if (gPeerManager.peers[i].active) {
             ip_addr targetIP = 0;
             OSErr parseErr, sendErr;
-
             log_message("TCP_SendQuitMessagesSync: Attempting QUIT to %s@%s",
                         gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
-
-            // Parse IP for this peer
             parseErr = ParseIPv4(gPeerManager.peers[i].ip, &targetIP);
             if (parseErr != noErr || targetIP == 0) {
                 log_message("Error: Could not parse peer IP string '%s'. Skipping.", gPeerManager.peers[i].ip);
-                lastErr = parseErr; // Record the error
-                continue; // Skip this peer
+                lastErr = parseErr;
+                continue;
             }
-
-            // Send using the internal synchronous function
             sendErr = InternalSyncTCPSend(targetIP, PORT_TCP, quitMessageBuffer, formattedLen,
                                           kShutdownConnectTimeoutTicks, kShutdownSendTimeoutTicks, giveTime);
-
             if (sendErr == noErr) {
                 log_message("Successfully sent QUIT to %s.", gPeerManager.peers[i].ip);
                 sentCount++;
             } else {
                 log_message("Error sending QUIT to %s: %d", gPeerManager.peers[i].ip, sendErr);
-                lastErr = sendErr; // Record the error
-                // Continue trying other peers even if one fails
+                lastErr = sendErr;
             }
-
-            // Yield time between attempts to be cooperative
             giveTime();
         }
     }
-
     log_message("TCP_SendQuitMessagesSync: Finished. Sent QUIT to %d out of %d active peers.", sentCount, activePeerCount);
-
-    // Return the last error encountered (or noErr if all succeeded)
     return lastErr;
 }
-
-
-// --- Private Helper Functions ---
-
 static void HandleListenerCompletion(short macTCPRefNum, OSErr ioResult) {
-    // Ensure this completion is for the current listener stream
     StreamPtr completedListenerStream = gTCPListenPB.tcpStream;
     if (completedListenerStream != gTCPListenStream || gTCPListenStream == NULL) {
         log_message("Warning (HandleListenerCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                     (unsigned long)completedListenerStream, (unsigned long)gTCPListenStream);
         return;
     }
-
     if (ioResult == noErr) {
-        // Connection indication received
         ip_addr acceptedIP = gTCPListenPB.csParam.open.remoteHost;
         tcp_port acceptedPort = gTCPListenPB.csParam.open.remotePort;
         char senderIPStr[INET_ADDRSTRLEN];
-        AddrToStr(acceptedIP, senderIPStr); // Use DNR to get string representation
+        AddrToStr(acceptedIP, senderIPStr);
         log_message("TCP Connection Indication from %s:%u on listener stream 0x%lX.",
                     senderIPStr, acceptedPort, (unsigned long)completedListenerStream);
-
-        // Check if we are already handling a connection or have other pending ops
         if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
              log_message("Warning: New connection indication while listener stream busy (Active: %d, RecvPending: %d, ClosePending: %d). Setting flag to re-listen later.",
                          gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-             gNeedToReListen = true; // We missed this connection, need to listen again later
+             gNeedToReListen = true;
         } else {
-            // Accept the connection state
             gCurrentConnectionIP = acceptedIP;
             gCurrentConnectionPort = acceptedPort;
             gIsConnectionActive = true;
-
-            // Start the first receive operation for this new connection
             OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-            if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen)
+            if (err != noErr && err != 1) {
                 log_message("Error (HandleListenerCompletion): Failed to start first TCPRcv on listener stream. Error: %d. Closing connection state.", err);
-                gIsConnectionActive = false; // Reset state
+                gIsConnectionActive = false;
                 gCurrentConnectionIP = 0;
                 gCurrentConnectionPort = 0;
-                // Don't start Close here, just set flag to re-listen
                 gNeedToReListen = true;
             } else {
                  log_to_file_only("HandleListenerCompletion: First TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
             }
         }
     } else {
-        // Handle errors from TCPPassiveOpen
         const char *errMsg = "Unknown Error";
-        Boolean isConnectionExists = (ioResult == connectionExists); // Transient, try again
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr);   // Fatal for this stream
-        Boolean isReqAborted = (ioResult == reqAborted);           // Usually from PBKillIO
-        // Add other common errors if needed
+        Boolean isConnectionExists = (ioResult == connectionExists);
+        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
+        Boolean isReqAborted = (ioResult == reqAborted);
         if (isConnectionExists) errMsg = "connectionExists (-23007)";
         else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
         else if (isReqAborted) errMsg = "reqAborted (-23015)";
-
         if (isConnectionExists) {
-             // This can happen if MacTCP's internal state is temporarily busy. Retry after a short delay.
              log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with transient error: %d (%s). Will retry after delay.", ioResult, errMsg);
              unsigned long dummyTimer;
-             Delay(kTCPListenRetryDelayTicks, &dummyTimer); // Simple delay
-             gNeedToReListen = true; // Flag to retry
+             Delay(kTCPListenRetryDelayTicks, &dummyTimer);
+             gNeedToReListen = true;
         } else if (isReqAborted) {
-             // This is expected if we killed the listen (e.g., during cleanup)
              log_to_file_only("HandleListenerCompletion: TCPPassiveOpen completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
-             // Don't automatically set gNeedToReListen here, cleanup handles it
         } else {
-            // Other errors
             log_message("Error (HandleListenerCompletion): TCPPassiveOpen completed with error: %d (%s)", ioResult, errMsg);
             if (isInvalidStream) {
-                 // This stream is unusable. Log and prevent further use.
                  log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid. It will be cleaned up.", (unsigned long)gTCPListenStream);
-                 // CleanupNetworking will handle the release. Don't try to use it further.
-                 gTCPListenStream = NULL; // Mark as unusable
-                 gNeedToReListen = false; // Cannot re-listen on a NULL stream
+                 gTCPListenStream = NULL;
+                 gNeedToReListen = false;
             } else {
-                 // For other errors, attempt to re-listen later
                  gNeedToReListen = true;
             }
         }
     }
 }
-
 static void HandleReceiveCompletion(short macTCPRefNum, OSErr ioResult) {
     StreamPtr completedRecvStream = gTCPRecvPB.tcpStream;
-
-    // Ensure completion is for the correct, non-NULL listener stream
     if (completedRecvStream != gTCPListenStream || gTCPListenStream == NULL) {
          log_message("Warning (HandleReceiveCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                      (unsigned long)completedRecvStream, (unsigned long)gTCPListenStream);
          return;
     }
-
-    // If connection is no longer marked active (e.g., closed during processing), handle differently
      if (!gIsConnectionActive) {
          if (ioResult == noErr) {
-             // Received data but connection state changed. Process data but don't continue.
              log_to_file_only("Warning (HandleReceiveCompletion): Receive completed successfully but connection no longer marked active. Data processed, not re-issuing receive.");
-             ProcessTCPReceive(macTCPRefNum); // Process any final data
+             ProcessTCPReceive(macTCPRefNum);
          } else {
              log_to_file_only("Warning (HandleReceiveCompletion): Receive completed with error %d, connection already inactive.", ioResult);
          }
-         // If the error wasn't just an abort, we likely need to re-listen eventually
          if (ioResult != reqAborted) {
             gNeedToReListen = true;
          }
-         return; // Do not proceed further
+         return;
      }
-
-    // Handle completion results for an active connection
     if (ioResult == noErr) {
-        // Data received successfully
         ProcessTCPReceive(macTCPRefNum);
-
-        // If connection is still active after processing, issue the next receive
         if (gIsConnectionActive && gTCPListenStream != NULL) {
             OSErr err = StartAsyncTCPRecv(macTCPRefNum);
-             if (err != noErr && err != 1) { // 1 = already pending (shouldn't happen)
+             if (err != noErr && err != 1) {
                  log_message("Error (HandleReceiveCompletion): Failed to start next async TCP receive after successful receive. Error: %d. Closing connection.", err);
-                 // Couldn't start next receive, close the connection abruptly
-                 StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
+                 StartAsyncTCPClose(macTCPRefNum, true);
              } else {
                  log_to_file_only("HandleReceiveCompletion: Successfully re-issued TCPRcv on stream 0x%lX.", (unsigned long)gTCPListenStream);
              }
         } else {
-             // Connection became inactive during processing (e.g., ProcessTCPReceive handled QUIT)
-             // or stream became NULL (fatal error).
              log_to_file_only("HandleReceiveCompletion: Connection stream closed/inactive or stream became NULL during processing. Not starting new receive.");
-             // If stream still exists and no close is pending, flag to re-listen
              if (gTCPListenStream != NULL && !gTCPClosePending) {
                  gNeedToReListen = true;
              }
         }
     } else if (ioResult == connectionClosing) {
-         // Peer initiated graceful close
          char senderIPStr[INET_ADDRSTRLEN];
          AddrToStr(gCurrentConnectionIP, senderIPStr);
          log_message("TCP Connection closing gracefully from %s (Stream: 0x%lX).", senderIPStr, (unsigned long)completedRecvStream);
-         // Process any final data that might have been in the buffer
          ProcessTCPReceive(macTCPRefNum);
-         // Clean up connection state and flag to re-listen
          gIsConnectionActive = false;
          gCurrentConnectionIP = 0;
          gCurrentConnectionPort = 0;
          gNeedToReListen = true;
     } else {
-         // Handle receive errors
          char senderIPStr[INET_ADDRSTRLEN];
-         AddrToStr(gCurrentConnectionIP, senderIPStr); // Get IP for logging
+         AddrToStr(gCurrentConnectionIP, senderIPStr);
          const char *errMsg = "Unknown Error";
-         Boolean isConnTerminated = (ioResult == connectionTerminated); // Abrupt close
-         Boolean isInvalidStream = (ioResult == invalidStreamPtr);   // Fatal
-         Boolean isReqAborted = (ioResult == reqAborted);           // From PBKillIO
-         // Add other relevant errors
+         Boolean isConnTerminated = (ioResult == connectionTerminated);
+         Boolean isInvalidStream = (ioResult == invalidStreamPtr);
+         Boolean isReqAborted = (ioResult == reqAborted);
          if (isConnTerminated) errMsg = "connectionTerminated (-23012)";
          else if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
          else if (isReqAborted) errMsg = "reqAborted (-23015)";
-
         if (isReqAborted) {
             log_to_file_only("HandleReceiveCompletion: Async TCPRcv completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
         } else {
             log_message("Error (HandleReceiveCompletion): Async TCPRcv completed with error: %d (%s) from %s (Stream: 0x%lX).", ioResult, errMsg, senderIPStr, (unsigned long)completedRecvStream);
         }
-
-        // Clean up connection state
         gIsConnectionActive = false;
         gCurrentConnectionIP = 0;
         gCurrentConnectionPort = 0;
-
-        // Handle fatal stream error
         if (isInvalidStream) {
              log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during receive. It will be cleaned up.", (unsigned long)gTCPListenStream);
-             gTCPListenStream = NULL; // Mark as unusable
-             gNeedToReListen = false; // Cannot re-listen
+             gTCPListenStream = NULL;
+             gNeedToReListen = false;
         } else if (!isReqAborted) {
-             // For other errors (like connectionTerminated), flag to re-listen
              gNeedToReListen = true;
         }
     }
 }
-
 static void HandleCloseCompletion(short macTCPRefNum, OSErr ioResult) {
     StreamPtr closedStream = gTCPClosePB.tcpStream;
-
-    // Ensure completion is for the correct, non-NULL listener stream
     if (closedStream != gTCPListenStream || gTCPListenStream == NULL) {
          log_message("Warning (HandleCloseCompletion): Ignoring completion for unexpected/NULL stream 0x%lX (Current: 0x%lX).",
                      (unsigned long)closedStream, (unsigned long)gTCPListenStream);
          return;
     }
-
-    // Connection is definitely inactive now
     gIsConnectionActive = false;
     gCurrentConnectionIP = 0;
     gCurrentConnectionPort = 0;
-
     if (ioResult == noErr) {
         log_to_file_only("HandleCloseCompletion: Async TCPClose completed successfully for stream 0x%lX.", (unsigned long)closedStream);
     } else {
-        // Handle close errors
         const char *errMsg = "Unknown Error";
-        Boolean isInvalidStream = (ioResult == invalidStreamPtr); // Fatal
-        Boolean isReqAborted = (ioResult == reqAborted);         // From PBKillIO
-        // Add other relevant errors (e.g., connectionDoesntExist)
+        Boolean isInvalidStream = (ioResult == invalidStreamPtr);
+        Boolean isReqAborted = (ioResult == reqAborted);
         if (isInvalidStream) errMsg = "invalidStreamPtr (-23010)";
         else if (isReqAborted) errMsg = "reqAborted (-23015)";
-
         if (isReqAborted) {
              log_to_file_only("HandleCloseCompletion: Async TCPClose completed with %d (%s), likely due to PBKillIO.", ioResult, errMsg);
         } else {
             log_message("Error (HandleCloseCompletion): Async TCPClose for stream 0x%lX completed with error: %d (%s)", (unsigned long)closedStream, ioResult, errMsg);
         }
-
-        // Handle fatal stream error
         if (isInvalidStream) {
              log_message("CRITICAL Error: Listener stream 0x%lX reported as invalid during close. It will be cleaned up.", (unsigned long)gTCPListenStream);
-             gTCPListenStream = NULL; // Mark as unusable
-             gNeedToReListen = false; // Cannot re-listen
-             return; // Don't set flag below
+             gTCPListenStream = NULL;
+             gNeedToReListen = false;
+             return;
         }
     }
-
-    // If the close wasn't just an abort, we need to re-listen
     if (ioResult != reqAborted) {
         log_to_file_only("HandleCloseCompletion: Setting flag to re-listen.");
         gNeedToReListen = true;
     }
 }
-
-
-// Start listening for incoming connections on the persistent listener stream
 static OSErr StartAsyncTCPListen(short macTCPRefNum) {
     OSErr err;
-
     if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPListen): Cannot listen, gTCPListenStream is NULL.");
         return invalidStreamPtr;
     }
     if (gTCPListenPending) {
         log_to_file_only("StartAsyncTCPListen: Listen already pending on stream 0x%lX.", (unsigned long)gTCPListenStream);
-        return 1; // Indicate already pending
+        return 1;
     }
-    // Cannot start listen if stream is busy with an active connection or other ops
     if (gIsConnectionActive || gTCPRecvPending || gTCPClosePending) {
         log_message("Error (StartAsyncTCPListen): Cannot listen, stream 0x%lX is busy (Active: %d, RecvPending: %d, ClosePending: %d).",
                     (unsigned long)gTCPListenStream, gIsConnectionActive, gTCPRecvPending, gTCPClosePending);
-        return inProgress; // Indicate busy
+        return inProgress;
     }
-
-    // Prepare the parameter block for TCPPassiveOpen
     memset(&gTCPListenPB, 0, sizeof(TCPiopb));
-    gTCPListenPB.ioCompletion = nil; // Use polling
+    gTCPListenPB.ioCompletion = nil;
     gTCPListenPB.ioCRefNum = macTCPRefNum;
     gTCPListenPB.csCode = TCPPassiveOpen;
     gTCPListenPB.tcpStream = gTCPListenStream;
-    // Set timeouts (optional, 0 usually means infinite for passive open)
-    gTCPListenPB.csParam.open.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
-    gTCPListenPB.csParam.open.ulpTimeoutValue = kTCPDefaultTimeout; // Use default (0 = infinite)
-    gTCPListenPB.csParam.open.ulpTimeoutAction = AbortTrue; // Action if timeout occurs (irrelevant if value is 0)
-    gTCPListenPB.csParam.open.commandTimeoutValue = 0; // No timeout for the command itself
-    // Specify local port and allow any remote host/port
+    gTCPListenPB.csParam.open.validityFlags = timeoutValue | timeoutAction;
+    gTCPListenPB.csParam.open.ulpTimeoutValue = kTCPDefaultTimeout;
+    gTCPListenPB.csParam.open.ulpTimeoutAction = AbortTrue;
+    gTCPListenPB.csParam.open.commandTimeoutValue = 0;
     gTCPListenPB.csParam.open.localPort = PORT_TCP;
-    gTCPListenPB.csParam.open.localHost = 0L; // Listen on all local interfaces
-    gTCPListenPB.csParam.open.remoteHost = 0L; // Accept connection from any remote IP
-    gTCPListenPB.csParam.open.remotePort = 0;  // Accept connection from any remote port
-    gTCPListenPB.csParam.open.userDataPtr = nil; // No user data
-
-    // Issue the asynchronous call
-    gTCPListenPending = true; // Set flag *before* calling
+    gTCPListenPB.csParam.open.localHost = 0L;
+    gTCPListenPB.csParam.open.remoteHost = 0L;
+    gTCPListenPB.csParam.open.remotePort = 0;
+    gTCPListenPB.csParam.open.userDataPtr = nil;
+    gTCPListenPending = true;
     err = PBControlAsync((ParmBlkPtr)&gTCPListenPB);
     if (err != noErr) {
         log_message("Error (StartAsyncTCPListen): PBControlAsync(TCPPassiveOpen) failed immediately. Error: %d", err);
-        gTCPListenPending = false; // Clear flag on immediate failure
+        gTCPListenPending = false;
         return err;
     }
-
     log_to_file_only("StartAsyncTCPListen: Async TCPPassiveOpen initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1; // Indicate call initiated successfully (pending)
+    return 1;
 }
-
-// Start receiving data on the active connection (listener stream)
 static OSErr StartAsyncTCPRecv(short macTCPRefNum) {
     OSErr err;
-
     if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPRecv): Cannot receive, gTCPListenStream is NULL.");
         return invalidStreamPtr;
@@ -778,395 +587,289 @@ static OSErr StartAsyncTCPRecv(short macTCPRefNum) {
     }
     if (gTCPRecvPending) {
          log_to_file_only("StartAsyncTCPRecv: Receive already pending on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return 1; // Indicate already pending
+         return 1;
     }
-    // Can only receive if a connection is active
     if (!gIsConnectionActive) {
          log_to_file_only("Warning (StartAsyncTCPRecv): Cannot receive, connection not marked active on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-         return connectionDoesntExist; // Or appropriate error
+         return connectionDoesntExist;
     }
-    // Cannot receive if other operations are blocking the stream
     if (gTCPListenPending || gTCPClosePending) {
          log_message("Error (StartAsyncTCPRecv): Cannot receive, stream 0x%lX has other pending operations (Listen: %d, Close: %d).",
                      (unsigned long)gTCPListenStream, gTCPListenPending, gTCPClosePending);
-         return inProgress; // Indicate busy
+         return inProgress;
     }
-
-    // Prepare the parameter block for TCPRcv
     memset(&gTCPRecvPB, 0, sizeof(TCPiopb));
-    gTCPRecvPB.ioCompletion = nil; // Use polling
+    gTCPRecvPB.ioCompletion = nil;
     gTCPRecvPB.ioCRefNum = macTCPRefNum;
     gTCPRecvPB.csCode = TCPRcv;
     gTCPRecvPB.tcpStream = gTCPListenStream;
-    gTCPRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;     // Our receive buffer
-    gTCPRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize; // Max bytes to receive
-    gTCPRecvPB.csParam.receive.commandTimeoutValue = 0; // No timeout for the receive command itself
-    gTCPRecvPB.csParam.receive.userDataPtr = nil; // No user data
-
-    // Issue the asynchronous call
-    gTCPRecvPending = true; // Set flag *before* calling
+    gTCPRecvPB.csParam.receive.rcvBuff = gTCPRecvBuffer;
+    gTCPRecvPB.csParam.receive.rcvBuffLen = kTCPRecvBufferSize;
+    gTCPRecvPB.csParam.receive.commandTimeoutValue = 0;
+    gTCPRecvPB.csParam.receive.userDataPtr = nil;
+    gTCPRecvPending = true;
     err = PBControlAsync((ParmBlkPtr)&gTCPRecvPB);
     if (err != noErr) {
         log_message("Error (StartAsyncTCPRecv): PBControlAsync(TCPRcv) failed immediately. Error: %d", err);
-        gTCPRecvPending = false; // Clear flag on immediate failure
-        // If receive fails immediately, the connection is likely broken. Close it.
-        StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
+        gTCPRecvPending = false;
+        StartAsyncTCPClose(macTCPRefNum, true);
         return err;
     }
-
     log_to_file_only("StartAsyncTCPRecv: Async TCPRcv initiated on listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1; // Indicate call initiated successfully (pending)
+    return 1;
 }
-
-// Start closing the active connection on the listener stream
 static OSErr StartAsyncTCPClose(short macTCPRefNum, Boolean abortConnection) {
     OSErr err;
-
     if (gTCPListenStream == NULL) {
         log_message("Error (StartAsyncTCPClose): Cannot close NULL stream.");
         return invalidStreamPtr;
     }
     if (gTCPClosePending) {
         log_to_file_only("StartAsyncTCPClose: Close already pending for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-        return 1; // Indicate already pending
+        return 1;
     }
-
-    // Mark connection as inactive *before* initiating close
     gIsConnectionActive = false;
     gCurrentConnectionIP = 0;
     gCurrentConnectionPort = 0;
-
-    // Kill any pending receive on this stream before closing
     if (gTCPRecvPending && gTCPRecvPB.tcpStream == gTCPListenStream) {
         log_to_file_only("StartAsyncTCPClose: Killing pending receive before closing.");
-        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false); // Async kill, ignore error
-        gTCPRecvPending = false; // Clear flag immediately
+        PBKillIO((ParmBlkPtr)&gTCPRecvPB, false);
+        gTCPRecvPending = false;
     }
-
-    // Prepare the parameter block for TCPClose
     memset(&gTCPClosePB, 0, sizeof(TCPiopb));
-    gTCPClosePB.ioCompletion = nil; // Use polling
+    gTCPClosePB.ioCompletion = nil;
     gTCPClosePB.ioCRefNum = macTCPRefNum;
     gTCPClosePB.csCode = TCPClose;
     gTCPClosePB.tcpStream = gTCPListenStream;
-    // Set ULP timeout for close operation (optional, 0 = default/infinite)
-    gTCPClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
-    gTCPClosePB.csParam.close.ulpTimeoutValue = kTCPDefaultTimeout; // Use default (0)
+    gTCPClosePB.csParam.close.validityFlags = timeoutValue | timeoutAction;
+    gTCPClosePB.csParam.close.ulpTimeoutValue = kTCPDefaultTimeout;
     if (abortConnection) {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = AbortTrue; // Abort immediately
+        gTCPClosePB.csParam.close.ulpTimeoutAction = AbortTrue;
         log_to_file_only("StartAsyncTCPClose: Using Abort action.");
     } else {
-        gTCPClosePB.csParam.close.ulpTimeoutAction = 0; // Graceful close (default action)
+        gTCPClosePB.csParam.close.ulpTimeoutAction = 0;
         log_to_file_only("StartAsyncTCPClose: Using Graceful close action.");
     }
-    gTCPClosePB.csParam.close.userDataPtr = nil; // No user data
-
-    // Issue the asynchronous call
-    gTCPClosePending = true; // Set flag *before* calling
+    gTCPClosePB.csParam.close.userDataPtr = nil;
+    gTCPClosePending = true;
     err = PBControlAsync((ParmBlkPtr)&gTCPClosePB);
     if (err != noErr) {
         log_message("Error (StartAsyncTCPClose): PBControlAsync(TCPClose) failed immediately for stream 0x%lX. Error: %d", (unsigned long)gTCPListenStream, err);
-        gTCPClosePending = false; // Clear flag on immediate failure
-        gNeedToReListen = true; // Flag to re-listen since close failed
+        gTCPClosePending = false;
+        gNeedToReListen = true;
         return err;
     }
-
     log_to_file_only("StartAsyncTCPClose: Initiated async TCPClose for listener stream 0x%lX.", (unsigned long)gTCPListenStream);
-    return 1; // Indicate call initiated successfully (pending)
+    return 1;
 }
-
-
-// Process data received in gTCPRecvBuffer
 static void ProcessTCPReceive(short macTCPRefNum) {
     char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN]; // Parsed from message
+    char senderIPStrFromPayload[INET_ADDRSTRLEN];
     char senderUsername[32];
     char msgType[32];
     char content[BUFFER_SIZE];
     unsigned short dataLength;
-
-    // Define the callbacks structure for the shared logic
     static tcp_platform_callbacks_t mac_callbacks = {
         .add_or_update_peer = mac_tcp_add_or_update_peer,
         .display_text_message = mac_tcp_display_text_message,
         .mark_peer_inactive = mac_tcp_mark_peer_inactive
     };
-
-    // Sanity checks
     if (!gIsConnectionActive || gTCPListenStream == NULL) {
         log_message("Warning (ProcessTCPReceive): Called when connection not active or listener stream is NULL.");
         return;
     }
-    // Ensure the completed PB matches the listener stream
     if (gTCPRecvPB.tcpStream != gTCPListenStream) {
         log_message("CRITICAL Warning (ProcessTCPReceive): Received data for unexpected stream 0x%lX, expected 0x%lX. Ignoring and closing.",
                     (unsigned long)gTCPRecvPB.tcpStream, (unsigned long)gTCPListenStream);
-        StartAsyncTCPClose(macTCPRefNum, true); // Abort = true
+        StartAsyncTCPClose(macTCPRefNum, true);
         return;
     }
-
-    dataLength = gTCPRecvPB.csParam.receive.rcvBuffLen; // Get actual bytes received
+    dataLength = gTCPRecvPB.csParam.receive.rcvBuffLen;
     if (dataLength > 0) {
-        // Get the sender's IP string from the connection info
         OSErr addrErr = AddrToStr(gCurrentConnectionIP, senderIPStrFromConnection);
         if (addrErr != noErr) {
-            // Fallback formatting if AddrToStr fails
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu",
                     (gCurrentConnectionIP >> 24) & 0xFF, (gCurrentConnectionIP >> 16) & 0xFF,
                     (gCurrentConnectionIP >> 8) & 0xFF, gCurrentConnectionIP & 0xFF);
             log_to_file_only("ProcessTCPReceive: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.",
                          addrErr, (unsigned long)gCurrentConnectionIP, senderIPStrFromConnection);
         }
-
-        // Parse the received data using the shared protocol function
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
-            // Successfully parsed, call the shared logic handler
             log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (Payload IP: %s).",
                        msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
-
-            handle_received_tcp_message(senderIPStrFromConnection, // Use IP from connection info
+            handle_received_tcp_message(senderIPStrFromConnection,
                                         senderUsername,
                                         msgType,
                                         content,
                                         &mac_callbacks,
-                                        NULL); // No platform context needed here
-
-            // Check if the message requires closing the connection (e.g., QUIT)
+                                        NULL);
             if (strcmp(msgType, MSG_QUIT) == 0) {
                  log_message("Connection to %s finishing due to received QUIT.", senderIPStrFromConnection);
-                 // Initiate close (abort=true since peer is quitting anyway)
                  StartAsyncTCPClose(macTCPRefNum, true);
-                 // gIsConnectionActive is set to false inside StartAsyncTCPClose
             }
         } else {
-            // Parsing failed
             log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
-            // Consider closing connection if parsing fails repeatedly? For now, just log.
         }
     } else {
-        // Received 0 bytes - often indicates graceful close initiation by peer
         log_to_file_only("ProcessTCPReceive: Received 0 bytes. Connection likely closing.");
-        // Don't need to explicitly close here; HandleReceiveCompletion handles connectionClosing error
     }
 }
-
-
-// --- Low-Level Synchronous TCP Helpers (Copied & Adapted) ---
-
-// Creates a TCP stream synchronously.
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtr, Ptr connectionBuffer, unsigned long connBufferLen)
 {
     OSErr err;
     TCPiopb pbCreate;
-
     if (streamPtr == NULL || connectionBuffer == NULL) return paramErr;
-
     memset(&pbCreate, 0, sizeof(TCPiopb));
-    pbCreate.ioCompletion = nil; // Synchronous
+    pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L; // Will be filled in by MacTCP
-    pbCreate.csParam.create.rcvBuff = connectionBuffer; // Internal buffer for MacTCP
+    pbCreate.tcpStream = 0L;
+    pbCreate.csParam.create.rcvBuff = connectionBuffer;
     pbCreate.csParam.create.rcvBuffLen = connBufferLen;
-    pbCreate.csParam.create.notifyProc = nil; // No ASR needed for sync operations
+    pbCreate.csParam.create.notifyProc = nil;
     pbCreate.csParam.create.userDataPtr = nil;
-
     err = PBControlSync((ParmBlkPtr)&pbCreate);
-
     if (err == noErr) {
         *streamPtr = pbCreate.tcpStream;
         if (*streamPtr == NULL) {
             log_message("Error (LowTCPCreateSync): PBControlSync succeeded but returned NULL stream.");
-            err = ioErr; // Indicate an unexpected issue
+            err = ioErr;
         }
     } else {
         *streamPtr = NULL;
     }
     return err;
 }
-
-// Opens a TCP connection synchronously using TCPActiveOpen.
 static OSErr LowTCPOpenConnectionSync(StreamPtr streamPtr, SInt8 timeoutTicks, ip_addr remoteHost,
                                       tcp_port remotePort, ip_addr *localHost, tcp_port *localPort,
                                       GiveTimePtr giveTime)
 {
     OSErr err;
-    TCPiopb *pBlock = NULL; // Allocate PB dynamically for sync calls using polling
-
+    TCPiopb *pBlock = NULL;
     if (giveTime == NULL) return paramErr;
     if (streamPtr == NULL) return invalidStreamPtr;
-
     pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
     if (pBlock == NULL) {
         log_message("Error (LowTCPOpenConnectionSync): Failed to allocate PB.");
         return memFullErr;
     }
-
-    // Prepare PB for TCPActiveOpen
-    pBlock->ioCompletion = nil; // Use polling
-    pBlock->ioCRefNum = gMacTCPRefNum; // Use global driver refnum
+    pBlock->ioCompletion = nil;
+    pBlock->ioCRefNum = gMacTCPRefNum;
     pBlock->csCode = TCPActiveOpen;
-    pBlock->ioResult = 1; // Initialize ioResult to indicate pending
+    pBlock->ioResult = 1;
     pBlock->tcpStream = streamPtr;
-    // Set ULP timeout
     pBlock->csParam.open.ulpTimeoutValue = timeoutTicks;
-    pBlock->csParam.open.ulpTimeoutAction = AbortTrue; // Abort if timeout occurs
-    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
-    pBlock->csParam.open.commandTimeoutValue = 0; // No timeout for the command itself
-    // Set remote host and port
+    pBlock->csParam.open.ulpTimeoutAction = AbortTrue;
+    pBlock->csParam.open.validityFlags = timeoutValue | timeoutAction;
+    pBlock->csParam.open.commandTimeoutValue = 0;
     pBlock->csParam.open.remoteHost = remoteHost;
     pBlock->csParam.open.remotePort = remotePort;
-    // Let MacTCP choose local port and IP
     pBlock->csParam.open.localPort = 0;
     pBlock->csParam.open.localHost = 0;
-
-    // Issue async call and poll for completion
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
         log_message("Error (LowTCPOpenConnectionSync): PBControlAsync failed immediately: %d", err);
         DisposePtr((Ptr)pBlock);
         return err;
     }
-
-    // Poll ioResult until it's <= 0 (completed or error)
     while (pBlock->ioResult > 0) {
-        giveTime(); // Yield to other processes
+        giveTime();
     }
-
-    err = pBlock->ioResult; // Get final result
-
-    // If successful, optionally return assigned local host/port
+    err = pBlock->ioResult;
     if (err == noErr) {
         if (localHost) *localHost = pBlock->csParam.open.localHost;
         if (localPort) *localPort = pBlock->csParam.open.localPort;
     }
-
-    DisposePtr((Ptr)pBlock); // Clean up allocated PB
+    DisposePtr((Ptr)pBlock);
     return err;
 }
-
-// Sends data synchronously using TCPSend.
 static OSErr LowTCPSendSync(StreamPtr streamPtr, SInt8 timeoutTicks, Boolean push, Boolean urgent,
                             Ptr wdsPtr, GiveTimePtr giveTime)
 {
     OSErr err;
     TCPiopb *pBlock = NULL;
-
     if (giveTime == NULL || wdsPtr == NULL) return paramErr;
     if (streamPtr == NULL) return invalidStreamPtr;
-
     pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
     if (pBlock == NULL) {
         log_message("Error (LowTCPSendSync): Failed to allocate PB.");
         return memFullErr;
     }
-
-    // Prepare PB for TCPSend
-    pBlock->ioCompletion = nil; // Use polling
+    pBlock->ioCompletion = nil;
     pBlock->ioCRefNum = gMacTCPRefNum;
     pBlock->csCode = TCPSend;
-    pBlock->ioResult = 1; // Indicate pending
+    pBlock->ioResult = 1;
     pBlock->tcpStream = streamPtr;
-    // Set ULP timeout
     pBlock->csParam.send.ulpTimeoutValue = timeoutTicks;
     pBlock->csParam.send.ulpTimeoutAction = AbortTrue;
-    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction; // Enable ULP timeout
-    // Set send flags and data pointer
+    pBlock->csParam.send.validityFlags = timeoutValue | timeoutAction;
     pBlock->csParam.send.pushFlag = push;
     pBlock->csParam.send.urgentFlag = urgent;
-    pBlock->csParam.send.wdsPtr = wdsPtr; // Pointer to Write Data Structure array
-
-    // Issue async call and poll for completion
+    pBlock->csParam.send.wdsPtr = wdsPtr;
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
         log_message("Error (LowTCPSendSync): PBControlAsync failed immediately: %d", err);
         DisposePtr((Ptr)pBlock);
         return err;
     }
-
-    // Poll ioResult
     while (pBlock->ioResult > 0) {
         giveTime();
     }
-
-    err = pBlock->ioResult; // Get final result
-    DisposePtr((Ptr)pBlock); // Clean up PB
+    err = pBlock->ioResult;
+    DisposePtr((Ptr)pBlock);
     return err;
 }
-
-// Aborts a TCP connection synchronously using TCPAbort.
 static OSErr LowTCPAbortSync(StreamPtr streamPtr, GiveTimePtr giveTime)
 {
     OSErr err;
     TCPiopb *pBlock = NULL;
-
     if (giveTime == NULL) return paramErr;
     if (streamPtr == NULL) return invalidStreamPtr;
-
     pBlock = (TCPiopb *)NewPtrClear(sizeof(TCPiopb));
     if (pBlock == NULL) {
         log_message("Error (LowTCPAbortSync): Failed to allocate PB.");
         return memFullErr;
     }
-
-    // Prepare PB for TCPAbort
-    pBlock->ioCompletion = nil; // Use polling
+    pBlock->ioCompletion = nil;
     pBlock->ioCRefNum = gMacTCPRefNum;
     pBlock->csCode = TCPAbort;
-    pBlock->ioResult = 1; // Indicate pending
+    pBlock->ioResult = 1;
     pBlock->tcpStream = streamPtr;
-
-    // Issue async call and poll for completion
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
-        // Abort might fail if connection doesn't exist, often not critical
         log_to_file_only("Info (LowTCPAbortSync): PBControlAsync failed immediately: %d", err);
-        // Don't necessarily return error here unless it's unexpected
         if (err != connectionDoesntExist && err != invalidStreamPtr) {
              log_message("Warning (LowTCPAbortSync): Unexpected immediate error: %d", err);
         }
         DisposePtr((Ptr)pBlock);
-        // Return noErr generally, as abort is best-effort cleanup
-        return noErr; // Or return err if strict error checking needed
+        return noErr;
     }
-
-    // Poll ioResult
     while (pBlock->ioResult > 0) {
         giveTime();
     }
-
-    err = pBlock->ioResult; // Get final result
+    err = pBlock->ioResult;
     if (err != noErr && err != connectionDoesntExist && err != invalidStreamPtr) {
          log_message("Warning (LowTCPAbortSync): Abort completed with error: %d", err);
     }
-
-    DisposePtr((Ptr)pBlock); // Clean up PB
-    // Return noErr generally for abort
-    return noErr; // Or return err if strict error checking needed
+    DisposePtr((Ptr)pBlock);
+    return noErr;
 }
-
-// Releases a TCP stream synchronously using TCPRelease.
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamPtr)
 {
     OSErr err;
     TCPiopb pbRelease;
-
     if (streamPtr == NULL) return invalidStreamPtr;
-
     memset(&pbRelease, 0, sizeof(TCPiopb));
-    pbRelease.ioCompletion = nil; // Synchronous
+    pbRelease.ioCompletion = nil;
     pbRelease.ioCRefNum = macTCPRefNum;
     pbRelease.csCode = TCPRelease;
     pbRelease.tcpStream = streamPtr;
-    // No csParam needed for TCPRelease
-
     err = PBControlSync((ParmBlkPtr)&pbRelease);
-    // Release might fail if stream is invalid, log but don't halt cleanup
     if (err != noErr && err != invalidStreamPtr) {
          log_message("Warning (LowTCPReleaseSync): PBControlSync(TCPRelease) failed: %d", err);
     } else if (err == invalidStreamPtr) {
          log_to_file_only("Info (LowTCPReleaseSync): Attempted to release invalid stream 0x%lX.", (unsigned long)streamPtr);
-         err = noErr; // Treat invalid stream on release as success (it's already gone)
+         err = noErr;
     }
     return err;
 }

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -1,13 +1,43 @@
+//====================================
+// FILE: ./classic_mac/tcp.h
+//====================================
+
 #ifndef TCP_H
-#define TCP_H 
+#define TCP_H
+
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
-#define kTCPDefaultTimeout 0
+
+// Define GiveTimePtr if not defined elsewhere (e.g., network.h)
+typedef void (*GiveTimePtr)(void);
+
+#define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
+
+// Initializes the persistent TCP listener stream.
+// Returns noErr on success, OSErr otherwise.
 OSErr InitTCPListener(short macTCPRefNum);
+
+// Cleans up the persistent TCP listener stream.
 void CleanupTCPListener(short macTCPRefNum);
+
+// Polls the listener stream for incoming connections and data.
+// MUST be called regularly from the main event loop.
 void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP);
-extern ip_addr gCurrentConnectionIP;
-extern tcp_port gCurrentConnectionPort;
-extern Boolean gIsConnectionActive;
-#endif
+
+// Sends a text message synchronously to a peer.
+// Creates a temporary stream, connects, sends, aborts, and releases.
+// Returns noErr on success, OSErr otherwise.
+OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
+
+// Sends QUIT messages synchronously to all active peers.
+// Uses temporary streams for each peer.
+// Returns the last error encountered (noErr if all succeed).
+OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
+
+// -- State related to the single incoming connection on the listener stream --
+extern ip_addr gCurrentConnectionIP;   // IP of the currently connected peer (incoming)
+extern tcp_port gCurrentConnectionPort; // Port of the currently connected peer (incoming)
+extern Boolean gIsConnectionActive;    // Is there an active incoming connection?
+
+#endif // TCP_H

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -1,43 +1,16 @@
-//====================================
-// FILE: ./classic_mac/tcp.h
-//====================================
-
 #ifndef TCP_H
-#define TCP_H
-
+#define TCP_H 
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
-
-// Define GiveTimePtr if not defined elsewhere (e.g., network.h)
 typedef void (*GiveTimePtr)(void);
-
-#define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
-
-// Initializes the persistent TCP listener stream.
-// Returns noErr on success, OSErr otherwise.
+#define kTCPDefaultTimeout 0
 OSErr InitTCPListener(short macTCPRefNum);
-
-// Cleans up the persistent TCP listener stream.
 void CleanupTCPListener(short macTCPRefNum);
-
-// Polls the listener stream for incoming connections and data.
-// MUST be called regularly from the main event loop.
 void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP);
-
-// Sends a text message synchronously to a peer.
-// Creates a temporary stream, connects, sends, aborts, and releases.
-// Returns noErr on success, OSErr otherwise.
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
-
-// Sends QUIT messages synchronously to all active peers.
-// Uses temporary streams for each peer.
-// Returns the last error encountered (noErr if all succeed).
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
-
-// -- State related to the single incoming connection on the listener stream --
-extern ip_addr gCurrentConnectionIP;   // IP of the currently connected peer (incoming)
-extern tcp_port gCurrentConnectionPort; // Port of the currently connected peer (incoming)
-extern Boolean gIsConnectionActive;    // Is there an active incoming connection?
-
-#endif // TCP_H
+extern ip_addr gCurrentConnectionIP;
+extern tcp_port gCurrentConnectionPort;
+extern Boolean gIsConnectionActive;
+#endif

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -1,23 +1,29 @@
 #ifndef TCP_H
-#define TCP_H 
+#define TCP_H
+
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
+
 typedef void (*GiveTimePtr)(void);
+
 #define kTCPDefaultTimeout 0
-#define streamBusyErr (-23050)
+#define streamBusyErr (-23050) // MacTCP specific error, not a general OS error
+
 typedef enum {
     TCP_STATE_UNINITIALIZED,
     TCP_STATE_IDLE,
-    TCP_STATE_LISTENING_POLL,
+    TCP_STATE_PASSIVE_OPEN_PENDING, // New state for asynchronous passive open
     TCP_STATE_CONNECTED_IN,
     TCP_STATE_RELEASING,
     TCP_STATE_ERROR
 } TCPState;
+
 OSErr InitTCP(short macTCPRefNum);
 void CleanupTCP(short macTCPRefNum);
 void PollTCP(GiveTimePtr giveTime);
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
 TCPState GetTCPState(void);
+
 #endif

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -13,29 +13,22 @@
 typedef void (*GiveTimePtr)(void);
 
 #define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
-#define streamBusyErr (-23050) // Custom error: Cannot send, stream busy or kill failed
+#define streamBusyErr (-23050) // Custom error: Cannot send, stream busy (receiving or sending)
 
-// --- TCP Stream State ---
-// Describes the current activity of the SINGLE shared stream using Async operations.
+// --- TCP Stream State (Synchronous Polling Model) ---
+// Describes the current activity of the SINGLE shared stream.
 typedef enum {
     TCP_STATE_UNINITIALIZED,    // Before InitTCP completes
-    TCP_STATE_IDLE,             // Stream created, ready to start listen or send
-    TCP_STATE_LISTENING,        // Async TCPPassiveOpen pending
-    TCP_STATE_CONNECTED_IN,     // Incoming connection established by ListenCompleteProc, ready for PollTCP to start Rcv
-    TCP_STATE_RECEIVING,        // Async TCPRcv pending
-    TCP_STATE_CLOSING_IN,       // Async TCPClose pending (for incoming connection)
+    TCP_STATE_IDLE,             // Stream created, ready to poll for listen or initiate send
+    TCP_STATE_LISTENING_POLL,   // TCPPassiveOpen sync poll in progress
+    TCP_STATE_CONNECTED_IN,     // Incoming connection established, ready to Rcv/Status poll
+    // Note: Sending state is handled by gIsSending flag + sync helpers (ActiveOpen, Send, Abort)
+    // TCP_STATE_SENDING,       // (Conceptual, not an explicit state in this model's gTCPState)
+    // TCP_STATE_ABORTING,      // (Conceptual, not an explicit state in this model's gTCPState)
     TCP_STATE_RELEASING,        // TCPRelease pending (during cleanup)
-    TCP_STATE_ERROR             // An unrecoverable error occurred
-    // Note: Sending state is handled by gIsSending flag + sync helpers
+    TCP_STATE_ERROR             // An unrecoverable error occurred (e.g., stream invalid)
 } TCPState;
 
-
-// --- Completion Routine Prototypes ---
-// These MUST be declared pascal for MacTCP callback convention
-pascal void ListenCompleteProc(struct TCPiopb *iopb);
-pascal void RecvCompleteProc(struct TCPiopb *iopb);
-pascal void CloseCompleteProc(struct TCPiopb *iopb);
-// We might need one for KillIO completion? MacTCP docs don't specify one for PBKillIO. Assume it's synchronous enough or the original completion runs.
 
 // Initializes the single persistent TCP stream.
 // Returns noErr on success, OSErr otherwise.
@@ -44,19 +37,17 @@ OSErr InitTCP(short macTCPRefNum);
 // Cleans up the single persistent TCP stream.
 void CleanupTCP(short macTCPRefNum);
 
-// Polls the SINGLE stream state machine (checks flags set by completion routines).
+// Polls the SINGLE stream state machine (for incoming connections/data using synchronous polling).
 // MUST be called regularly from the main event loop.
-void PollTCP(void); // No GiveTimePtr needed here
+void PollTCP(GiveTimePtr giveTime); // Takes GiveTimePtr for internal polling loops
 
 // Sends a text message SYNCHRONOUSLY to a peer using the single stream.
-// Attempts to kill pending async ops first.
-// Returns noErr on success, streamBusyErr if busy/kill fails, or other OSErr on failure.
+// Returns noErr on success, streamBusyErr if busy, or other OSErr on failure.
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
 
 // Sends QUIT messages SYNCHRONOUSLY to all active peers using the single stream,
 // with delays between each peer's send attempt.
-// Attempts to kill pending async ops first.
-// Returns streamBusyErr if busy/kill fails initially, or the last error encountered (noErr if all succeed).
+// Returns streamBusyErr if busy initially, or the last error encountered (noErr if all succeed).
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
 
 // --- Public State Access (Optional, for debugging/info) ---

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -1,56 +1,23 @@
-//====================================
-// FILE: ./classic_mac/tcp.h
-//====================================
-
 #ifndef TCP_H
-#define TCP_H
-
+#define TCP_H 
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
-
-// Define GiveTimePtr if not defined elsewhere (e.g., network.h)
 typedef void (*GiveTimePtr)(void);
-
-#define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
-#define streamBusyErr (-23050) // Custom error: Cannot send, stream busy (receiving or sending)
-
-// --- TCP Stream State (Synchronous Polling Model) ---
-// Describes the current activity of the SINGLE shared stream.
+#define kTCPDefaultTimeout 0
+#define streamBusyErr (-23050)
 typedef enum {
-    TCP_STATE_UNINITIALIZED,    // Before InitTCP completes
-    TCP_STATE_IDLE,             // Stream created, ready to poll for listen or initiate send
-    TCP_STATE_LISTENING_POLL,   // TCPPassiveOpen sync poll in progress
-    TCP_STATE_CONNECTED_IN,     // Incoming connection established, ready to Rcv/Status poll
-    // Note: Sending state is handled by gIsSending flag + sync helpers (ActiveOpen, Send, Abort)
-    // TCP_STATE_SENDING,       // (Conceptual, not an explicit state in this model's gTCPState)
-    // TCP_STATE_ABORTING,      // (Conceptual, not an explicit state in this model's gTCPState)
-    TCP_STATE_RELEASING,        // TCPRelease pending (during cleanup)
-    TCP_STATE_ERROR             // An unrecoverable error occurred (e.g., stream invalid)
+    TCP_STATE_UNINITIALIZED,
+    TCP_STATE_IDLE,
+    TCP_STATE_LISTENING_POLL,
+    TCP_STATE_CONNECTED_IN,
+    TCP_STATE_RELEASING,
+    TCP_STATE_ERROR
 } TCPState;
-
-
-// Initializes the single persistent TCP stream.
-// Returns noErr on success, OSErr otherwise.
 OSErr InitTCP(short macTCPRefNum);
-
-// Cleans up the single persistent TCP stream.
 void CleanupTCP(short macTCPRefNum);
-
-// Polls the SINGLE stream state machine (for incoming connections/data using synchronous polling).
-// MUST be called regularly from the main event loop.
-void PollTCP(GiveTimePtr giveTime); // Takes GiveTimePtr for internal polling loops
-
-// Sends a text message SYNCHRONOUSLY to a peer using the single stream.
-// Returns noErr on success, streamBusyErr if busy, or other OSErr on failure.
+void PollTCP(GiveTimePtr giveTime);
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
-
-// Sends QUIT messages SYNCHRONOUSLY to all active peers using the single stream,
-// with delays between each peer's send attempt.
-// Returns streamBusyErr if busy initially, or the last error encountered (noErr if all succeed).
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
-
-// --- Public State Access (Optional, for debugging/info) ---
 TCPState GetTCPState(void);
-
-#endif // TCP_H
+#endif

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -1,16 +1,53 @@
+//====================================
+// FILE: ./classic_mac/tcp.h
+//====================================
+
 #ifndef TCP_H
-#define TCP_H 
+#define TCP_H
+
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
+
+// Define GiveTimePtr if not defined elsewhere (e.g., network.h)
 typedef void (*GiveTimePtr)(void);
-#define kTCPDefaultTimeout 0
-OSErr InitTCPListener(short macTCPRefNum);
-void CleanupTCPListener(short macTCPRefNum);
-void PollTCPListener(short macTCPRefNum, ip_addr myLocalIP);
+
+#define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
+
+// --- TCP Listener Stream State ---
+// Describes the current activity of the dedicated LISTENER stream.
+typedef enum {
+    TCP_LSTATE_UNINITIALIZED, // Before InitTCP completes
+    TCP_LSTATE_IDLE,          // Stream created, ready to listen
+    TCP_LSTATE_LISTENING,     // TCPPassiveOpen pending
+    TCP_LSTATE_RECEIVING,     // TCPRcv pending (incoming connection active)
+    TCP_LSTATE_CLOSING,       // TCPClose pending (graceful close of incoming connection)
+    TCP_LSTATE_RELEASING,     // TCPRelease pending (during cleanup)
+    TCP_LSTATE_ERROR          // An unrecoverable error occurred
+} TCPListenerState;
+
+
+// Initializes the persistent TCP listener stream and starts listening.
+// Returns noErr on success, OSErr otherwise.
+OSErr InitTCP(short macTCPRefNum);
+
+// Cleans up the persistent TCP listener stream.
+void CleanupTCP(short macTCPRefNum);
+
+// Polls the LISTENER stream state machine (for incoming connections/data).
+// MUST be called regularly from the main event loop.
+void PollTCPListener(short macTCPRefNum);
+
+// Sends a text message SYNCHRONOUSLY to a peer using a temporary stream.
+// Returns noErr on success, OSErr otherwise.
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
+
+// Sends QUIT messages SYNCHRONOUSLY to all active peers using temporary streams,
+// with delays between each peer's send attempt.
+// Returns the last error encountered (noErr if all succeed).
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
-extern ip_addr gCurrentConnectionIP;
-extern tcp_port gCurrentConnectionPort;
-extern Boolean gIsConnectionActive;
-#endif
+
+// --- Public State Access (Optional, for debugging/info) ---
+TCPListenerState GetTCPListenerState(void); // Function to get the current listener state
+
+#endif // TCP_H

--- a/classic_mac/tcp.h
+++ b/classic_mac/tcp.h
@@ -13,41 +13,53 @@
 typedef void (*GiveTimePtr)(void);
 
 #define kTCPDefaultTimeout 0 // Default ULP timeout (0 = infinite)
+#define streamBusyErr (-23050) // Custom error: Cannot send, stream busy or kill failed
 
-// --- TCP Listener Stream State ---
-// Describes the current activity of the dedicated LISTENER stream.
+// --- TCP Stream State ---
+// Describes the current activity of the SINGLE shared stream using Async operations.
 typedef enum {
-    TCP_LSTATE_UNINITIALIZED, // Before InitTCP completes
-    TCP_LSTATE_IDLE,          // Stream created, ready to listen
-    TCP_LSTATE_LISTENING,     // TCPPassiveOpen pending
-    TCP_LSTATE_RECEIVING,     // TCPRcv pending (incoming connection active)
-    TCP_LSTATE_CLOSING,       // TCPClose pending (graceful close of incoming connection)
-    TCP_LSTATE_RELEASING,     // TCPRelease pending (during cleanup)
-    TCP_LSTATE_ERROR          // An unrecoverable error occurred
-} TCPListenerState;
+    TCP_STATE_UNINITIALIZED,    // Before InitTCP completes
+    TCP_STATE_IDLE,             // Stream created, ready to start listen or send
+    TCP_STATE_LISTENING,        // Async TCPPassiveOpen pending
+    TCP_STATE_CONNECTED_IN,     // Incoming connection established by ListenCompleteProc, ready for PollTCP to start Rcv
+    TCP_STATE_RECEIVING,        // Async TCPRcv pending
+    TCP_STATE_CLOSING_IN,       // Async TCPClose pending (for incoming connection)
+    TCP_STATE_RELEASING,        // TCPRelease pending (during cleanup)
+    TCP_STATE_ERROR             // An unrecoverable error occurred
+    // Note: Sending state is handled by gIsSending flag + sync helpers
+} TCPState;
 
 
-// Initializes the persistent TCP listener stream and starts listening.
+// --- Completion Routine Prototypes ---
+// These MUST be declared pascal for MacTCP callback convention
+pascal void ListenCompleteProc(struct TCPiopb *iopb);
+pascal void RecvCompleteProc(struct TCPiopb *iopb);
+pascal void CloseCompleteProc(struct TCPiopb *iopb);
+// We might need one for KillIO completion? MacTCP docs don't specify one for PBKillIO. Assume it's synchronous enough or the original completion runs.
+
+// Initializes the single persistent TCP stream.
 // Returns noErr on success, OSErr otherwise.
 OSErr InitTCP(short macTCPRefNum);
 
-// Cleans up the persistent TCP listener stream.
+// Cleans up the single persistent TCP stream.
 void CleanupTCP(short macTCPRefNum);
 
-// Polls the LISTENER stream state machine (for incoming connections/data).
+// Polls the SINGLE stream state machine (checks flags set by completion routines).
 // MUST be called regularly from the main event loop.
-void PollTCPListener(short macTCPRefNum);
+void PollTCP(void); // No GiveTimePtr needed here
 
-// Sends a text message SYNCHRONOUSLY to a peer using a temporary stream.
-// Returns noErr on success, OSErr otherwise.
+// Sends a text message SYNCHRONOUSLY to a peer using the single stream.
+// Attempts to kill pending async ops first.
+// Returns noErr on success, streamBusyErr if busy/kill fails, or other OSErr on failure.
 OSErr TCP_SendTextMessageSync(const char *peerIP, const char *message, GiveTimePtr giveTime);
 
-// Sends QUIT messages SYNCHRONOUSLY to all active peers using temporary streams,
+// Sends QUIT messages SYNCHRONOUSLY to all active peers using the single stream,
 // with delays between each peer's send attempt.
-// Returns the last error encountered (noErr if all succeed).
+// Attempts to kill pending async ops first.
+// Returns streamBusyErr if busy/kill fails initially, or the last error encountered (noErr if all succeed).
 OSErr TCP_SendQuitMessagesSync(GiveTimePtr giveTime);
 
 // --- Public State Access (Optional, for debugging/info) ---
-TCPListenerState GetTCPListenerState(void); // Function to get the current listener state
+TCPState GetTCPState(void);
 
 #endif // TCP_H


### PR DESCRIPTION
Refactor(Classic Mac): Improve TCP stream handling for UI responsiveness

Implemented a fully asynchronous passive open for TCP listening on Classic Mac.
This prevents the UI from freezing while waiting for incoming connections.

Modified TCP send operations (text messages and QUIT notifications) to:
1. Check if a passive open is pending.
2. If so, abort the pending passive open to free the stream.
3. Proceed with the send operation.
4. Return the stream to an IDLE state, allowing PollTCP to re-initiate
   asynchronous listening.

This ensures that critical send operations, like sending QUIT messages
during shutdown, can execute even if the application was actively listening
for incoming connections, while significantly improving general UI
responsiveness during idle periods.