### PR TITLE
Refactor(classic_mac): Centralize peer list GUI logic

### DIFF
--- a/classic_mac/dialog.c
+++ b/classic_mac/dialog.c
@@ -1,3 +1,6 @@
+// FILE: ./classic_mac/dialog.c
+//====================================
+
 //====================================
 // FILE: ./classic_mac/dialog.c
 //====================================
@@ -203,7 +206,8 @@ void HandleSendButtonClick(void)
         ClearInputText();
     } else { // Unicast send
         peer_t targetPeer;
-        if (GetSelectedPeerInfo(&targetPeer)) { // GetSelectedPeerInfo is from classic_mac/peer.c
+        // Use the new function from dialog_peerlist.c
+        if (DialogPeerList_GetSelectedPeer(&targetPeer)) {
             log_message("Attempting sync send to selected peer %s@%s: '%s'",
                         targetPeer.username, targetPeer.ip, inputCStr);
 

--- a/classic_mac/dialog_peerlist.c
+++ b/classic_mac/dialog_peerlist.c
@@ -1,7 +1,7 @@
 #include "dialog_peerlist.h"
-#include "dialog.h"
+#include "dialog.h"    // For kBroadcastCheckbox, gMainWindow
 #include "logging.h"
-#include "peer.h"
+#include "peer.h"      // For gPeerManager, PruneTimedOutPeers
 #include <MacTypes.h>
 #include <Lists.h>
 #include <Dialogs.h>
@@ -12,8 +12,10 @@
 #include <Controls.h>
 #include <stdio.h>
 #include <string.h>
+
 ListHandle gPeerListHandle = NULL;
-Cell gLastSelectedCell = {0, -1};
+Cell gLastSelectedCell = {0, -1}; // {h, v} - v = -1 means no selection
+
 Boolean InitPeerListControl(DialogPtr dialog)
 {
     DialogItemType itemType;
@@ -22,36 +24,43 @@ Boolean InitPeerListControl(DialogPtr dialog)
     Point cellSize;
     FontInfo fontInfo;
     Boolean listOk = false;
+
     log_message("Initializing Peer List Control...");
     GetDialogItem(dialog, kPeerListUserItem, &itemType, &itemHandle, &destRectList);
+
     if (itemType == userItem) {
         log_message("Item %d is UserItem. Rect: (%d,%d,%d,%d)", kPeerListUserItem,
                     destRectList.top, destRectList.left, destRectList.bottom, destRectList.right);
+
         GrafPtr oldPort;
         GetPort(&oldPort);
-        SetPort(GetWindowPort(dialog));
+        SetPort(GetWindowPort(dialog)); // Use dialog's port for font info
         GetFontInfo(&fontInfo);
         SetPort(oldPort);
+
         cellSize.v = fontInfo.ascent + fontInfo.descent + fontInfo.leading;
         if (cellSize.v <= 0) {
             log_message("Warning: Calculated cell height is %d, using default 12.", cellSize.v);
-            cellSize.v = 12;
+            cellSize.v = 12; // A common default
         }
-        cellSize.h = destRectList.right - destRectList.left;
-        SetRect(&dataBounds, 0, 0, 1, 0);
+        cellSize.h = destRectList.right - destRectList.left; // Full width for now
+
+        SetRect(&dataBounds, 0, 0, 1, 0); // 1 column, 0 rows initially
+
         log_message("Calling LNew for Peer List (Cell Size: H%d, V%d)...", cellSize.h, cellSize.v);
         gPeerListHandle = LNew(&destRectList, &dataBounds, cellSize, 0, (WindowPtr)dialog,
-                               true,
-                               false,
-                               false,
-                               true);
+                               true,  // drawIt
+                               false, // hasGrow
+                               false, // scrollHoriz
+                               true); // scrollVert (though we don't provide a scrollbar DITL item for it yet)
+
         if (gPeerListHandle == NULL) {
             log_message("CRITICAL ERROR: LNew failed for Peer List! (Error: %d)", ResError());
             listOk = false;
         } else {
             log_message("LNew succeeded for Peer List. Handle: 0x%lX", (unsigned long)gPeerListHandle);
-            (*gPeerListHandle)->selFlags = lOnlyOne;
-            LActivate(true, gPeerListHandle);
+            (*gPeerListHandle)->selFlags = lOnlyOne; // Allow only single selection
+            LActivate(true, gPeerListHandle); // Activate the list
             listOk = true;
         }
     } else {
@@ -61,65 +70,82 @@ Boolean InitPeerListControl(DialogPtr dialog)
     }
     return listOk;
 }
+
 void CleanupPeerListControl(void)
 {
     log_message("Cleaning up Peer List Control...");
     if (gPeerListHandle != NULL) {
-        LActivate(false, gPeerListHandle);
+        LActivate(false, gPeerListHandle); // Deactivate before disposing
         LDispose(gPeerListHandle);
         gPeerListHandle = NULL;
     }
+    gLastSelectedCell.v = -1; // Reset selection state
     log_message("Peer List Control cleanup finished.");
 }
+
 Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
 {
     Boolean clickWasInContent = false;
     if (gPeerListHandle != NULL) {
         Point localClick = theEvent->where;
         GrafPtr oldPort;
+
         GetPort(&oldPort);
-        SetPort(GetWindowPort(dialog));
+        SetPort(GetWindowPort(dialog)); // Convert to dialog's local coordinates
         GlobalToLocal(&localClick);
         SetPort(oldPort);
+
         SignedByte listState = HGetState((Handle)gPeerListHandle);
         HLock((Handle)gPeerListHandle);
+
         if (*gPeerListHandle == NULL) {
             log_message("HandlePeerListClick Error: gPeerListHandle deref failed after HLock!");
             HSetState((Handle)gPeerListHandle, listState);
             return false;
         }
+
         if (PtInRect(localClick, &(**gPeerListHandle).rView)) {
             clickWasInContent = true;
             log_to_file_only("HandlePeerListClick: Click inside Peer List view rect. Calling LClick.");
+
+            // LClick handles selection changes and updates gLastSelectedCell internally if lOnlyOne is set
             (void)LClick(localClick, theEvent->modifiers, gPeerListHandle);
-            Cell clickedCell = LLastClick(gPeerListHandle);
-            Cell cellToVerify = clickedCell;
-            if (clickedCell.v >= 0 && clickedCell.h >= 0) {
-                if (LGetSelect(false, &cellToVerify, gPeerListHandle)) {
-                    gLastSelectedCell = clickedCell;
+
+            Cell clickedCell = LLastClick(gPeerListHandle); // Get the cell LClick determined was clicked
+            Cell cellToVerify = clickedCell; // LGetSelect modifies the cell passed in, so use a copy
+
+            // Verify that the clicked cell is actually selected
+            if (clickedCell.v >= 0 && clickedCell.h >= 0) { // Valid cell coordinates
+                if (LGetSelect(false, &cellToVerify, gPeerListHandle)) { // Check if this cell is selected
+                    gLastSelectedCell = clickedCell; // Update our master selection state
                     log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) IS selected. Unchecking broadcast.", gLastSelectedCell.h, gLastSelectedCell.v);
+
+                    // If a peer is selected, uncheck the broadcast checkbox
                     DialogItemType itemType;
                     Handle itemHandle;
                     Rect itemRect;
                     ControlHandle broadcastCheckboxHandle;
-                    GrafPtr clickOldPort;
+                    GrafPtr clickOldPort; // Save port again for GetDialogItem which might change it
                     GetPort(&clickOldPort);
-                    SetPort(GetWindowPort(gMainWindow));
+                    SetPort(GetWindowPort(gMainWindow)); // Ensure port is dialog for GetDialogItem
+
                     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
                     if (itemHandle != NULL && itemType == (ctrlItem + chkCtrl)) {
                         broadcastCheckboxHandle = (ControlHandle)itemHandle;
-                        SetControlValue(broadcastCheckboxHandle, 0);
+                        SetControlValue(broadcastCheckboxHandle, 0); // Uncheck
                     } else {
                         log_message("HandlePeerListClick: Could not find/set broadcast checkbox (item %d).", kBroadcastCheckbox);
                     }
-                    SetPort(clickOldPort);
+                    SetPort(clickOldPort); // Restore port
                 } else {
+                    // LClick might have deselected it (e.g. clicking an already selected cell with certain modifiers)
                     log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) is NOT selected by LGetSelect(false,...). Clearing selection.", clickedCell.h, clickedCell.v);
-                    SetPt(&gLastSelectedCell, 0, -1);
+                    SetPt(&gLastSelectedCell, 0, -1); // No selection
                 }
             } else {
+                // Click was in the list but not on a specific cell (e.g. empty area)
                 log_to_file_only("HandlePeerListClick: LLastClick returned invalid cell (%d,%d) after LClick. Clearing selection.", clickedCell.h, clickedCell.v);
-                SetPt(&gLastSelectedCell, 0, -1);
+                SetPt(&gLastSelectedCell, 0, -1); // No selection
             }
         } else {
             log_to_file_only("HandlePeerListClick: Click was outside Peer List view rect.");
@@ -128,83 +154,119 @@ Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
     }
     return clickWasInContent;
 }
+
 void UpdatePeerDisplayList(Boolean forceRedraw)
 {
     Cell theCell;
-    char peerStr[INET_ADDRSTRLEN + 32 + 2];
+    char peerStr[INET_ADDRSTRLEN + 32 + 2]; // username@ip + null
     int currentListLengthInRows;
     int activePeerCount = 0;
     SignedByte listState;
     Boolean oldSelectionStillValidAndFound = false;
     peer_t oldSelectedPeerData;
     Boolean hadOldSelectionData = false;
+
     if (gPeerListHandle == NULL) {
         log_message("Skipping UpdatePeerDisplayList: List not initialized.");
         return;
     }
-    if (gLastSelectedCell.v >= 0) {
-        hadOldSelectionData = GetSelectedPeerInfo(&oldSelectedPeerData);
+
+    // Try to preserve selection
+    if (gLastSelectedCell.v >= 0) { // If there was a selection
+        // Use the (now local) function to get data for the previously selected peer
+        hadOldSelectionData = DialogPeerList_GetSelectedPeer(&oldSelectedPeerData);
         if (hadOldSelectionData) {
             log_to_file_only("UpdatePeerDisplayList: Attempting to preserve selection for peer %s@%s (was display row %d).", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
         } else {
-            log_to_file_only("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but GetSelectedPeerInfo failed. No specific peer to preserve.", gLastSelectedCell.v);
+            // This means gLastSelectedCell.v was >= 0, but DialogPeerList_GetSelectedPeer failed
+            // (e.g., peer became inactive). DialogPeerList_GetSelectedPeer would have reset gLastSelectedCell.v.
+            log_to_file_only("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but DialogPeerList_GetSelectedPeer failed. No specific peer to preserve.", gLastSelectedCell.v /* this might be -1 now */);
         }
     } else {
          log_to_file_only("UpdatePeerDisplayList: No prior selection (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
     }
-    PruneTimedOutPeers();
+
+    PruneTimedOutPeers(); // Prune before redrawing
+
     listState = HGetState((Handle)gPeerListHandle);
     HLock((Handle)gPeerListHandle);
+
     if (*gPeerListHandle == NULL) {
         log_message("UpdatePeerDisplayList Error: gPeerListHandle deref failed after HLock!");
         HSetState((Handle)gPeerListHandle, listState);
         return;
     }
+
     currentListLengthInRows = (**gPeerListHandle).dataBounds.bottom;
+
+    // Clear existing rows
     if (currentListLengthInRows > 0) {
-        LDelRow(currentListLengthInRows, 0, gPeerListHandle);
+        LDelRow(currentListLengthInRows, 0, gPeerListHandle); // Delete all rows starting from row 0
         log_to_file_only("UpdatePeerDisplayList: Deleted %d rows from List Manager.", currentListLengthInRows);
     }
+
+    // Reset selection for now; will be restored if found
     Cell tempNewSelectedCell = {0, -1};
+    // gLastSelectedCell.v = -1; // Done by DialogPeerList_GetSelectedPeer if it fails, or if no initial selection
+
+    // Add active peers
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             const char *displayName = (gPeerManager.peers[i].username[0] != '\0') ? gPeerManager.peers[i].username : "???";
             sprintf(peerStr, "%s@%s", displayName, gPeerManager.peers[i].ip);
-            LAddRow(1, activePeerCount, gPeerListHandle);
-            SetPt(&theCell, 0, activePeerCount);
+
+            LAddRow(1, activePeerCount, gPeerListHandle); // Add 1 row at the end (current activePeerCount index)
+            SetPt(&theCell, 0, activePeerCount); // Column 0, current row
             LSetCell(peerStr, strlen(peerStr), theCell, gPeerListHandle);
-            if (hadOldSelectionData && strcmp(gPeerManager.peers[i].ip, oldSelectedPeerData.ip) == 0 &&
+
+            // Check if this is the previously selected peer
+            if (hadOldSelectionData &&
+                strcmp(gPeerManager.peers[i].ip, oldSelectedPeerData.ip) == 0 &&
                 strcmp(gPeerManager.peers[i].username, oldSelectedPeerData.username) == 0) {
-                tempNewSelectedCell = theCell;
+                tempNewSelectedCell = theCell; // This is the new cell for the old selection
                 oldSelectionStillValidAndFound = true;
             }
             activePeerCount++;
         }
     }
+
+    // Update dataBounds to reflect the new number of rows
     (**gPeerListHandle).dataBounds.bottom = activePeerCount;
+
+    // Restore selection if the peer is still active and found
     if (oldSelectionStillValidAndFound) {
         LSetSelect(true, tempNewSelectedCell, gPeerListHandle);
-        gLastSelectedCell = tempNewSelectedCell;
+        gLastSelectedCell = tempNewSelectedCell; // Update our master selection state
         log_to_file_only("UpdatePeerDisplayList: Reselected peer '%s@%s' at new display row %d.", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
     } else {
         if (hadOldSelectionData) {
              log_to_file_only("UpdatePeerDisplayList: Previous selection '%s@%s' not found/reselected or became inactive.", oldSelectedPeerData.username, oldSelectedPeerData.ip);
         }
-        SetPt(&gLastSelectedCell, 0, -1);
+        // If no selection was restored, gLastSelectedCell should be {-1, -1} or {0, -1}
+        // LLastClick and LGetSelect handle this, or DialogPeerList_GetSelectedPeer if it failed.
+        // Explicitly ensure no selection if nothing was restored.
+        if (!oldSelectionStillValidAndFound) {
+             SetPt(&gLastSelectedCell, 0, -1);
+        }
     }
+
     HSetState((Handle)gPeerListHandle, listState);
+
+    // Determine if a redraw is needed
     if (forceRedraw || activePeerCount != currentListLengthInRows || oldSelectionStillValidAndFound || (hadOldSelectionData && !oldSelectionStillValidAndFound) ) {
         GrafPtr windowPort = GetWindowPort(gMainWindow);
         if (windowPort != NULL) {
             GrafPtr oldPortForDrawing;
             GetPort(&oldPortForDrawing);
             SetPort(windowPort);
-            listState = HGetState((Handle)gPeerListHandle);
+
+            listState = HGetState((Handle)gPeerListHandle); // Lock again for InvalRect context
             HLock((Handle)gPeerListHandle);
             if (*gPeerListHandle != NULL) {
-                InvalRect(&(**gPeerListHandle).rView);
+                InvalRect(&(**gPeerListHandle).rView); // Invalidate the list's view rectangle
             }
             HSetState((Handle)gPeerListHandle, listState);
+
             SetPort(oldPortForDrawing);
             log_message("Peer list updated. Active peers: %d. Invalidating list rect.", activePeerCount);
         } else {
@@ -214,6 +276,7 @@ void UpdatePeerDisplayList(Boolean forceRedraw)
         log_to_file_only("UpdatePeerDisplayList: No significant change detected for redraw. Active: %d, OldRows: %d.", activePeerCount, currentListLengthInRows);
     }
 }
+
 void HandlePeerListUpdate(DialogPtr dialog)
 {
     if (gPeerListHandle != NULL) {
@@ -221,14 +284,80 @@ void HandlePeerListUpdate(DialogPtr dialog)
         if (windowPort != NULL) {
             GrafPtr oldPort;
             GetPort(&oldPort);
-            SetPort(windowPort);
-            LUpdate(windowPort->visRgn, gPeerListHandle);
+            SetPort(windowPort); // Set port to the dialog's window
+            LUpdate(windowPort->visRgn, gPeerListHandle); // Update the list within the visible region
             SetPort(oldPort);
         } else {
             log_message("HandlePeerListUpdate Error: Cannot update list, window port is NULL.");
         }
     }
 }
+
+// MOVED & RENAMED from classic_mac/peer.c
+Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer)
+{
+    // gPeerListHandle is a global in this file
+    // gLastSelectedCell is a global in this file
+    // gPeerManager is an extern from "peer.h"
+
+    if (gPeerListHandle == NULL || outPeer == NULL) {
+        return false;
+    }
+
+    if (gLastSelectedCell.v < 0) { // v is the row index; -1 means no selection
+        log_to_file_only("DialogPeerList_GetSelectedPeer: No peer selected (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
+        return false;
+    }
+
+    int selectedDisplayRow = gLastSelectedCell.v;
+    int current_active_peer_index = 0; // This will be the 0-based index into the *displayed* list
+
+    for (int i = 0; i < MAX_PEERS; i++) {
+        if (gPeerManager.peers[i].active) {
+            if (current_active_peer_index == selectedDisplayRow) {
+                *outPeer = gPeerManager.peers[i];
+                log_to_file_only("DialogPeerList_GetSelectedPeer: Found selected peer '%s'@'%s' at display row %d (data index %d).",
+                                 (outPeer->username[0] ? outPeer->username : "???"), outPeer->ip, selectedDisplayRow, i);
+                return true;
+            }
+            current_active_peer_index++;
+        }
+    }
+
+    // If we reach here, the selectedDisplayRow was out of bounds for the current active peers
+    // (e.g., peer became inactive since last selection)
+    log_message("DialogPeerList_GetSelectedPeer Warning: Selected row %d is out of bounds or peer became inactive (current active peers: %d).",
+                selectedDisplayRow, current_active_peer_index);
+    SetPt(&gLastSelectedCell, 0, -1); // Clear the invalid selection
+    return false;
+}
+
+// NEW function
+void DialogPeerList_DeselectAll(void) {
+    if (gPeerListHandle != NULL && gLastSelectedCell.v >= 0) {
+        GrafPtr oldPortForList;
+        GetPort(&oldPortForList);
+        SetPort(GetWindowPort(gMainWindow)); // Assumes gMainWindow is valid and is the list's window
+
+        LSetSelect(false, gLastSelectedCell, gPeerListHandle); // Deselect the current cell
+        SetPt(&gLastSelectedCell, 0, -1); // Clear our record of the selection
+
+        // Invalidate the list's view to ensure it redraws correctly
+        SignedByte listState = HGetState((Handle)gPeerListHandle);
+        HLock((Handle)gPeerListHandle);
+        if (*gPeerListHandle != NULL) {
+            InvalRect(&(**gPeerListHandle).rView);
+        }
+        HSetState((Handle)gPeerListHandle, listState);
+
+        SetPort(oldPortForList);
+        log_to_file_only("DialogPeerList_DeselectAll: Cleared selection and invalidated view.");
+    } else {
+        log_to_file_only("DialogPeerList_DeselectAll: No selection to clear or list not initialized.");
+    }
+}
+
+
 void ActivatePeerList(Boolean activating)
 {
     if (gPeerListHandle != NULL) {

--- a/classic_mac/dialog_peerlist.h
+++ b/classic_mac/dialog_peerlist.h
@@ -1,19 +1,24 @@
 #ifndef DIALOG_PEERLIST_H
-#define DIALOG_PEERLIST_H 
+#define DIALOG_PEERLIST_H
+
 #include <MacTypes.h>
 #include <Lists.h>
 #include <Dialogs.h>
 #include <Events.h>
-#include "peer.h"
+#include "peer.h" // For peer_t, MAX_PEERS (via shared/common_defs.h) and gPeerManager extern
+
 extern DialogPtr gMainWindow;
 extern ListHandle gPeerListHandle;
 extern Cell gLastSelectedCell;
-extern peer_t gPeerList[MAX_PEERS];
+// extern peer_t gPeerList[MAX_PEERS]; // REMOVED - Unused and incorrect
+
 Boolean InitPeerListControl(DialogPtr dialog);
 void CleanupPeerListControl(void);
 Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent);
 void UpdatePeerDisplayList(Boolean forceRedraw);
 void HandlePeerListUpdate(DialogPtr dialog);
-Boolean GetSelectedPeerInfo(peer_t *outPeer);
+Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer); // MOVED & RENAMED from classic_mac/peer.h
+void DialogPeerList_DeselectAll(void);                 // NEW function
 void ActivatePeerList(Boolean activating);
+
 #endif

--- a/classic_mac/peer.c
+++ b/classic_mac/peer.c
@@ -1,20 +1,29 @@
 #include "peer.h"
 #include "logging.h"
 #include <stddef.h>
-#include <stdbool.h>
+// #include <stdbool.h> // Boolean is from MacTypes.h
 #include <string.h>
-#include <MacTypes.h>
-#include <Lists.h>
-#include <Dialogs.h>
-peer_manager_t gPeerManager;
+#include <MacTypes.h> // For Boolean, Cell, SetPt
+// ListHandle and Dialogs are not needed here anymore after moving GetSelectedPeerInfo
+// #include <Lists.h>
+// #include <Dialogs.h>
+
+peer_manager_t gPeerManager; // Definition
+
 void InitPeerList(void)
 {
     peer_shared_init_list(&gPeerManager);
 }
+
 int AddOrUpdatePeer(const char *ip, const char *username)
 {
+    // This function now just wraps the shared logic.
+    // If platform-specific side effects were needed (e.g. immediate UI update on add),
+    // they would be here or triggered from here.
+    // The current model updates UI periodically or on specific notifications.
     return peer_shared_add_or_update(&gPeerManager, ip, username);
 }
+
 Boolean MarkPeerInactive(const char *ip)
 {
     if (!ip) return false;
@@ -22,66 +31,44 @@ Boolean MarkPeerInactive(const char *ip)
     if (index != -1) {
         if (gPeerManager.peers[index].active) {
             log_message("Marking peer %s@%s as inactive due to QUIT message.", gPeerManager.peers[index].username, ip);
-            gPeerManager.peers[index].active = 0;
-            return true;
+            gPeerManager.peers[index].active = 0; // Mark inactive in our Mac-specific list
+            // Potentially trigger UI update here if needed, or rely on periodic updates
+            return true; // Status changed
         } else {
             log_to_file_only("MarkPeerInactive: Peer %s was already inactive.", ip);
-            return false;
+            return false; // Status did not change
         }
     }
     log_to_file_only("MarkPeerInactive: Peer %s not found in list.", ip);
     return false;
 }
+
 void PruneTimedOutPeers(void)
 {
     int pruned_count = peer_shared_prune_timed_out(&gPeerManager);
     if (pruned_count > 0) {
         log_message("Pruned %d timed-out peer(s).", pruned_count);
+        // UI will be updated by UpdatePeerDisplayList which calls this.
     }
 }
+
+// This function gets a peer by its logical Nth position among *active* peers.
+// Useful if you need to iterate through active peers without knowing their gPeerManager index.
 Boolean GetPeerByIndex(int active_index, peer_t *out_peer)
 {
     int current_active_count = 0;
-    if (active_index <= 0 || out_peer == NULL) {
+    if (active_index < 0 || out_peer == NULL) { // active_index is 0-based
         return false;
     }
+
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
-            current_active_count++;
             if (current_active_count == active_index) {
                 *out_peer = gPeerManager.peers[i];
                 return true;
             }
-        }
-    }
-    return false;
-}
-Boolean GetSelectedPeerInfo(peer_t *outPeer)
-{
-    extern ListHandle gPeerListHandle;
-    extern Cell gLastSelectedCell;
-    if (gPeerListHandle == NULL || outPeer == NULL) {
-        return false;
-    }
-    if (gLastSelectedCell.v < 0) {
-        log_to_file_only("GetSelectedPeerInfo: No peer selected (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
-        return false;
-    }
-    int selectedDisplayRow = gLastSelectedCell.v;
-    int current_active_count = 0;
-    for (int i = 0; i < MAX_PEERS; i++) {
-        if (gPeerManager.peers[i].active) {
-            if (current_active_count == selectedDisplayRow) {
-                *outPeer = gPeerManager.peers[i];
-                log_to_file_only("GetSelectedPeerInfo: Found selected peer '%s'@'%s' at display row %d (data index %d).",
-                                 (outPeer->username[0] ? outPeer->username : "???"), outPeer->ip, selectedDisplayRow, i);
-                return true;
-            }
             current_active_count++;
         }
     }
-    log_message("GetSelectedPeerInfo Warning: Selected row %d is out of bounds or peer became inactive (current active peers: %d).",
-                selectedDisplayRow, current_active_count);
-    SetPt(&gLastSelectedCell, 0, -1);
-    return false;
+    return false; // active_index out of bounds
 }

--- a/classic_mac/peer.h
+++ b/classic_mac/peer.h
@@ -1,13 +1,17 @@
 #ifndef PEER_MAC_H
-#define PEER_MAC_H 
+#define PEER_MAC_H
+
 #include <MacTypes.h>
-#include "../shared/common_defs.h"
-#include "../shared/peer.h"
-extern peer_manager_t gPeerManager;
-void InitPeerList(void);
-int AddOrUpdatePeer(const char *ip, const char *username);
-Boolean MarkPeerInactive(const char *ip);
-void PruneTimedOutPeers(void);
-Boolean GetPeerByIndex(int active_index, peer_t *out_peer);
-Boolean GetSelectedPeerInfo(peer_t *outPeer);
+#include "../shared/common_defs.h" // For peer_t, MAX_PEERS
+#include "../shared/peer.h"       // For peer_manager_t
+
+extern peer_manager_t gPeerManager; // Manages the actual peer data
+
+void InitPeerList(void); // Initializes gPeerManager
+int AddOrUpdatePeer(const char *ip, const char *username); // Operates on gPeerManager
+Boolean MarkPeerInactive(const char *ip); // Operates on gPeerManager
+void PruneTimedOutPeers(void); // Operates on gPeerManager
+Boolean GetPeerByIndex(int active_index, peer_t *out_peer); // Gets from gPeerManager by logical active index
+// Boolean GetSelectedPeerInfo(peer_t *outPeer); // REMOVED - Logic moved to dialog_peerlist.c
+
 #endif


### PR DESCRIPTION
- Moved GetSelectedPeerInfo from peer.c to dialog_peerlist.c and renamed it to DialogPeerList_GetSelectedPeer. This centralizes the interpretation of the List Manager's selection state and its translation to peer_t data within the dialog_peerlist module.
- Created DialogPeerList_DeselectAll in dialog_peerlist.c to encapsulate the logic for deselecting list items, previously handled directly in main.c when the broadcast checkbox was toggled.
- Removed unused 'extern peer_t gPeerList[]' from dialog_peerlist.h.
- Updated call sites in dialog.c (HandleSendButtonClick) and main.c (broadcast checkbox handler) to use the new/moved functions.

These changes improve the cohesion of dialog_peerlist.c, making it more responsible for its own state and interactions, and reduce direct manipulation of its internals from other modules.