### PR TITLE
Refactor(ClassicMac): Centralize message scrollbar logic and fix thum…

### DIFF
--- a/classic_mac/dialog.c
+++ b/classic_mac/dialog.c
@@ -1,18 +1,10 @@
-// FILE: ./classic_mac/dialog.c
-//====================================
-
-//====================================
-// FILE: ./classic_mac/dialog.c
-//====================================
-
 #include "dialog.h"
 #include "logging.h"
-#include "network.h" // For gMyUsername (extern), gMyLocalIPStr
-#include "peer.h"    // For gPeerManager
-#include "./mactcp_messaging.h" // For MacTCP_SendMessageSync, streamBusyErr
-#include "../shared/logging.h" // For is_debug_output_enabled, set_debug_output_enabled
-#include "../shared/protocol.h" // For MSG_TEXT
-
+#include "network.h"
+#include "peer.h"
+#include "./mactcp_messaging.h"
+#include "../shared/logging.h"
+#include "../shared/protocol.h"
 #include <MacTypes.h>
 #include <Dialogs.h>
 #include <TextEdit.h>
@@ -27,15 +19,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <Errors.h> // For noErr
-
-// Global variables related to the main dialog window and its components
+#include <Errors.h>
 DialogPtr gMainWindow = NULL;
-Boolean gDialogTEInitialized = false;   // True if both Messages and Input TEs are set up
-Boolean gDialogListInitialized = false; // True if Peer List is set up
-// char gMyUsername[32];                // REMOVED - extern declaration comes from network.h
-// Cell gLastSelectedCell = {0, -1};    // REMOVED - extern declaration comes from dialog_peerlist.h
-
+Boolean gDialogTEInitialized = false;
+Boolean gDialogListInitialized = false;
 Boolean InitDialog(void)
 {
     Boolean messagesOk = false;
@@ -46,7 +33,6 @@ Boolean InitDialog(void)
     Handle itemHandle;
     Rect itemRect;
     GrafPtr oldPort;
-
     log_message("Loading dialog resource ID %d...", kBaseResID);
     gMainWindow = GetNewDialog(kBaseResID, NULL, (WindowPtr) - 1L);
     if (gMainWindow == NULL) {
@@ -54,18 +40,13 @@ Boolean InitDialog(void)
         return false;
     }
     log_message("Dialog loaded successfully (gMainWindow: 0x%lX).", (unsigned long)gMainWindow);
-
     GetPort(&oldPort);
-    SetPort(GetWindowPort(gMainWindow)); // Set current port to the dialog's window
-
-    // Initialize components
+    SetPort(GetWindowPort(gMainWindow));
     messagesOk = InitMessagesTEAndScrollbar(gMainWindow);
     inputOk = InitInputTE(gMainWindow);
     listOk = InitPeerListControl(gMainWindow);
-
     gDialogTEInitialized = (messagesOk && inputOk);
     gDialogListInitialized = listOk;
-
     if (!gDialogTEInitialized || !gDialogListInitialized) {
         log_message("Error: One or more dialog components (TEs, List) failed to initialize. Cleaning up.");
         if (listOk) CleanupPeerListControl();
@@ -76,8 +57,6 @@ Boolean InitDialog(void)
         SetPort(oldPort);
         return false;
     }
-
-    // Initialize Debug Checkbox state
     GetDialogItem(gMainWindow, kDebugCheckbox, &itemType, &itemHandle, &itemRect);
     if (itemHandle != NULL) {
         if (itemType == (ctrlItem + chkCtrl)) {
@@ -90,13 +69,11 @@ Boolean InitDialog(void)
     } else {
          log_message("Warning: Item %d (kDebugCheckbox) handle is NULL! Cannot set initial state.", kDebugCheckbox);
     }
-
-    // Initialize Broadcast Checkbox state (default to off)
     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
     if (itemHandle != NULL) {
         if (itemType == (ctrlItem + chkCtrl)) {
              ctrlHandle = (ControlHandle)itemHandle;
-             SetControlValue(ctrlHandle, 0); // Off by default
+             SetControlValue(ctrlHandle, 0);
              log_message("Broadcast checkbox (Item %d) initialized to: OFF", kBroadcastCheckbox);
         } else {
             log_message("Warning: Item %d (kBroadcastCheckbox) is not a checkbox (Type: %d)! Cannot set initial state.", kBroadcastCheckbox, itemType);
@@ -104,27 +81,21 @@ Boolean InitDialog(void)
     } else {
         log_message("Warning: Item %d (kBroadcastCheckbox) handle is NULL! Cannot set initial state.", kBroadcastCheckbox);
     }
-
-
-    UpdatePeerDisplayList(true); // Populate peer list
+    UpdatePeerDisplayList(true);
     log_message("Setting focus to input field (item %d)...", kInputTextEdit);
-    ActivateInputTE(true);      // Activate input TE for typing
-
-    UpdateDialogControls(); // Initial draw/update of all controls
+    ActivateInputTE(true);
+    UpdateDialogControls();
     log_message("Initial UpdateDialogControls() called from InitDialog.");
-
-    SetPort(oldPort); // Restore original port
+    SetPort(oldPort);
     log_message("InitDialog finished successfully.");
     return true;
 }
-
 void CleanupDialog(void)
 {
     log_message("Cleaning up Dialog...");
     CleanupPeerListControl();
     CleanupInputTE();
     CleanupMessagesTEAndScrollbar();
-
     if (gMainWindow != NULL) {
         log_message("Disposing dialog window...");
         DisposeDialog(gMainWindow);
@@ -134,41 +105,35 @@ void CleanupDialog(void)
     gDialogListInitialized = false;
     log_message("Dialog cleanup complete.");
 }
-
 void HandleSendButtonClick(void)
 {
-    char inputCStr[256]; // Buffer for input text
+    char inputCStr[256];
     ControlHandle broadcastCheckboxHandle;
     DialogItemType itemType;
     Handle itemHandle;
     Rect itemRect;
     Boolean isBroadcast;
-    char displayMsg[BUFFER_SIZE + 100]; // For messages displayed in the TE
+    char displayMsg[BUFFER_SIZE + 100];
     OSErr sendErr = noErr;
     int i;
-
     if (!gDialogTEInitialized || gInputTE == NULL) {
         log_message("Error (HandleSendButtonClick): Input TE not initialized.");
         SysBeep(10);
         return;
     }
-
     if (!GetInputText(inputCStr, sizeof(inputCStr))) {
         log_message("Error: Could not get text from input field for sending.");
         SysBeep(10);
-        ActivateInputTE(true); // Reactivate for user
+        ActivateInputTE(true);
         return;
     }
-
     if (strlen(inputCStr) == 0) {
         log_message("Send Action: Input field is empty. No action taken.");
-        ActivateInputTE(true); // Reactivate for user
+        ActivateInputTE(true);
         return;
     }
-
-    // Check broadcast checkbox state
     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
-    isBroadcast = false; // Default to not broadcast
+    isBroadcast = false;
     if (itemHandle != NULL && itemType == (ctrlItem + chkCtrl)) {
         broadcastCheckboxHandle = (ControlHandle)itemHandle;
         isBroadcast = (GetControlValue(broadcastCheckboxHandle) == 1);
@@ -176,13 +141,11 @@ void HandleSendButtonClick(void)
     } else {
         log_message("Warning: Broadcast item %d is not a checkbox or handle is NULL! Assuming not broadcast.", kBroadcastCheckbox);
     }
-
     if (isBroadcast) {
         int sent_count = 0;
         log_message("Attempting broadcast of: '%s'", inputCStr);
         sprintf(displayMsg, "You (Broadcast): %s", inputCStr);
         AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r");
-
         for (i = 0; i < MAX_PEERS; i++) {
             if (gPeerManager.peers[i].active) {
                 sendErr = MacTCP_SendMessageSync(gPeerManager.peers[i].ip,
@@ -196,7 +159,6 @@ void HandleSendButtonClick(void)
                 } else {
                     log_message("Broadcast send to %s@%s failed: %d",
                                 gPeerManager.peers[i].username, gPeerManager.peers[i].ip, sendErr);
-                    // Optionally display error for this specific peer in messages TE
                 }
             }
         }
@@ -204,13 +166,11 @@ void HandleSendButtonClick(void)
         AppendToMessagesTE(displayMsg); AppendToMessagesTE("\r");
         log_message("Broadcast of '%s' completed. Sent to %d peers.", inputCStr, sent_count);
         ClearInputText();
-    } else { // Unicast send
+    } else {
         peer_t targetPeer;
-        // Use the new function from dialog_peerlist.c
         if (DialogPeerList_GetSelectedPeer(&targetPeer)) {
             log_message("Attempting sync send to selected peer %s@%s: '%s'",
                         targetPeer.username, targetPeer.ip, inputCStr);
-
             sendErr = MacTCP_SendMessageSync(targetPeer.ip,
                                              inputCStr,
                                              MSG_TEXT,
@@ -223,7 +183,7 @@ void HandleSendButtonClick(void)
                 log_message("Sync send completed successfully.");
                 ClearInputText();
             } else {
-                if (sendErr == streamBusyErr) { // MacTCP specific error
+                if (sendErr == streamBusyErr) {
                      sprintf(displayMsg, "Could not send to %s: network busy. Try again.", targetPeer.username);
                 } else {
                      sprintf(displayMsg, "Error sending to %s: %d", targetPeer.username, sendErr);
@@ -238,35 +198,25 @@ void HandleSendButtonClick(void)
             SysBeep(10);
         }
     }
-    ActivateInputTE(true); // Reactivate input field
+    ActivateInputTE(true);
 }
-
 void ActivateDialogTE(Boolean activating)
 {
     ActivateMessagesTEAndScrollbar(activating);
     ActivateInputTE(activating);
 }
-
 void UpdateDialogControls(void)
 {
     GrafPtr oldPort;
     GrafPtr windowPort = GetWindowPort(gMainWindow);
-
     if (windowPort == NULL) {
         log_message("UpdateDialogControls Error: Window port is NULL for gMainWindow!");
         return;
     }
-
     GetPort(&oldPort);
     SetPort(windowPort);
-
-    HandleMessagesTEUpdate(gMainWindow); // Update messages TE content
-    HandleInputTEUpdate(gMainWindow);    // Update input TE content (e.g., draw frame)
-    HandlePeerListUpdate(gMainWindow);   // Update peer list display
-
-    // Any other controls that need explicit update can be added here.
-    // For example, if scrollbar visibility/hilite depends on window activation,
-    // it's often handled in activateEvt, but a general redraw might also touch it.
-
+    HandleMessagesTEUpdate(gMainWindow);
+    HandleInputTEUpdate(gMainWindow);
+    HandlePeerListUpdate(gMainWindow);
     SetPort(oldPort);
 }

--- a/classic_mac/dialog_messages.h
+++ b/classic_mac/dialog_messages.h
@@ -12,6 +12,7 @@ void CleanupMessagesTEAndScrollbar(void);
 void AppendToMessagesTE(const char *text);
 void AdjustMessagesScrollbar(void);
 void HandleMessagesScrollClick(ControlHandle theControl, short partCode);
+void ScrollMessagesTEToValue(short newScrollValue);
 void HandleMessagesTEUpdate(DialogPtr dialog);
 void ActivateMessagesTEAndScrollbar(Boolean activating);
 void ScrollMessagesTE(short deltaPixels);

--- a/classic_mac/dialog_peerlist.c
+++ b/classic_mac/dialog_peerlist.c
@@ -1,7 +1,7 @@
 #include "dialog_peerlist.h"
-#include "dialog.h"    // For kBroadcastCheckbox, gMainWindow
+#include "dialog.h"
 #include "logging.h"
-#include "peer.h"      // For gPeerManager, PruneTimedOutPeers
+#include "peer.h"
 #include <MacTypes.h>
 #include <Lists.h>
 #include <Dialogs.h>
@@ -12,10 +12,8 @@
 #include <Controls.h>
 #include <stdio.h>
 #include <string.h>
-
 ListHandle gPeerListHandle = NULL;
-Cell gLastSelectedCell = {0, -1}; // {h, v} - v = -1 means no selection
-
+Cell gLastSelectedCell = {0, -1};
 Boolean InitPeerListControl(DialogPtr dialog)
 {
     DialogItemType itemType;
@@ -24,43 +22,36 @@ Boolean InitPeerListControl(DialogPtr dialog)
     Point cellSize;
     FontInfo fontInfo;
     Boolean listOk = false;
-
     log_message("Initializing Peer List Control...");
     GetDialogItem(dialog, kPeerListUserItem, &itemType, &itemHandle, &destRectList);
-
     if (itemType == userItem) {
         log_message("Item %d is UserItem. Rect: (%d,%d,%d,%d)", kPeerListUserItem,
                     destRectList.top, destRectList.left, destRectList.bottom, destRectList.right);
-
         GrafPtr oldPort;
         GetPort(&oldPort);
-        SetPort(GetWindowPort(dialog)); // Use dialog's port for font info
+        SetPort(GetWindowPort(dialog));
         GetFontInfo(&fontInfo);
         SetPort(oldPort);
-
         cellSize.v = fontInfo.ascent + fontInfo.descent + fontInfo.leading;
         if (cellSize.v <= 0) {
             log_message("Warning: Calculated cell height is %d, using default 12.", cellSize.v);
-            cellSize.v = 12; // A common default
+            cellSize.v = 12;
         }
-        cellSize.h = destRectList.right - destRectList.left; // Full width for now
-
-        SetRect(&dataBounds, 0, 0, 1, 0); // 1 column, 0 rows initially
-
+        cellSize.h = destRectList.right - destRectList.left;
+        SetRect(&dataBounds, 0, 0, 1, 0);
         log_message("Calling LNew for Peer List (Cell Size: H%d, V%d)...", cellSize.h, cellSize.v);
         gPeerListHandle = LNew(&destRectList, &dataBounds, cellSize, 0, (WindowPtr)dialog,
-                               true,  // drawIt
-                               false, // hasGrow
-                               false, // scrollHoriz
-                               true); // scrollVert (though we don't provide a scrollbar DITL item for it yet)
-
+                               true,
+                               false,
+                               false,
+                               true);
         if (gPeerListHandle == NULL) {
             log_message("CRITICAL ERROR: LNew failed for Peer List! (Error: %d)", ResError());
             listOk = false;
         } else {
             log_message("LNew succeeded for Peer List. Handle: 0x%lX", (unsigned long)gPeerListHandle);
-            (*gPeerListHandle)->selFlags = lOnlyOne; // Allow only single selection
-            LActivate(true, gPeerListHandle); // Activate the list
+            (*gPeerListHandle)->selFlags = lOnlyOne;
+            LActivate(true, gPeerListHandle);
             listOk = true;
         }
     } else {
@@ -70,82 +61,66 @@ Boolean InitPeerListControl(DialogPtr dialog)
     }
     return listOk;
 }
-
 void CleanupPeerListControl(void)
 {
     log_message("Cleaning up Peer List Control...");
     if (gPeerListHandle != NULL) {
-        LActivate(false, gPeerListHandle); // Deactivate before disposing
+        LActivate(false, gPeerListHandle);
         LDispose(gPeerListHandle);
         gPeerListHandle = NULL;
     }
-    gLastSelectedCell.v = -1; // Reset selection state
+    gLastSelectedCell.v = -1;
     log_message("Peer List Control cleanup finished.");
 }
-
 Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
 {
     Boolean clickWasInContent = false;
     if (gPeerListHandle != NULL) {
         Point localClick = theEvent->where;
         GrafPtr oldPort;
-
         GetPort(&oldPort);
-        SetPort(GetWindowPort(dialog)); // Convert to dialog's local coordinates
+        SetPort(GetWindowPort(dialog));
         GlobalToLocal(&localClick);
         SetPort(oldPort);
-
         SignedByte listState = HGetState((Handle)gPeerListHandle);
         HLock((Handle)gPeerListHandle);
-
         if (*gPeerListHandle == NULL) {
             log_message("HandlePeerListClick Error: gPeerListHandle deref failed after HLock!");
             HSetState((Handle)gPeerListHandle, listState);
             return false;
         }
-
         if (PtInRect(localClick, &(**gPeerListHandle).rView)) {
             clickWasInContent = true;
             log_to_file_only("HandlePeerListClick: Click inside Peer List view rect. Calling LClick.");
-
-            // LClick handles selection changes and updates gLastSelectedCell internally if lOnlyOne is set
             (void)LClick(localClick, theEvent->modifiers, gPeerListHandle);
-
-            Cell clickedCell = LLastClick(gPeerListHandle); // Get the cell LClick determined was clicked
-            Cell cellToVerify = clickedCell; // LGetSelect modifies the cell passed in, so use a copy
-
-            // Verify that the clicked cell is actually selected
-            if (clickedCell.v >= 0 && clickedCell.h >= 0) { // Valid cell coordinates
-                if (LGetSelect(false, &cellToVerify, gPeerListHandle)) { // Check if this cell is selected
-                    gLastSelectedCell = clickedCell; // Update our master selection state
+            Cell clickedCell = LLastClick(gPeerListHandle);
+            Cell cellToVerify = clickedCell;
+            if (clickedCell.v >= 0 && clickedCell.h >= 0) {
+                if (LGetSelect(false, &cellToVerify, gPeerListHandle)) {
+                    gLastSelectedCell = clickedCell;
                     log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) IS selected. Unchecking broadcast.", gLastSelectedCell.h, gLastSelectedCell.v);
-
-                    // If a peer is selected, uncheck the broadcast checkbox
                     DialogItemType itemType;
                     Handle itemHandle;
                     Rect itemRect;
                     ControlHandle broadcastCheckboxHandle;
-                    GrafPtr clickOldPort; // Save port again for GetDialogItem which might change it
+                    GrafPtr clickOldPort;
                     GetPort(&clickOldPort);
-                    SetPort(GetWindowPort(gMainWindow)); // Ensure port is dialog for GetDialogItem
-
+                    SetPort(GetWindowPort(gMainWindow));
                     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
                     if (itemHandle != NULL && itemType == (ctrlItem + chkCtrl)) {
                         broadcastCheckboxHandle = (ControlHandle)itemHandle;
-                        SetControlValue(broadcastCheckboxHandle, 0); // Uncheck
+                        SetControlValue(broadcastCheckboxHandle, 0);
                     } else {
                         log_message("HandlePeerListClick: Could not find/set broadcast checkbox (item %d).", kBroadcastCheckbox);
                     }
-                    SetPort(clickOldPort); // Restore port
+                    SetPort(clickOldPort);
                 } else {
-                    // LClick might have deselected it (e.g. clicking an already selected cell with certain modifiers)
                     log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) is NOT selected by LGetSelect(false,...). Clearing selection.", clickedCell.h, clickedCell.v);
-                    SetPt(&gLastSelectedCell, 0, -1); // No selection
+                    SetPt(&gLastSelectedCell, 0, -1);
                 }
             } else {
-                // Click was in the list but not on a specific cell (e.g. empty area)
                 log_to_file_only("HandlePeerListClick: LLastClick returned invalid cell (%d,%d) after LClick. Clearing selection.", clickedCell.h, clickedCell.v);
-                SetPt(&gLastSelectedCell, 0, -1); // No selection
+                SetPt(&gLastSelectedCell, 0, -1);
             }
         } else {
             log_to_file_only("HandlePeerListClick: Click was outside Peer List view rect.");
@@ -154,119 +129,86 @@ Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
     }
     return clickWasInContent;
 }
-
 void UpdatePeerDisplayList(Boolean forceRedraw)
 {
     Cell theCell;
-    char peerStr[INET_ADDRSTRLEN + 32 + 2]; // username@ip + null
+    char peerStr[INET_ADDRSTRLEN + 32 + 2];
     int currentListLengthInRows;
     int activePeerCount = 0;
     SignedByte listState;
     Boolean oldSelectionStillValidAndFound = false;
     peer_t oldSelectedPeerData;
     Boolean hadOldSelectionData = false;
-
     if (gPeerListHandle == NULL) {
         log_message("Skipping UpdatePeerDisplayList: List not initialized.");
         return;
     }
-
-    // Try to preserve selection
-    if (gLastSelectedCell.v >= 0) { // If there was a selection
-        // Use the (now local) function to get data for the previously selected peer
+    if (gLastSelectedCell.v >= 0) {
         hadOldSelectionData = DialogPeerList_GetSelectedPeer(&oldSelectedPeerData);
         if (hadOldSelectionData) {
             log_to_file_only("UpdatePeerDisplayList: Attempting to preserve selection for peer %s@%s (was display row %d).", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
         } else {
-            // This means gLastSelectedCell.v was >= 0, but DialogPeerList_GetSelectedPeer failed
-            // (e.g., peer became inactive). DialogPeerList_GetSelectedPeer would have reset gLastSelectedCell.v.
-            log_to_file_only("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but DialogPeerList_GetSelectedPeer failed. No specific peer to preserve.", gLastSelectedCell.v /* this might be -1 now */);
+            log_to_file_only("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but DialogPeerList_GetSelectedPeer failed. No specific peer to preserve.", gLastSelectedCell.v );
         }
     } else {
          log_to_file_only("UpdatePeerDisplayList: No prior selection (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
     }
-
-    PruneTimedOutPeers(); // Prune before redrawing
-
+    PruneTimedOutPeers();
     listState = HGetState((Handle)gPeerListHandle);
     HLock((Handle)gPeerListHandle);
-
     if (*gPeerListHandle == NULL) {
         log_message("UpdatePeerDisplayList Error: gPeerListHandle deref failed after HLock!");
         HSetState((Handle)gPeerListHandle, listState);
         return;
     }
-
     currentListLengthInRows = (**gPeerListHandle).dataBounds.bottom;
-
-    // Clear existing rows
     if (currentListLengthInRows > 0) {
-        LDelRow(currentListLengthInRows, 0, gPeerListHandle); // Delete all rows starting from row 0
+        LDelRow(currentListLengthInRows, 0, gPeerListHandle);
         log_to_file_only("UpdatePeerDisplayList: Deleted %d rows from List Manager.", currentListLengthInRows);
     }
-
-    // Reset selection for now; will be restored if found
     Cell tempNewSelectedCell = {0, -1};
-    // gLastSelectedCell.v = -1; // Done by DialogPeerList_GetSelectedPeer if it fails, or if no initial selection
-
-    // Add active peers
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             const char *displayName = (gPeerManager.peers[i].username[0] != '\0') ? gPeerManager.peers[i].username : "???";
             sprintf(peerStr, "%s@%s", displayName, gPeerManager.peers[i].ip);
-
-            LAddRow(1, activePeerCount, gPeerListHandle); // Add 1 row at the end (current activePeerCount index)
-            SetPt(&theCell, 0, activePeerCount); // Column 0, current row
+            LAddRow(1, activePeerCount, gPeerListHandle);
+            SetPt(&theCell, 0, activePeerCount);
             LSetCell(peerStr, strlen(peerStr), theCell, gPeerListHandle);
-
-            // Check if this is the previously selected peer
             if (hadOldSelectionData &&
                 strcmp(gPeerManager.peers[i].ip, oldSelectedPeerData.ip) == 0 &&
                 strcmp(gPeerManager.peers[i].username, oldSelectedPeerData.username) == 0) {
-                tempNewSelectedCell = theCell; // This is the new cell for the old selection
+                tempNewSelectedCell = theCell;
                 oldSelectionStillValidAndFound = true;
             }
             activePeerCount++;
         }
     }
-
-    // Update dataBounds to reflect the new number of rows
     (**gPeerListHandle).dataBounds.bottom = activePeerCount;
-
-    // Restore selection if the peer is still active and found
     if (oldSelectionStillValidAndFound) {
         LSetSelect(true, tempNewSelectedCell, gPeerListHandle);
-        gLastSelectedCell = tempNewSelectedCell; // Update our master selection state
+        gLastSelectedCell = tempNewSelectedCell;
         log_to_file_only("UpdatePeerDisplayList: Reselected peer '%s@%s' at new display row %d.", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
     } else {
         if (hadOldSelectionData) {
              log_to_file_only("UpdatePeerDisplayList: Previous selection '%s@%s' not found/reselected or became inactive.", oldSelectedPeerData.username, oldSelectedPeerData.ip);
         }
-        // If no selection was restored, gLastSelectedCell should be {-1, -1} or {0, -1}
-        // LLastClick and LGetSelect handle this, or DialogPeerList_GetSelectedPeer if it failed.
-        // Explicitly ensure no selection if nothing was restored.
         if (!oldSelectionStillValidAndFound) {
              SetPt(&gLastSelectedCell, 0, -1);
         }
     }
-
     HSetState((Handle)gPeerListHandle, listState);
-
-    // Determine if a redraw is needed
     if (forceRedraw || activePeerCount != currentListLengthInRows || oldSelectionStillValidAndFound || (hadOldSelectionData && !oldSelectionStillValidAndFound) ) {
         GrafPtr windowPort = GetWindowPort(gMainWindow);
         if (windowPort != NULL) {
             GrafPtr oldPortForDrawing;
             GetPort(&oldPortForDrawing);
             SetPort(windowPort);
-
-            listState = HGetState((Handle)gPeerListHandle); // Lock again for InvalRect context
+            listState = HGetState((Handle)gPeerListHandle);
             HLock((Handle)gPeerListHandle);
             if (*gPeerListHandle != NULL) {
-                InvalRect(&(**gPeerListHandle).rView); // Invalidate the list's view rectangle
+                InvalRect(&(**gPeerListHandle).rView);
             }
             HSetState((Handle)gPeerListHandle, listState);
-
             SetPort(oldPortForDrawing);
             log_message("Peer list updated. Active peers: %d. Invalidating list rect.", activePeerCount);
         } else {
@@ -276,7 +218,6 @@ void UpdatePeerDisplayList(Boolean forceRedraw)
         log_to_file_only("UpdatePeerDisplayList: No significant change detected for redraw. Active: %d, OldRows: %d.", activePeerCount, currentListLengthInRows);
     }
 }
-
 void HandlePeerListUpdate(DialogPtr dialog)
 {
     if (gPeerListHandle != NULL) {
@@ -284,34 +225,25 @@ void HandlePeerListUpdate(DialogPtr dialog)
         if (windowPort != NULL) {
             GrafPtr oldPort;
             GetPort(&oldPort);
-            SetPort(windowPort); // Set port to the dialog's window
-            LUpdate(windowPort->visRgn, gPeerListHandle); // Update the list within the visible region
+            SetPort(windowPort);
+            LUpdate(windowPort->visRgn, gPeerListHandle);
             SetPort(oldPort);
         } else {
             log_message("HandlePeerListUpdate Error: Cannot update list, window port is NULL.");
         }
     }
 }
-
-// MOVED & RENAMED from classic_mac/peer.c
 Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer)
 {
-    // gPeerListHandle is a global in this file
-    // gLastSelectedCell is a global in this file
-    // gPeerManager is an extern from "peer.h"
-
     if (gPeerListHandle == NULL || outPeer == NULL) {
         return false;
     }
-
-    if (gLastSelectedCell.v < 0) { // v is the row index; -1 means no selection
+    if (gLastSelectedCell.v < 0) {
         log_to_file_only("DialogPeerList_GetSelectedPeer: No peer selected (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
         return false;
     }
-
     int selectedDisplayRow = gLastSelectedCell.v;
-    int current_active_peer_index = 0; // This will be the 0-based index into the *displayed* list
-
+    int current_active_peer_index = 0;
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             if (current_active_peer_index == selectedDisplayRow) {
@@ -323,41 +255,30 @@ Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer)
             current_active_peer_index++;
         }
     }
-
-    // If we reach here, the selectedDisplayRow was out of bounds for the current active peers
-    // (e.g., peer became inactive since last selection)
     log_message("DialogPeerList_GetSelectedPeer Warning: Selected row %d is out of bounds or peer became inactive (current active peers: %d).",
                 selectedDisplayRow, current_active_peer_index);
-    SetPt(&gLastSelectedCell, 0, -1); // Clear the invalid selection
+    SetPt(&gLastSelectedCell, 0, -1);
     return false;
 }
-
-// NEW function
 void DialogPeerList_DeselectAll(void) {
     if (gPeerListHandle != NULL && gLastSelectedCell.v >= 0) {
         GrafPtr oldPortForList;
         GetPort(&oldPortForList);
-        SetPort(GetWindowPort(gMainWindow)); // Assumes gMainWindow is valid and is the list's window
-
-        LSetSelect(false, gLastSelectedCell, gPeerListHandle); // Deselect the current cell
-        SetPt(&gLastSelectedCell, 0, -1); // Clear our record of the selection
-
-        // Invalidate the list's view to ensure it redraws correctly
+        SetPort(GetWindowPort(gMainWindow));
+        LSetSelect(false, gLastSelectedCell, gPeerListHandle);
+        SetPt(&gLastSelectedCell, 0, -1);
         SignedByte listState = HGetState((Handle)gPeerListHandle);
         HLock((Handle)gPeerListHandle);
         if (*gPeerListHandle != NULL) {
             InvalRect(&(**gPeerListHandle).rView);
         }
         HSetState((Handle)gPeerListHandle, listState);
-
         SetPort(oldPortForList);
         log_to_file_only("DialogPeerList_DeselectAll: Cleared selection and invalidated view.");
     } else {
         log_to_file_only("DialogPeerList_DeselectAll: No selection to clear or list not initialized.");
     }
 }
-
-
 void ActivatePeerList(Boolean activating)
 {
     if (gPeerListHandle != NULL) {

--- a/classic_mac/dialog_peerlist.h
+++ b/classic_mac/dialog_peerlist.h
@@ -1,24 +1,19 @@
 #ifndef DIALOG_PEERLIST_H
-#define DIALOG_PEERLIST_H
-
+#define DIALOG_PEERLIST_H 
 #include <MacTypes.h>
 #include <Lists.h>
 #include <Dialogs.h>
 #include <Events.h>
-#include "peer.h" // For peer_t, MAX_PEERS (via shared/common_defs.h) and gPeerManager extern
-
+#include "peer.h"
 extern DialogPtr gMainWindow;
 extern ListHandle gPeerListHandle;
 extern Cell gLastSelectedCell;
-// extern peer_t gPeerList[MAX_PEERS]; // REMOVED - Unused and incorrect
-
 Boolean InitPeerListControl(DialogPtr dialog);
 void CleanupPeerListControl(void);
 Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent);
 void UpdatePeerDisplayList(Boolean forceRedraw);
 void HandlePeerListUpdate(DialogPtr dialog);
-Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer); // MOVED & RENAMED from classic_mac/peer.h
-void DialogPeerList_DeselectAll(void);                 // NEW function
+Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer);
+void DialogPeerList_DeselectAll(void);
 void ActivatePeerList(Boolean activating);
-
 #endif

--- a/classic_mac/mactcp_messaging.c
+++ b/classic_mac/mactcp_messaging.c
@@ -1,7 +1,3 @@
-//====================================
-// FILE: ./classic_mac/mactcp_messaging.c
-//====================================
-
 #include "./mactcp_messaging.h"
 #include "logging.h"
 #include "protocol.h"
@@ -9,8 +5,7 @@
 #include "dialog.h"
 #include "dialog_peerlist.h"
 #include "network.h"
-#include "../shared/messaging.h" // For tcp_platform_callbacks_t and handle_received_tcp_message
-
+#include "../shared/messaging.h"
 #include <Devices.h>
 #include <Errors.h>
 #include <MacTypes.h>
@@ -18,61 +13,40 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <Events.h> // For EventRecord, WaitNextEvent (used in YieldTimeToSystem)
-#include <OSUtils.h> // For Delay
-
-// TCP Buffer Sizes
+#include <Events.h>
+#include <OSUtils.h>
 #define kTCPRecvBufferSize 8192
-#define kTCPInternalBufferSize 8192 // For TCPCreate connection buffer
-
-// ULP Timeout values for various operations (in seconds)
+#define kTCPInternalBufferSize 8192
 #define kTCPPassiveOpenULPTimeoutSeconds 2
 #define kConnectULPTimeoutSeconds 5
 #define kSendULPTimeoutSeconds 3
 #define kAbortULPTimeoutSeconds 1
-
-// Application-level poll timeouts for synchronous operations (in ticks, 60 ticks = 1 second)
-#define kTCPRecvPollTimeoutTicks 1     // Short timeout for quick poll if data expected
-#define kTCPStatusPollTimeoutTicks 1   // Short timeout for status check
-#define kConnectPollTimeoutTicks (kConnectULPTimeoutSeconds * 60 + 30) // App poll timeout for connect
-#define kSendPollTimeoutTicks (kSendULPTimeoutSeconds * 60 + 30)       // App poll timeout for send
-#define kAbortPollTimeoutTicks (kAbortULPTimeoutSeconds * 60 + 30)     // App poll timeout for abort
-
-// Delay for retrying operations or between certain actions
-#define kErrorRetryDelayTicks 120 // 2 seconds, for retrying after some errors
-#define kQuitLoopDelayTicks 120   // Delay used in the original SendQuit loop, now for reference if main.c needs it
-
-// MacTCP specific error codes (some are standard, some might be from MacTCP docs)
-// streamBusyErr is defined in the header
-#define kMacTCPTimeoutErr (-23016)        // General TCP timeout from MacTCP
-#define kDuplicateSocketErr (-23017)      // Attempt to create duplicate socket
-#define kConnectionExistsErr (-23007)     // Connection already exists (e.g. active open)
-#define kConnectionClosingErr (-23005)    // Connection is closing
-#define kConnectionDoesntExistErr (-23008)// Connection does not exist
-#define kInvalidStreamPtrErr (-23010)     // Invalid TCP stream pointer
-#define kInvalidWDSErr (-23014)           // Invalid Write Data Structure
-#define kInvalidBufPtrErr (-23013)        // Invalid buffer pointer
-#define kRequestAbortedErr (-23006)       // Request was aborted (e.g. by ULP timeout or another call)
-
-#define AbortTrue 1 // Parameter for ULP timeout action
-
-// Globals for the single TCP stream management
+#define kTCPRecvPollTimeoutTicks 1
+#define kTCPStatusPollTimeoutTicks 1
+#define kConnectPollTimeoutTicks (kConnectULPTimeoutSeconds * 60 + 30)
+#define kSendPollTimeoutTicks (kSendULPTimeoutSeconds * 60 + 30)
+#define kAbortPollTimeoutTicks (kAbortULPTimeoutSeconds * 60 + 30)
+#define kErrorRetryDelayTicks 120
+#define kQuitLoopDelayTicks 120
+#define kMacTCPTimeoutErr (-23016)
+#define kDuplicateSocketErr (-23017)
+#define kConnectionExistsErr (-23007)
+#define kConnectionClosingErr (-23005)
+#define kConnectionDoesntExistErr (-23008)
+#define kInvalidStreamPtrErr (-23010)
+#define kInvalidWDSErr (-23014)
+#define kInvalidBufPtrErr (-23013)
+#define kRequestAbortedErr (-23006)
+#define AbortTrue 1
 static StreamPtr gTCPStream = NULL;
-static Ptr gTCPInternalBuffer = NULL; // Buffer for TCPCreate
-static Ptr gTCPRecvBuffer = NULL;     // Buffer for TCPRcv
+static Ptr gTCPInternalBuffer = NULL;
+static Ptr gTCPRecvBuffer = NULL;
 static TCPState gTCPState = TCP_STATE_UNINITIALIZED;
-static Boolean gIsSending = false;    // Flag to prevent concurrent send operations
-
-// Information about the currently connected peer (for incoming connections)
+static Boolean gIsSending = false;
 static ip_addr gPeerIP = 0;
 static tcp_port gPeerPort = 0;
-
-// Parameter block for asynchronous TCPPassiveOpen
 static TCPiopb gTCPPassiveOpenPB;
 static Boolean gPassiveOpenPBInitialized = false;
-
-
-// Forward declarations for internal static functions
 static void ProcessTCPReceive(unsigned short dataLength);
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt16 appPollTimeoutTicks);
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr connectionBuffer, unsigned long connBufferLen);
@@ -82,63 +56,52 @@ static OSErr LowTCPRcvSyncPoll(SInt16 appPollTimeoutTicks, Ptr buffer, unsigned 
 static OSErr LowTCPStatusSyncPoll(SInt16 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState);
 static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime);
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease);
-
-// Platform-specific callbacks for the shared TCP message handler
 static int mac_tcp_add_or_update_peer(const char *ip, const char *username, void *platform_context)
 {
-    (void)platform_context; // Unused
+    (void)platform_context;
     int addResult = AddOrUpdatePeer(ip, username);
-    if (addResult > 0) { // New peer added
+    if (addResult > 0) {
         log_message("Peer connected/updated via TCP: %s@%s", username, ip);
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
-    } else if (addResult == 0) { // Existing peer updated
+    } else if (addResult == 0) {
         log_to_file_only("Peer updated via TCP: %s@%s", username, ip);
-    } else { // Error or list full
+    } else {
         log_message("Peer list full or error, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
-
 static void mac_tcp_display_text_message(const char *username, const char *ip, const char *message_content, void *platform_context)
 {
-    (void)platform_context; // Unused
-    (void)ip; // IP is available if needed, but typically username is primary identifier in chat
-    char displayMsg[BUFFER_SIZE + 100]; // Ensure enough space for formatting
-
+    (void)platform_context;
+    (void)ip;
+    char displayMsg[BUFFER_SIZE + 100];
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
-        AppendToMessagesTE("\r"); // Newline for Mac TextEdit
+        AppendToMessagesTE("\r");
         log_message("Message from %s@%s: %s", username, ip, message_content);
     } else {
         log_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
-
 static void mac_tcp_mark_peer_inactive(const char *ip, void *platform_context)
 {
-    (void)platform_context; // Unused
+    (void)platform_context;
     if (!ip) return;
-
     log_message("Peer %s has sent QUIT notification via TCP.", ip);
-    if (MarkPeerInactive(ip)) { // MarkPeerInactive returns true if status changed
+    if (MarkPeerInactive(ip)) {
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     }
 }
-
-
 OSErr InitTCP(short macTCPRefNum)
 {
     OSErr err;
     log_message("Initializing Single TCP Stream (Async Passive Open / Sync Poll Strategy)...");
-
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
         log_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
-        return streamAlreadyOpen; // Or some other appropriate error
+        return streamAlreadyOpen;
     }
-
-    // Allocate buffers
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
@@ -149,55 +112,42 @@ OSErr InitTCP(short macTCPRefNum)
         return memFullErr;
     }
     log_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
-
-    // Create the TCP stream
     log_message("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
         log_message("Error: Failed to create TCP Stream: %d", err);
-        CleanupTCP(macTCPRefNum); // Clean up allocated buffers if any
+        CleanupTCP(macTCPRefNum);
         return err;
     }
     log_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
-
-    // Initialize parameter block for passive open (listening)
     memset(&gTCPPassiveOpenPB, 0, sizeof(TCPiopb));
-    gTCPPassiveOpenPB.ioCompletion = nil; // For async calls
+    gTCPPassiveOpenPB.ioCompletion = nil;
     gTCPPassiveOpenPB.ioCRefNum = gMacTCPRefNum;
     gTCPPassiveOpenPB.tcpStream = gTCPStream;
     gPassiveOpenPBInitialized = true;
-
     gTCPState = TCP_STATE_IDLE;
     gIsSending = false;
     gPeerIP = 0;
     gPeerPort = 0;
-
     log_message("TCP initialization complete. State: IDLE.");
     return noErr;
 }
-
 void CleanupTCP(short macTCPRefNum)
 {
     log_message("Cleaning up Single TCP Stream...");
-    StreamPtr streamToRelease = gTCPStream; // Cache before setting global to NULL
+    StreamPtr streamToRelease = gTCPStream;
     TCPState stateBeforeCleanup = gTCPState;
-
-    gTCPState = TCP_STATE_RELEASING; // Mark as releasing to stop PollTCP actions
-    gTCPStream = NULL; // Prevent further use by PollTCP or new Send calls
-
-    // If a connection was active or pending, try to abort it cleanly
+    gTCPState = TCP_STATE_RELEASING;
+    gTCPStream = NULL;
     if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_PASSIVE_OPEN_PENDING) {
         log_message("Cleanup: Attempting synchronous abort (best effort)...");
         if (streamToRelease != NULL) {
-            // Temporarily restore gTCPStream for LowTCPAbortSyncPoll if it expects it
-            StreamPtr currentGlobalStream = gTCPStream; // Should be NULL here
-            gTCPStream = streamToRelease; // Restore for the abort call
+            StreamPtr currentGlobalStream = gTCPStream;
+            gTCPStream = streamToRelease;
             LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, YieldTimeToSystem);
-            gTCPStream = currentGlobalStream; // Set back to NULL
+            gTCPStream = currentGlobalStream;
         }
     }
-
-    // Release the stream
     if (streamToRelease != NULL && macTCPRefNum != 0) {
         log_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
         OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
@@ -206,14 +156,11 @@ void CleanupTCP(short macTCPRefNum)
     } else if (streamToRelease != NULL) {
         log_message("Warning: Cannot release stream, MacTCP refnum is 0.");
     }
-
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
     gPeerIP = 0;
     gPeerPort = 0;
-    gPassiveOpenPBInitialized = false; // Reset PB init status
-
-    // Dispose buffers
+    gPassiveOpenPBInitialized = false;
     if (gTCPRecvBuffer != NULL) {
         DisposePtr(gTCPRecvBuffer);
         gTCPRecvBuffer = NULL;
@@ -224,112 +171,91 @@ void CleanupTCP(short macTCPRefNum)
     }
     log_message("TCP cleanup finished.");
 }
-
 void PollTCP(GiveTimePtr giveTime)
 {
     OSErr err;
     unsigned short amountUnread = 0;
     Byte connectionState = 0;
-    unsigned long dummyTimer; // For Delay
-
+    unsigned long dummyTimer;
     if (gTCPStream == NULL || gTCPState == TCP_STATE_UNINITIALIZED || gTCPState == TCP_STATE_ERROR || gTCPState == TCP_STATE_RELEASING) {
-        return; // Not initialized, in error, or cleaning up
+        return;
     }
-
-    if (gIsSending) { // If a send operation is in progress, yield and return
+    if (gIsSending) {
         giveTime();
         return;
     }
-
     switch (gTCPState) {
         case TCP_STATE_IDLE:
-            // Attempt to start listening for an incoming connection
             log_to_file_only("PollTCP: State IDLE. Attempting ASYNC Passive Open (ULP: %ds)...", kTCPPassiveOpenULPTimeoutSeconds);
-            if (!gPassiveOpenPBInitialized) { // Should not happen if InitTCP was successful
+            if (!gPassiveOpenPBInitialized) {
                 log_message("PollTCP CRITICAL: gTCPPassiveOpenPB not initialized!");
                 gTCPState = TCP_STATE_ERROR;
                 break;
             }
-
             gTCPPassiveOpenPB.csCode = TCPPassiveOpen;
             gTCPPassiveOpenPB.csParam.open.ulpTimeoutValue = kTCPPassiveOpenULPTimeoutSeconds;
-            gTCPPassiveOpenPB.csParam.open.ulpTimeoutAction = AbortTrue; // Abort if timeout expires
+            gTCPPassiveOpenPB.csParam.open.ulpTimeoutAction = AbortTrue;
             gTCPPassiveOpenPB.csParam.open.validityFlags = timeoutValue | timeoutAction;
             gTCPPassiveOpenPB.csParam.open.localPort = PORT_TCP;
-            gTCPPassiveOpenPB.csParam.open.localHost = 0L; // Any local IP
-            // For passive open, remote host/port are usually 0 to accept from anyone
+            gTCPPassiveOpenPB.csParam.open.localHost = 0L;
             gTCPPassiveOpenPB.csParam.open.remoteHost = 0L;
             gTCPPassiveOpenPB.csParam.open.remotePort = 0;
-            // Other params (TOS, TTL, etc.) set to default/0
             gTCPPassiveOpenPB.csParam.open.tosFlags = 0;
             gTCPPassiveOpenPB.csParam.open.precedence = 0;
             gTCPPassiveOpenPB.csParam.open.dontFrag = false;
             gTCPPassiveOpenPB.csParam.open.timeToLive = 0;
             gTCPPassiveOpenPB.csParam.open.security = 0;
             gTCPPassiveOpenPB.csParam.open.optionCnt = 0;
-            gTCPPassiveOpenPB.csParam.open.commandTimeoutValue = 0; // No command timeout for async
-            gTCPPassiveOpenPB.ioResult = 1; // Mark as pending
-
+            gTCPPassiveOpenPB.csParam.open.commandTimeoutValue = 0;
+            gTCPPassiveOpenPB.ioResult = 1;
             err = PBControlAsync((ParmBlkPtr)&gTCPPassiveOpenPB);
             if (err == noErr) {
                 log_to_file_only("PollTCP: Async TCPPassiveOpen initiated.");
                 gTCPState = TCP_STATE_PASSIVE_OPEN_PENDING;
             } else {
                 log_message("PollTCP: PBControlAsync(TCPPassiveOpen) failed immediately: %d. Retrying after delay.", err);
-                gTCPState = TCP_STATE_IDLE; // Remain in IDLE to retry
+                gTCPState = TCP_STATE_IDLE;
                 Delay(kErrorRetryDelayTicks, &dummyTimer);
             }
             break;
-
         case TCP_STATE_PASSIVE_OPEN_PENDING:
-            giveTime(); // Yield while waiting for async operation
-            if (gTCPPassiveOpenPB.ioResult == 1) { // Still pending
+            giveTime();
+            if (gTCPPassiveOpenPB.ioResult == 1) {
                 return;
             }
-
-            // Async operation completed
             if (gTCPPassiveOpenPB.ioResult == noErr) {
-                // Successful connection
                 gPeerIP = gTCPPassiveOpenPB.csParam.open.remoteHost;
                 gPeerPort = gTCPPassiveOpenPB.csParam.open.remotePort;
                 char senderIPStr[INET_ADDRSTRLEN];
-                AddrToStr(gPeerIP, senderIPStr); // Convert IP to string for logging
+                AddrToStr(gPeerIP, senderIPStr);
                 log_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
                 gTCPState = TCP_STATE_CONNECTED_IN;
-                goto CheckConnectedInData; // Process any immediately available data
+                goto CheckConnectedInData;
             } else {
-                // Passive open failed
                 err = gTCPPassiveOpenPB.ioResult;
                 if (err == kRequestAbortedErr) {
                      log_message("PollTCP: Async Passive Open was aborted (err %d), likely by a send operation. Returning to IDLE.", err);
                 } else {
                     log_message("PollTCP: Async Passive Open failed: %d.", err);
                 }
-
-                // If failed due to duplicate socket or existing connection, try to abort to clear the stream
                 if (err == kDuplicateSocketErr || err == kConnectionExistsErr) {
                     log_message("PollTCP: Attempting Abort to clear stream after Passive Open failure (%d).", err);
                     LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 }
-                gTCPState = TCP_STATE_IDLE; // Return to IDLE to retry listening
+                gTCPState = TCP_STATE_IDLE;
                 Delay(kErrorRetryDelayTicks, &dummyTimer);
             }
             break;
-
         case TCP_STATE_CONNECTED_IN:
-        CheckConnectedInData: // Label for direct jump after successful passive open
+        CheckConnectedInData:
             log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
             err = LowTCPStatusSyncPoll(kTCPStatusPollTimeoutTicks, giveTime, &amountUnread, &connectionState);
-
             if (err != noErr) {
                 log_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 gTCPState = TCP_STATE_IDLE;
                 break;
             }
-
-            // Check MacTCP connection states: 8=Established, 10=FIN_WAIT_1, 12=FIN_WAIT_2, 14=CLOSE_WAIT
-            // If not in one of these, something is wrong or it closed abruptly.
             if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14 ) {
                 char peerIPStr[INET_ADDRSTRLEN];
                 AddrToStr(gPeerIP, peerIPStr);
@@ -338,62 +264,51 @@ void PollTCP(GiveTimePtr giveTime)
                 gTCPState = TCP_STATE_IDLE;
                 break;
             }
-
             log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
-
             if (amountUnread > 0) {
-                unsigned short bytesToRead = kTCPRecvBufferSize; // Max to read
+                unsigned short bytesToRead = kTCPRecvBufferSize;
                 Boolean markFlag = false, urgentFlag = false;
-
                 log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
                 err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
-
                 if (err == noErr) {
                     log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                     ProcessTCPReceive(bytesToRead);
-                } else if (err == kConnectionClosingErr) { // Connection closing, but data was received
+                } else if (err == kConnectionClosingErr) {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
                     if (bytesToRead > 0) ProcessTCPReceive(bytesToRead);
-                    // Connection is closing, so abort our end and go back to idle.
                     LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                     gTCPState = TCP_STATE_IDLE;
                 } else if (err == commandTimeout) {
-                    // This can happen if status showed data, but Rcv timed out (e.g. data arrived between calls)
                     log_to_file_only("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
-                } else { // Other errors on Rcv
+                } else {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
                     LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                     gTCPState = TCP_STATE_IDLE;
                 }
-            } else { // No data unread
-                if (connectionState == 14 ) { // CLOSE_WAIT: peer has closed, we should close too.
+            } else {
+                if (connectionState == 14 ) {
                     char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                     log_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Aborting to clean up. Returning to IDLE.", peerIPStr);
                     LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                     gTCPState = TCP_STATE_IDLE;
-                } else if (connectionState != 8) { // Not established, but also not CLOSE_WAIT (e.g. FIN_WAIT_1/2)
+                } else if (connectionState != 8) {
                      char peerIPStr[INET_ADDRSTRLEN]; AddrToStr(gPeerIP, peerIPStr);
                      log_to_file_only("PollTCP: Peer %s in closing state %d with no data. Waiting for MacTCP.", peerIPStr, connectionState);
                 }
-                // If state is 8 (Established) and no data, just continue polling.
             }
             break;
-
         default:
             log_message("PollTCP: In unexpected state %d.", gTCPState);
-            gTCPState = TCP_STATE_IDLE; // Reset to a known state
+            gTCPState = TCP_STATE_IDLE;
             break;
     }
 }
-
 TCPState GetTCPState(void)
 {
     return gTCPState;
 }
-
-
 OSErr MacTCP_SendMessageSync(const char *peerIPStr,
                              const char *message_content,
                              const char *msg_type,
@@ -403,16 +318,13 @@ OSErr MacTCP_SendMessageSync(const char *peerIPStr,
 {
     OSErr err = noErr, finalErr = noErr;
     ip_addr targetIP = 0;
-    char messageBuffer[BUFFER_SIZE]; // Buffer for the formatted message
+    char messageBuffer[BUFFER_SIZE];
     int formattedLen;
-    struct wdsEntry sendWDS[2]; // Write Data Structure for TCPSend
-
+    struct wdsEntry sendWDS[2];
     log_to_file_only("MacTCP_SendMessageSync: Request to send '%s' to %s", msg_type, peerIPStr);
-
-    if (gMacTCPRefNum == 0) return notOpenErr; // MacTCP driver not open
+    if (gMacTCPRefNum == 0) return notOpenErr;
     if (gTCPStream == NULL && gTCPState != TCP_STATE_RELEASING && gTCPState != TCP_STATE_UNINITIALIZED) {
-         // This case implies a logic error if gTCPStream is NULL but state isn't one of the deep cleanup/uninit ones.
-         if (gTCPStream == NULL) { // Double check, as the outer condition might be complex
+         if (gTCPStream == NULL) {
             log_message("Error (SendMessage): gTCPStream is NULL and not in deep cleanup state.");
             return kInvalidStreamPtrErr;
          }
@@ -420,9 +332,6 @@ OSErr MacTCP_SendMessageSync(const char *peerIPStr,
     if (peerIPStr == NULL || msg_type == NULL || local_username == NULL || local_ip_str == NULL || giveTime == NULL) {
         return paramErr;
     }
-    // message_content can be NULL or empty for certain message types like QUIT
-
-    // If we are currently listening (passive open pending), we must abort it to send.
     if (gTCPState == TCP_STATE_PASSIVE_OPEN_PENDING) {
         log_message("SendMessage: Stream was in PASSIVE_OPEN_PENDING. Aborting pending listen to allow send.");
         OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
@@ -430,220 +339,160 @@ OSErr MacTCP_SendMessageSync(const char *peerIPStr,
             log_to_file_only("SendMessage: Abort of pending passive open successful.");
         } else {
             log_message("SendMessage: Abort of pending passive open FAILED: %d. Send may fail.", abortErr);
-            // If abort timed out, stream might still be busy.
             return (abortErr == commandTimeout) ? streamBusyErr : abortErr;
         }
-        gTCPState = TCP_STATE_IDLE; // After abort, stream should be idle
+        gTCPState = TCP_STATE_IDLE;
     }
-
     if (gIsSending) {
         log_message("Warning (SendMessage): Send already in progress.");
         return streamBusyErr;
     }
-
-    // Stream must be idle to initiate an active open for sending
     if (gTCPState != TCP_STATE_IDLE) {
         log_message("Warning (SendMessage): Stream not IDLE (state %d) after attempting to clear. Cannot send now.", gTCPState);
-        return streamBusyErr; // Or another appropriate error indicating non-idle state
+        return streamBusyErr;
     }
-
-    gIsSending = true; // Set sending flag
-
-    // Parse the destination IP string
+    gIsSending = true;
     err = ParseIPv4(peerIPStr, &targetIP);
     if (err != noErr || targetIP == 0) {
         log_message("Error (SendMessage): Invalid peer IP '%s'.", peerIPStr);
         finalErr = paramErr;
         goto SendMessageCleanup;
     }
-
-    // Format the message using the shared protocol function
     formattedLen = format_message(messageBuffer, BUFFER_SIZE, msg_type, local_username, local_ip_str, message_content ? message_content : "");
     if (formattedLen <= 0) {
         log_message("Error (SendMessage): format_message failed for type '%s'.", msg_type);
-        finalErr = paramErr; // Or a more specific error
+        finalErr = paramErr;
         goto SendMessageCleanup;
     }
-
-    // Perform TCP Active Open (Connect)
     log_to_file_only("SendMessage: Connecting to %s...", peerIPStr);
     err = LowTCPActiveOpenSyncPoll(kConnectULPTimeoutSeconds, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
         log_to_file_only("SendMessage: Connected successfully to %s.", peerIPStr);
-
-        // Prepare WDS for sending
-        sendWDS[0].length = formattedLen -1; // Do not send the null terminator from format_message
+        sendWDS[0].length = formattedLen -1;
         sendWDS[0].ptr = (Ptr)messageBuffer;
-        sendWDS[1].length = 0; // Terminator for WDS array
+        sendWDS[1].length = 0;
         sendWDS[1].ptr = NULL;
-
-        // Send the data
         log_to_file_only("SendMessage: Sending data (%d bytes)...", sendWDS[0].length);
-        err = LowTCPSendSyncPoll(kSendULPTimeoutSeconds, true /* push */, (Ptr)sendWDS, giveTime);
+        err = LowTCPSendSyncPoll(kSendULPTimeoutSeconds, true , (Ptr)sendWDS, giveTime);
         if (err != noErr) {
             log_message("Error (SendMessage): Send failed to %s: %d", peerIPStr, err);
             finalErr = err;
         } else {
             log_to_file_only("SendMessage: Send successful to %s.", peerIPStr);
         }
-
-        // Abort the connection (since we're doing connect-send-disconnect per message)
         log_to_file_only("SendMessage: Aborting connection to %s...", peerIPStr);
         OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
         if (abortErr != noErr) {
             log_message("Warning (SendMessage): Abort failed for %s: %d", peerIPStr, abortErr);
-            if (finalErr == noErr) finalErr = abortErr; // Report abort error if send was ok
+            if (finalErr == noErr) finalErr = abortErr;
         }
     } else {
         log_message("Error (SendMessage): Connect to %s failed: %d", peerIPStr, err);
         finalErr = err;
-        // Specific handling for connectionExistsErr if it means the peer is in TIME_WAIT or similar
         if (err == kConnectionExistsErr && strcmp(msg_type, MSG_QUIT) == 0) {
              log_message("SendMessage: Connect for QUIT to %s failed with connectionExists. Peer might be in TIME_WAIT. Assuming QUIT effectively sent.", peerIPStr);
-             finalErr = noErr; // Treat as non-fatal for QUIT in this specific case
+             finalErr = noErr;
         }
     }
-
 SendMessageCleanup:
-    gIsSending = false; // Clear sending flag
-    gTCPState = TCP_STATE_IDLE; // Return stream to IDLE state for listening or next send
+    gIsSending = false;
+    gTCPState = TCP_STATE_IDLE;
     log_to_file_only("MacTCP_SendMessageSync to %s for '%s': Released send lock. Final Status: %d.", peerIPStr, msg_type, finalErr);
     return finalErr;
 }
-
-
 static void ProcessTCPReceive(unsigned short dataLength)
 {
     char senderIPStrFromConnection[INET_ADDRSTRLEN];
-    char senderIPStrFromPayload[INET_ADDRSTRLEN]; // Parsed from message
-    char senderUsername[32]; // Parsed from message
-    char msgType[32];        // Parsed from message
-    char content[BUFFER_SIZE]; // Parsed from message
-
-    // Static struct for callbacks, initialized once
+    char senderIPStrFromPayload[INET_ADDRSTRLEN];
+    char senderUsername[32];
+    char msgType[32];
+    char content[BUFFER_SIZE];
     static tcp_platform_callbacks_t mac_callbacks = {
         .add_or_update_peer = mac_tcp_add_or_update_peer,
         .display_text_message = mac_tcp_display_text_message,
         .mark_peer_inactive = mac_tcp_mark_peer_inactive
     };
-
     if (dataLength > 0 && gTCPRecvBuffer != NULL) {
-        // Get sender IP from the connection parameters (gPeerIP is set by PassiveOpen)
         OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
         if (addrErr != noErr) {
-            // Fallback if AddrToStr fails (e.g., DNR not working)
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
             log_to_file_only("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
         }
-
-        // Null-terminate the received data if it fits, for parse_message
         if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0';
-        else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0'; // Ensure null termination if buffer is full
-
+        else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0';
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
             log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
                              msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
-
-            // Call the shared message handler
-            handle_received_tcp_message(senderIPStrFromConnection, // IP from connection is more reliable
+            handle_received_tcp_message(senderIPStrFromConnection,
                                         senderUsername,
                                         msgType,
                                         content,
                                         &mac_callbacks,
-                                        NULL /* platform_context, not used by these mac_callbacks */);
-
-            // Specific post-processing for QUIT
+                                        NULL );
             if (strcmp(msgType, MSG_QUIT) == 0) {
                 log_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
-                // The PollTCP state machine will see the connection state change (e.g. to CLOSE_WAIT)
-                // and then abort and return to IDLE.
             }
         } else {
             log_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
         }
     } else if (dataLength == 0) {
-        // This can happen if the connection is closing or a keep-alive with no data.
         log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal or KeepAlive).");
     } else {
-        // Should not happen if dataLength > 0 implies gTCPRecvBuffer is valid.
         log_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
     }
 }
-
-// Low-level MacTCP call wrappers using a synchronous polling model
-// These functions block until the MacTCP operation completes or an app-level timeout occurs.
-
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt16 appPollTimeoutTicks)
 {
     OSErr err;
     unsigned long startTime = TickCount();
-
     if (pBlock == NULL || giveTime == NULL) return paramErr;
-    if (gMacTCPRefNum == 0) return notOpenErr; // MacTCP driver not open
-
-    // For most csCodes, gTCPStream must be valid. Exceptions: TCPCreate, TCPRelease (handled by caller)
+    if (gMacTCPRefNum == 0) return notOpenErr;
     if (csCode != TCPCreate && csCode != TCPRelease) {
         if (gTCPStream == NULL) {
             log_message("Error (LowLevelSyncPoll %d): gTCPStream is NULL.", csCode);
             return kInvalidStreamPtrErr;
         }
-        pBlock->tcpStream = gTCPStream; // Ensure PB uses the global stream
+        pBlock->tcpStream = gTCPStream;
     } else if (csCode == TCPRelease && pBlock->tcpStream == NULL) {
-        // For TCPRelease, the stream to release is passed in pBlock by the caller
         log_message("Error (LowLevelSyncPoll TCPRelease): pBlock->tcpStream is NULL.");
         return kInvalidStreamPtrErr;
     }
-
-
-    pBlock->ioCompletion = nil; // Synchronous polling, no completion routine
+    pBlock->ioCompletion = nil;
     pBlock->ioCRefNum = gMacTCPRefNum;
-    pBlock->ioResult = 1; // Mark as pending for the loop
+    pBlock->ioResult = 1;
     pBlock->csCode = csCode;
-
-    err = PBControlAsync((ParmBlkPtr)pBlock); // Initiate async MacTCP call
+    err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
         log_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
         return err;
     }
-
-    // Poll until ioResult is no longer 1 (pending)
     while (pBlock->ioResult > 0) {
-        giveTime(); // Yield to other processes/event loop
-
-        // Check for application-level timeout
+        giveTime();
         if (appPollTimeoutTicks > 0 && (TickCount() - startTime) >= (unsigned long)appPollTimeoutTicks) {
             log_to_file_only("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
-            // Note: MacTCP call might still be pending. Aborting it here could be complex.
-            // This timeout is mostly a safeguard for the app not to hang indefinitely.
-            // The ULP timeout in the PB should ideally handle MacTCP-level timeouts.
-            return commandTimeout; // Return a generic timeout error
+            return commandTimeout;
         }
     }
-    return pBlock->ioResult; // Return the actual result from MacTCP
+    return pBlock->ioResult;
 }
-
-
 static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr rcvBuff, unsigned long rcvBuffLen) {
     OSErr err;
     TCPiopb pbCreate;
-
     if (streamPtrOut == NULL || rcvBuff == NULL) return paramErr;
-
     memset(&pbCreate, 0, sizeof(TCPiopb));
     pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
     pbCreate.csCode = TCPCreate;
-    pbCreate.tcpStream = 0L; // Will be filled by MacTCP
+    pbCreate.tcpStream = 0L;
     pbCreate.csParam.create.rcvBuff = rcvBuff;
     pbCreate.csParam.create.rcvBuffLen = rcvBuffLen;
-    pbCreate.csParam.create.notifyProc = nil; // No notifier routine
-
-    err = PBControlSync((ParmBlkPtr)&pbCreate); // Use synchronous MacTCP call
+    pbCreate.csParam.create.notifyProc = nil;
+    err = PBControlSync((ParmBlkPtr)&pbCreate);
     if (err == noErr) {
         *streamPtrOut = pbCreate.tcpStream;
         if (*streamPtrOut == NULL) {
             log_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
-            err = ioErr; // Or some other MacTCP error
+            err = ioErr;
         }
     } else {
         *streamPtrOut = NULL;
@@ -651,114 +500,83 @@ static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr r
     }
     return err;
 }
-
 static OSErr LowTCPActiveOpenSyncPoll(Byte ulpTimeoutSeconds, ip_addr remoteHost, tcp_port remotePort, GiveTimePtr giveTime) {
     TCPiopb pbOpen;
     SInt16 pollTimeout;
-
     memset(&pbOpen, 0, sizeof(TCPiopb));
-    // Setup parameters for active open (connect)
     pbOpen.csParam.open.ulpTimeoutValue = ulpTimeoutSeconds;
-    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue; // Abort on ULP timeout
+    pbOpen.csParam.open.ulpTimeoutAction = AbortTrue;
     pbOpen.csParam.open.validityFlags = timeoutValue | timeoutAction;
-    pbOpen.csParam.open.commandTimeoutValue = 0; // No command timeout for async base
+    pbOpen.csParam.open.commandTimeoutValue = 0;
     pbOpen.csParam.open.remoteHost = remoteHost;
     pbOpen.csParam.open.remotePort = remotePort;
-    pbOpen.csParam.open.localPort = 0;  // Ephemeral local port
-    pbOpen.csParam.open.localHost = 0L; // Any local IP
-
-    pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30; // App poll timeout slightly > ULP timeout
+    pbOpen.csParam.open.localPort = 0;
+    pbOpen.csParam.open.localHost = 0L;
+    pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
     return LowLevelSyncPoll(&pbOpen, giveTime, TCPActiveOpen, pollTimeout);
 }
-
 static OSErr LowTCPSendSyncPoll(Byte ulpTimeoutSeconds, Boolean push, Ptr wdsPtr, GiveTimePtr giveTime) {
     TCPiopb pbSend;
     SInt16 pollTimeout;
-
     if (wdsPtr == NULL) return kInvalidWDSErr;
-
     memset(&pbSend, 0, sizeof(TCPiopb));
     pbSend.csParam.send.ulpTimeoutValue = ulpTimeoutSeconds;
     pbSend.csParam.send.ulpTimeoutAction = AbortTrue;
     pbSend.csParam.send.validityFlags = timeoutValue | timeoutAction;
     pbSend.csParam.send.pushFlag = push;
-    pbSend.csParam.send.urgentFlag = false; // Not using urgent data
+    pbSend.csParam.send.urgentFlag = false;
     pbSend.csParam.send.wdsPtr = wdsPtr;
-
     pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
     return LowLevelSyncPoll(&pbSend, giveTime, TCPSend, pollTimeout);
 }
-
 static OSErr LowTCPRcvSyncPoll(SInt16 appPollTimeoutTicks, Ptr buffer, unsigned short *bufferLen, Boolean *markFlag, Boolean *urgentFlag, GiveTimePtr giveTime) {
     OSErr err;
     TCPiopb pbRcv;
     unsigned short initialBufferLen;
-
     if (buffer == NULL || bufferLen == NULL || *bufferLen == 0) return kInvalidBufPtrErr;
     if (markFlag == NULL || urgentFlag == NULL) return paramErr;
-
-    initialBufferLen = *bufferLen; // Store requested buffer length
+    initialBufferLen = *bufferLen;
     memset(&pbRcv, 0, sizeof(TCPiopb));
-    // Use a very short commandTimeout for TCPRcv if polling,
-    // as we expect data if status said so.
-    pbRcv.csParam.receive.commandTimeoutValue = 1; // Minimal command timeout
+    pbRcv.csParam.receive.commandTimeoutValue = 1;
     pbRcv.csParam.receive.rcvBuff = buffer;
     pbRcv.csParam.receive.rcvBuffLen = initialBufferLen;
-
     err = LowLevelSyncPoll(&pbRcv, giveTime, TCPRcv, appPollTimeoutTicks);
-
-    *bufferLen = pbRcv.csParam.receive.rcvBuffLen; // Actual bytes received
-    *markFlag = pbRcv.csParam.receive.markFlag;   // TCP PUSH flag
+    *bufferLen = pbRcv.csParam.receive.rcvBuffLen;
+    *markFlag = pbRcv.csParam.receive.markFlag;
     *urgentFlag = pbRcv.csParam.receive.urgentFlag;
-
     return err;
 }
-
 static OSErr LowTCPStatusSyncPoll(SInt16 appPollTimeoutTicks, GiveTimePtr giveTime, unsigned short *amtUnread, Byte *connState) {
     OSErr err;
     TCPiopb pbStat;
-
     if (amtUnread == NULL || connState == NULL) return paramErr;
-
     memset(&pbStat, 0, sizeof(TCPiopb));
     err = LowLevelSyncPoll(&pbStat, giveTime, TCPStatus, appPollTimeoutTicks);
-
     if (err == noErr) {
         *amtUnread = pbStat.csParam.status.amtUnreadData;
         *connState = pbStat.csParam.status.connectionState;
     } else {
         *amtUnread = 0;
-        *connState = 0; // Indicate unknown or error state
+        *connState = 0;
         log_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
-        // Map invalidStreamPtr to connectionDoesntExist, as status on a non-existent stream implies this.
         if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr;
     }
     return err;
 }
-
 static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime) {
     OSErr err;
     TCPiopb pbAbort;
     SInt16 pollTimeout;
-
-    if (gTCPStream == NULL) { // Aborting a NULL stream is a no-op or error depending on context
+    if (gTCPStream == NULL) {
         log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
-        return noErr; // Or kInvalidStreamPtrErr if strict
+        return noErr;
     }
-
     memset(&pbAbort, 0, sizeof(TCPiopb));
-    // ULP timeout for abort is usually not critical, but set for consistency
-    // pbAbort.csParam.abort.ulpTimeoutValue = ulpTimeoutSeconds; // Not standard for Abort
-    // pbAbort.csParam.abort.ulpTimeoutAction = AbortTrue;
-    // pbAbort.csParam.abort.validityFlags = 0;
-
     pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
     err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, pollTimeout);
-
-    // Certain errors from Abort might be considered "successful" in terms of resetting the stream
     if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr || err == kRequestAbortedErr) {
         log_to_file_only("LowTCPAbortSyncPoll: Abort completed (err %d). Considered OK for reset.", err);
-        err = noErr; // Treat these as non-fatal for the purpose of aborting
+        err = noErr;
     } else if (err != noErr) {
         log_message("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
     } else {
@@ -766,25 +584,21 @@ static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime) {
     }
     return err;
 }
-
 static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease) {
     OSErr err;
     TCPiopb pbRelease;
-
     if (streamToRelease == NULL) return kInvalidStreamPtrErr;
-
     memset(&pbRelease, 0, sizeof(TCPiopb));
     pbRelease.ioCompletion = nil;
     pbRelease.ioCRefNum = macTCPRefNum;
     pbRelease.csCode = TCPRelease;
-    pbRelease.tcpStream = streamToRelease; // Specify the stream to release
-
+    pbRelease.tcpStream = streamToRelease;
     err = PBControlSync((ParmBlkPtr)&pbRelease);
-    if (err != noErr && err != kInvalidStreamPtrErr) { // kInvalidStreamPtrErr means it was already gone
+    if (err != noErr && err != kInvalidStreamPtrErr) {
         log_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
     } else if (err == kInvalidStreamPtrErr) {
         log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
-        err = noErr; // Treat as non-fatal if already released
+        err = noErr;
     }
     return err;
 }

--- a/classic_mac/mactcp_messaging.h
+++ b/classic_mac/mactcp_messaging.h
@@ -1,19 +1,11 @@
-//====================================
-// FILE: ./classic_mac/mactcp_messaging.h
-//====================================
-
 #ifndef TCP_H
-#define TCP_H
-
+#define TCP_H 
 #include <MacTypes.h>
 #include <MacTCP.h>
 #include "common_defs.h"
-
 typedef void (*GiveTimePtr)(void);
-
 #define kTCPDefaultTimeout 0
-#define streamBusyErr (-23050) // MacTCP specific error for busy stream
-
+#define streamBusyErr (-23050)
 typedef enum {
     TCP_STATE_UNINITIALIZED,
     TCP_STATE_IDLE,
@@ -22,18 +14,14 @@ typedef enum {
     TCP_STATE_RELEASING,
     TCP_STATE_ERROR
 } TCPState;
-
 OSErr InitTCP(short macTCPRefNum);
 void CleanupTCP(short macTCPRefNum);
 void PollTCP(GiveTimePtr giveTime);
-
 OSErr MacTCP_SendMessageSync(const char *peerIPStr,
                              const char *message_content,
                              const char *msg_type,
                              const char *local_username,
                              const char *local_ip_str,
                              GiveTimePtr giveTime);
-
 TCPState GetTCPState(void);
-
-#endif /* TCP_H */
+#endif

--- a/classic_mac/main.c
+++ b/classic_mac/main.c
@@ -1,10 +1,3 @@
-// FILE: ./classic_mac/main.c
-//====================================
-
-//====================================
-// FILE: ./classic_mac/main.c
-//====================================
-
 #include <MacTypes.h>
 #include <Quickdraw.h>
 #include <Fonts.h>
@@ -17,77 +10,45 @@
 #include <Lists.h>
 #include <Controls.h>
 #include <stdlib.h>
-#include <OSUtils.h> // For Delay
-
+#include <OSUtils.h>
 #include "logging.h"
-#include "network.h" // For InitializeNetworking, CleanupNetworking, gMyUsername, gMyLocalIPStr
-#include "dialog.h"  // For InitDialog, CleanupDialog, gMainWindow, k* defines
-#include "peer.h"    // For InitPeerList, gPeerManager
-#include "dialog_peerlist.h" // For UpdatePeerDisplayList, HandlePeerListClick, DialogPeerList_DeselectAll, ActivatePeerList
-#include "dialog_input.h"    // For gInputTE, TEClick, TEKey
-#include "dialog_messages.h" // For gMessagesTE, MyScrollAction, ScrollMessagesTE
-#include "./mactcp_messaging.h" // For PollTCP, MacTCP_SendMessageSync, streamBusyErr
-#include "discovery.h"       // For PollUDPListener, CheckSendBroadcast
-#include "../shared/logging.h" // For set_debug_output_enabled
-#include "../shared/protocol.h" // For MSG_QUIT
-
-#include <Sound.h> // For SysBeep
-
-// Constants for scrollbar part codes (ensure these are standard or defined if custom)
-#ifndef inThumb
-#define inThumb 129
-#endif
-#ifndef inUpButton
-#define inUpButton 20
-#endif
-#ifndef inDownButton
-#define inDownButton 21
-#endif
-#ifndef inPageUp
-#define inPageUp 22
-#endif
-#ifndef inPageDown
-#define inPageDown 23
-#endif
-
-// Global application state
-Boolean gDone = false; // Flag to terminate the main event loop
-unsigned long gLastPeerListUpdateTime = 0; // For periodic peer list pruning/refresh
-const unsigned long kPeerListUpdateIntervalTicks = 5 * 60; // 5 seconds (60 ticks per second)
-const unsigned long kQuitMessageDelayTicks = 120; // 2 seconds delay between sending QUIT messages
-
-// Forward declarations
+#include "network.h"
+#include "dialog.h"
+#include "peer.h"
+#include "dialog_peerlist.h"
+#include "dialog_input.h"
+#include "dialog_messages.h"
+#include "./mactcp_messaging.h"
+#include "discovery.h"
+#include "../shared/logging.h"
+#include "../shared/protocol.h"
+#include <Sound.h>
+Boolean gDone = false;
+unsigned long gLastPeerListUpdateTime = 0;
+const unsigned long kPeerListUpdateIntervalTicks = 5 * 60;
+const unsigned long kQuitMessageDelayTicks = 120;
 void InitializeToolbox(void);
 void MainEventLoop(void);
 void HandleEvent(EventRecord *event);
 void HandleIdleTasks(void);
-
 int main(void)
 {
     OSErr networkErr;
     Boolean dialogOk;
-
     InitLogFile();
     log_message("Starting Classic Mac P2P Messenger...");
-
-    MaxApplZone(); // Expand application heap
+    MaxApplZone();
     log_message("MaxApplZone called.");
-
     InitializeToolbox();
     log_message("Toolbox Initialized.");
-
-    // Initialize networking (MacTCP, DNR, UDP, TCP streams)
     networkErr = InitializeNetworking();
     if (networkErr != noErr) {
         log_message("Fatal: Network initialization failed (%d). Exiting.", networkErr);
         CloseLogFile();
         return 1;
     }
-
-    InitPeerList(); // Initialize the gPeerManager structure
+    InitPeerList();
     log_message("Peer list data structure initialized.");
-
-    // Initialize the main dialog window and its components
     dialogOk = InitDialog();
     if (!dialogOk) {
         log_message("Fatal: Dialog initialization failed. Exiting.");
@@ -95,68 +56,48 @@ int main(void)
         CloseLogFile();
         return 1;
     }
-
     log_message("Entering main event loop...");
     MainEventLoop();
     log_message("Exited main event loop.");
-
-    // Shutdown sequence
     log_message("Initiating shutdown sequence...");
-
-    // Send QUIT messages to all active peers
-    log_message("Sending QUIT messages to active peers...");
     int quit_sent_count = 0;
     int quit_active_peers = 0;
     OSErr last_quit_err = noErr;
-    unsigned long dummyTimerForDelay; // For Delay()
-
+    unsigned long dummyTimerForDelay;
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             quit_active_peers++;
             log_message("Attempting to send QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
             OSErr current_quit_err = MacTCP_SendMessageSync(
-                gPeerManager.peers[i].ip,
-                "", // No content for QUIT message
-                MSG_QUIT,
-                gMyUsername,
-                gMyLocalIPStr,
-                YieldTimeToSystem
-            );
-
+                gPeerManager.peers[i].ip, "", MSG_QUIT, gMyUsername, gMyLocalIPStr, YieldTimeToSystem);
             if (current_quit_err == noErr) {
                 quit_sent_count++;
             } else {
                 log_message("Failed to send QUIT to %s@%s: Error %d", gPeerManager.peers[i].username, gPeerManager.peers[i].ip, current_quit_err);
                 if (last_quit_err == noErr || (last_quit_err == streamBusyErr && current_quit_err != streamBusyErr) ) {
-                    // Store the first "hard" error, or any error if previous was just busy
                     last_quit_err = current_quit_err;
                 }
             }
-            // Yield and delay between sending QUIT messages to avoid flooding and give MacTCP time
             YieldTimeToSystem();
             Delay(kQuitMessageDelayTicks, &dummyTimerForDelay);
         }
     }
-
     if (quit_active_peers > 0) {
         log_message("Finished sending QUIT messages. Sent to %d of %d active peers. Last error (if any): %d", quit_sent_count, quit_active_peers, last_quit_err);
     } else {
         log_message("No active peers to send QUIT messages to.");
     }
     if (last_quit_err == streamBusyErr) {
-        log_message("Warning: Sending QUIT messages encountered a stream busy error during the process.");
+        log_message("Warning: Sending QUIT messages encountered a stream busy error.");
     } else if (last_quit_err != noErr) {
-        log_message("Warning: Sending QUIT messages encountered error: %d during the process.", last_quit_err);
+        log_message("Warning: Sending QUIT messages encountered error: %d.", last_quit_err);
     }
-
-
     CleanupDialog();
     CleanupNetworking();
     CloseLogFile();
     log_message("Application terminated gracefully.");
     return 0;
 }
-
 void InitializeToolbox(void)
 {
     InitGraf(&qd.thePort);
@@ -164,107 +105,70 @@ void InitializeToolbox(void)
     InitWindows();
     InitMenus();
     TEInit();
-    InitDialogs(NULL); // No resume procedure
+    InitDialogs(NULL);
     InitCursor();
 }
-
 void MainEventLoop(void)
 {
     EventRecord event;
     Boolean gotEvent;
-    long sleepTime = 1L; // Minimal sleep time for WaitNextEvent, effectively polling often
-
+    long sleepTime = 1L;
     while (!gDone) {
-        // Idle TextEdit fields if they exist
         if (gMessagesTE != NULL) TEIdle(gMessagesTE);
         if (gInputTE != NULL) TEIdle(gInputTE);
-
-        HandleIdleTasks(); // Handle networking and other background tasks
-
+        HandleIdleTasks();
         gotEvent = WaitNextEvent(everyEvent, &event, sleepTime, NULL);
-
         if (gotEvent) {
-            Boolean eventHandledByApp = false; // Flag to see if we need to call DialogSelect/system handlers
-
+            Boolean eventHandledByApp = false;
             if (event.what == mouseDown) {
                 WindowPtr whichWindow;
                 short windowPart = FindWindow(event.where, &whichWindow);
-
                 if (whichWindow == (WindowPtr)gMainWindow && windowPart == inContent) {
                     Point localPt = event.where;
                     ControlHandle foundControl;
                     short foundControlPart;
-                    Rect inputTERectDITL; // DITL rect for input TE user item
+                    Rect inputTERectDITL;
                     DialogItemType itemTypeDITL;
                     Handle itemHandleDITL;
                     GrafPtr oldPort;
-
                     GetPort(&oldPort);
-                    SetPort(GetWindowPort(gMainWindow)); // Work in dialog's coordinate system
+                    SetPort(GetWindowPort(gMainWindow));
                     GlobalToLocal(&localPt);
-
-                    // Check for clicks in scrollbar first (as it's a control)
                     foundControlPart = FindControl(localPt, whichWindow, &foundControl);
                     if (foundControl == gMessagesScrollBar && foundControlPart != 0 &&
                         (**foundControl).contrlVis && (**foundControl).contrlHilite == 0 ) {
-                        log_to_file_only("MouseDown: Handling click in Messages Scrollbar (part %d).", foundControlPart);
-                        if (foundControlPart == inThumb) {
+                        log_to_file_only("MouseDown: Click in Messages Scrollbar (part %d).", foundControlPart);
+                        if (foundControlPart == kControlIndicatorPart) {
                             short oldValue = GetControlValue(foundControl);
-                            TrackControl(foundControl, localPt, nil); // Track thumb directly
+                            TrackControl(foundControl, localPt, nil);
                             short newValue = GetControlValue(foundControl);
-                            log_to_file_only("MouseDown: Scrollbar thumb drag finished. OldVal=%d, NewVal=%d", oldValue, newValue);
-                            if (newValue != oldValue && gMessagesTE != NULL) {
-                                SignedByte teState = HGetState((Handle)gMessagesTE);
-                                HLock((Handle)gMessagesTE);
-                                if (*gMessagesTE != NULL) {
-                                    short lineHeight = (**gMessagesTE).lineHeight;
-                                    if (lineHeight > 0) {
-                                        // Calculate scroll based on new thumb value (which is line number)
-                                        short currentActualTopLine = -(**gMessagesTE).destRect.top / lineHeight;
-                                        short scrollDeltaPixels = (currentActualTopLine - newValue) * lineHeight;
-                                        log_to_file_only("MouseDown: Scrolling TE after thumb drag by %d pixels.", scrollDeltaPixels);
-                                        ScrollMessagesTE(scrollDeltaPixels);
-                                    } else {
-                                        log_message("MouseDown WARNING: Scrollbar thumb drag, but lineHeight is 0.");
-                                    }
-                                } else {
-                                    log_message("MouseDown ERROR: Scrollbar thumb drag, but gMessagesTE deref failed!");
-                                }
-                                HSetState((Handle)gMessagesTE, teState);
+                            log_to_file_only("MouseDown: Scrollbar thumb drag. OldVal=%d, NewVal=%d", oldValue, newValue);
+                            if (newValue != oldValue) {
+                                ScrollMessagesTEToValue(newValue);
                             }
-                        } else { // Up/down arrows, page regions
+                        } else {
                             TrackControl(foundControl, localPt, &MyScrollAction);
                         }
                         eventHandledByApp = true;
                     }
-                    // Check for clicks in Peer List (UserItem for List Manager)
-                    // Must check gPeerListHandle itself as it's a UserItem, not a standard control FindControl would get
                     else if (gPeerListHandle != NULL && PtInRect(localPt, &(**gPeerListHandle).rView)) {
-                        // HandlePeerListClick expects the original event with global coordinates
-                        // but it internally converts. For consistency, ensure it knows its dialog.
                         eventHandledByApp = HandlePeerListClick(gMainWindow, &event);
                     }
-                    // Check for clicks in Input TE (UserItem for TextEdit)
                     else {
-                         // Get the DITL rect for the input TE user item to check PtInRect against TE's viewRect
                          GetDialogItem(gMainWindow, kInputTextEdit, &itemTypeDITL, &itemHandleDITL, &inputTERectDITL);
                          if (gInputTE != NULL && PtInRect(localPt, &(**gInputTE).viewRect)) {
-                            // TEClick expects local coordinates relative to the TE's GrafPort (the window)
                             TEClick(localPt, (event.modifiers & shiftKey) != 0, gInputTE);
                             eventHandledByApp = true;
                          }
                     }
                     SetPort(oldPort);
                 }
-            } // end mouseDown
-
-            // If not handled by custom logic above, try DialogSelect for standard items
+            }
             if (!eventHandledByApp) {
                 if (IsDialogEvent(&event)) {
                     DialogPtr whichDialog;
                     short itemHit;
                     if (DialogSelect(&event, &whichDialog, &itemHit)) {
-                        // DialogSelect returns true if it handled the event (e.g. button click, TE interaction for edittext items)
                         if (whichDialog == gMainWindow && itemHit > 0) {
                             ControlHandle controlH;
                             DialogItemType itemType;
@@ -272,26 +176,19 @@ void MainEventLoop(void)
                             Rect itemRect;
                             GrafPtr oldPortForDrawing;
                             short currentValue;
-
                             switch (itemHit) {
-                                case kSendButton:
-                                    HandleSendButtonClick();
-                                    break;
+                                case kSendButton: HandleSendButtonClick(); break;
                                 case kDebugCheckbox:
                                     GetDialogItem(gMainWindow, kDebugCheckbox, &itemType, &itemHandle, &itemRect);
                                     if (itemHandle && itemType == (ctrlItem + chkCtrl)) {
                                         controlH = (ControlHandle)itemHandle;
                                         currentValue = GetControlValue(controlH);
-                                        SetControlValue(controlH, !currentValue); // Toggle
+                                        SetControlValue(controlH, !currentValue);
                                         Boolean newState = (GetControlValue(controlH) == 1);
-                                        set_debug_output_enabled(newState); // Update shared state
+                                        set_debug_output_enabled(newState);
                                         log_message("Debug output %s.", newState ? "ENABLED" : "DISABLED");
-
-                                        // Redraw checkbox
-                                        GetPort(&oldPortForDrawing);
-                                        SetPort(GetWindowPort(gMainWindow));
-                                        InvalRect(&itemRect);
-                                        SetPort(oldPortForDrawing);
+                                        GetPort(&oldPortForDrawing); SetPort(GetWindowPort(gMainWindow));
+                                        InvalRect(&itemRect); SetPort(oldPortForDrawing);
                                     }
                                     break;
                                 case kBroadcastCheckbox:
@@ -299,192 +196,101 @@ void MainEventLoop(void)
                                     if (itemHandle && itemType == (ctrlItem + chkCtrl)) {
                                         controlH = (ControlHandle)itemHandle;
                                         currentValue = GetControlValue(controlH);
-                                        SetControlValue(controlH, !currentValue); // Toggle
-                                        short newCheckboxValue = GetControlValue(controlH);
-
-                                        if (newCheckboxValue == 1) { // If broadcast is now checked
-                                            log_message("Broadcast checkbox checked. Deselecting peer if any.");
-                                            DialogPeerList_DeselectAll(); // Use new encapsulated function
+                                        SetControlValue(controlH, !currentValue);
+                                        if (GetControlValue(controlH) == 1) {
+                                            log_message("Broadcast checkbox checked. Deselecting peer.");
+                                            DialogPeerList_DeselectAll();
                                         } else {
                                             log_message("Broadcast checkbox unchecked.");
                                         }
-                                        // Redraw checkbox
-                                        GetPort(&oldPortForDrawing);
-                                        SetPort(GetWindowPort(gMainWindow));
-                                        InvalRect(&itemRect);
-                                        SetPort(oldPortForDrawing);
+                                        GetPort(&oldPortForDrawing); SetPort(GetWindowPort(gMainWindow));
+                                        InvalRect(&itemRect); SetPort(oldPortForDrawing);
                                     }
                                     break;
                                 case kMessagesScrollbar:
-                                    // This case might be hit if DialogSelect handles a click on a scrollbar DITL item
-                                    // that wasn't caught by FindControl/TrackControl in mouseDown.
-                                    // This is less common for scrollbars handled with TrackControl(..., actionProc).
-                                    log_message("WARNING: DialogSelect returned item kMessagesScrollbar - This should ideally be handled in mouseDown.");
+                                    log_message("WARNING: DialogSelect returned kMessagesScrollbar.");
                                     if (gMessagesTE != NULL && gMessagesScrollBar != NULL) {
-                                        short currentScrollVal = GetControlValue(gMessagesScrollBar);
-                                        short scrollDeltaPixels = 0, lineHeight = 0;
-                                        GrafPtr scrollPort;
-                                        GetPort(&scrollPort);
-                                        SetPort(GetWindowPort(gMainWindow));
-
-                                        SignedByte teState = HGetState((Handle)gMessagesTE);
-                                        HLock((Handle)gMessagesTE);
-                                        if (gMessagesTE == NULL || *gMessagesTE == NULL) {
-                                             log_message("ERROR: (DialogSelect Scrollbar Case) gMessagesTE became invalid!");
-                                             if (gMessagesTE != NULL) HSetState((Handle)gMessagesTE, teState);
-                                             SetPort(scrollPort);
-                                             break;
-                                        }
-                                        lineHeight = (**gMessagesTE).lineHeight;
-                                        if (lineHeight > 0) {
-                                            short currentActualTopLine = -(**gMessagesTE).destRect.top / lineHeight;
-                                            scrollDeltaPixels = (currentActualTopLine - currentScrollVal) * lineHeight;
-
-                                            if (scrollDeltaPixels != 0) ScrollMessagesTE(scrollDeltaPixels);
-                                        }
-                                        HSetState((Handle)gMessagesTE, teState);
-                                        SetPort(scrollPort);
+                                        ScrollMessagesTEToValue(GetControlValue(gMessagesScrollBar));
                                     }
                                     break;
-
-                                default:
-                                     log_to_file_only("DialogSelect returned unhandled item: %d", itemHit);
-                                    break;
+                                default: log_to_file_only("DialogSelect unhandled item: %d", itemHit); break;
                             }
                         }
-                        eventHandledByApp = true; // DialogSelect handled it
+                        eventHandledByApp = true;
                     }
                 }
             }
-
-            // If not handled by custom logic or DialogSelect, pass to system/general handlers
             if (!eventHandledByApp) {
                 HandleEvent(&event);
             }
-        } else { // No event from WaitNextEvent
-             HandleIdleTasks(); // Still do idle tasks if WNE returned false (e.g. on timeout)
+        } else {
+             HandleIdleTasks();
         }
     }
 }
-
 void HandleIdleTasks(void)
 {
     unsigned long currentTimeTicks = TickCount();
-
-    // Poll network listeners
     PollUDPListener(gMacTCPRefNum, gMyLocalIP);
-    PollTCP(YieldTimeToSystem); // Polls TCP listener and handles incoming connections/data
-
-    // Send periodic discovery broadcast
+    PollTCP(YieldTimeToSystem);
     CheckSendBroadcast(gMacTCPRefNum, gMyUsername, gMyLocalIPStr);
-
-    // Periodically update peer list (prune timeouts, redraw if needed)
-    if (gLastPeerListUpdateTime == 0 || // First time
-        (currentTimeTicks < gLastPeerListUpdateTime) || // TickCount wrapped around
-        (currentTimeTicks - gLastPeerListUpdateTime) >= kPeerListUpdateIntervalTicks)
-    {
-        if (gPeerListHandle != NULL) { // Ensure list is initialized
-            UpdatePeerDisplayList(false); // false = don't force redraw if no data change
-        }
+    if (gLastPeerListUpdateTime == 0 || (currentTimeTicks < gLastPeerListUpdateTime) ||
+        (currentTimeTicks - gLastPeerListUpdateTime) >= kPeerListUpdateIntervalTicks) {
+        if (gPeerListHandle != NULL) UpdatePeerDisplayList(false);
         gLastPeerListUpdateTime = currentTimeTicks;
     }
 }
-
-
 void HandleEvent(EventRecord *event)
 {
     short windowPart;
     WindowPtr whichWindow;
     char theChar;
-
     switch (event->what) {
         case mouseDown:
             windowPart = FindWindow(event->where, &whichWindow);
             switch (windowPart) {
-                case inMenuBar:
-                    // Menu handling would go here if we had menus
-                    // MenuSelect(event->where);
-                    break;
-                case inSysWindow: // Click in a DA window
-                    SystemClick(event, whichWindow);
-                    break;
-                case inDrag: // Click in title bar to drag
-                    if (whichWindow == (WindowPtr)gMainWindow) {
-                        DragWindow(whichWindow, event->where, &qd.screenBits.bounds);
+                case inMenuBar: break;
+                case inSysWindow: SystemClick(event, whichWindow); break;
+                case inDrag: if (whichWindow == (WindowPtr)gMainWindow) DragWindow(whichWindow, event->where, &qd.screenBits.bounds); break;
+                case inGoAway:
+                    if (whichWindow == (WindowPtr)gMainWindow && TrackGoAway(whichWindow, event->where)) {
+                        log_message("Close box clicked. Setting gDone = true.");
+                        gDone = true;
                     }
                     break;
-                case inGoAway: // Click in close box
-                    if (whichWindow == (WindowPtr)gMainWindow) {
-                        if (TrackGoAway(whichWindow, event->where)) {
-                            log_message("Close box clicked. Setting gDone = true.");
-                            gDone = true; // Signal to exit main loop
-                        }
-                    }
-                    break;
-                case inContent:
-                     // If click in content was not handled by specific item handlers (scrollbar, list, TE)
-                     // it might be a click to activate the window if it's not front.
-                     if (whichWindow != FrontWindow()) {
-                        SelectWindow(whichWindow);
-                     } else {
-                         // Click in content of front window, not handled by other logic.
-                         log_to_file_only("HandleEvent: mouseDown in content fell through all handlers.");
-                     }
-                    break;
-                default:
-                     log_to_file_only("HandleEvent: mouseDown in unknown window part: %d", windowPart);
-                    break;
+                case inContent: if (whichWindow != FrontWindow()) SelectWindow(whichWindow); else log_to_file_only("HandleEvent: mouseDown in content fell through."); break;
+                default: log_to_file_only("HandleEvent: mouseDown in unknown window part: %d", windowPart); break;
             }
             break;
-
-        case keyDown:
-        case autoKey:
+        case keyDown: case autoKey:
             theChar = event->message & charCodeMask;
-            if ((event->modifiers & cmdKey) != 0) {
-                // Command-key handling would go here if we had menus/shortcuts
-                // short menuResult = MenuKey(theChar);
-                // HandleMenuChoice(menuResult);
-            } else {
-                // Pass regular key presses to the active TE (Input TE)
-                if (gInputTE != NULL && gMainWindow != NULL && FrontWindow() == (WindowPtr)gMainWindow) {
-                    TEKey(theChar, gInputTE);
-                }
+            if (! (event->modifiers & cmdKey) && gInputTE != NULL && gMainWindow != NULL && FrontWindow() == (WindowPtr)gMainWindow) {
+                TEKey(theChar, gInputTE);
             }
             break;
-
         case updateEvt:
             whichWindow = (WindowPtr)event->message;
             BeginUpdate(whichWindow);
             if (whichWindow == (WindowPtr)gMainWindow) {
-                DrawDialog(whichWindow);    // Redraws standard DITL items
-                UpdateDialogControls();     // Redraws custom items (TEs, List)
-            } else {
-                // Handle updates for other windows if any (e.g. DAs)
+                DrawDialog(whichWindow);
+                UpdateDialogControls();
             }
             EndUpdate(whichWindow);
             break;
-
-        case activateEvt: // Window activation/deactivation
+        case activateEvt:
             whichWindow = (WindowPtr)event->message;
             if (whichWindow == (WindowPtr)gMainWindow) {
                 Boolean becomingActive = ((event->modifiers & activeFlag) != 0);
-                ActivateDialogTE(becomingActive); // Activate/deactivate TEs
-                ActivatePeerList(becomingActive); // Activate/deactivate List Manager
-
-                // Adjust scrollbar hilite state based on window activation
+                ActivateDialogTE(becomingActive);
+                ActivatePeerList(becomingActive);
                 if (gMessagesScrollBar != NULL) {
                      short maxScroll = GetControlMaximum(gMessagesScrollBar);
-                     short hiliteValue = 255; // Inactive
-                     if (becomingActive && maxScroll > 0 && (**gMessagesScrollBar).contrlVis) {
-                         hiliteValue = 0; // Active
-                     }
+                     short hiliteValue = 255;
+                     if (becomingActive && maxScroll > 0 && (**gMessagesScrollBar).contrlVis) hiliteValue = 0;
                      HiliteControl(gMessagesScrollBar, hiliteValue);
                 }
             }
             break;
-
-        // Other event types (diskEvt, osEvt, etc.) can be handled here if needed
-        default:
-            break;
+        default: break;
     }
 }

--- a/classic_mac/peer.c
+++ b/classic_mac/peer.c
@@ -1,29 +1,17 @@
 #include "peer.h"
 #include "logging.h"
 #include <stddef.h>
-// #include <stdbool.h> // Boolean is from MacTypes.h
 #include <string.h>
-#include <MacTypes.h> // For Boolean, Cell, SetPt
-// ListHandle and Dialogs are not needed here anymore after moving GetSelectedPeerInfo
-// #include <Lists.h>
-// #include <Dialogs.h>
-
-peer_manager_t gPeerManager; // Definition
-
+#include <MacTypes.h>
+peer_manager_t gPeerManager;
 void InitPeerList(void)
 {
     peer_shared_init_list(&gPeerManager);
 }
-
 int AddOrUpdatePeer(const char *ip, const char *username)
 {
-    // This function now just wraps the shared logic.
-    // If platform-specific side effects were needed (e.g. immediate UI update on add),
-    // they would be here or triggered from here.
-    // The current model updates UI periodically or on specific notifications.
     return peer_shared_add_or_update(&gPeerManager, ip, username);
 }
-
 Boolean MarkPeerInactive(const char *ip)
 {
     if (!ip) return false;
@@ -31,36 +19,29 @@ Boolean MarkPeerInactive(const char *ip)
     if (index != -1) {
         if (gPeerManager.peers[index].active) {
             log_message("Marking peer %s@%s as inactive due to QUIT message.", gPeerManager.peers[index].username, ip);
-            gPeerManager.peers[index].active = 0; // Mark inactive in our Mac-specific list
-            // Potentially trigger UI update here if needed, or rely on periodic updates
-            return true; // Status changed
+            gPeerManager.peers[index].active = 0;
+            return true;
         } else {
             log_to_file_only("MarkPeerInactive: Peer %s was already inactive.", ip);
-            return false; // Status did not change
+            return false;
         }
     }
     log_to_file_only("MarkPeerInactive: Peer %s not found in list.", ip);
     return false;
 }
-
 void PruneTimedOutPeers(void)
 {
     int pruned_count = peer_shared_prune_timed_out(&gPeerManager);
     if (pruned_count > 0) {
         log_message("Pruned %d timed-out peer(s).", pruned_count);
-        // UI will be updated by UpdatePeerDisplayList which calls this.
     }
 }
-
-// This function gets a peer by its logical Nth position among *active* peers.
-// Useful if you need to iterate through active peers without knowing their gPeerManager index.
 Boolean GetPeerByIndex(int active_index, peer_t *out_peer)
 {
     int current_active_count = 0;
-    if (active_index < 0 || out_peer == NULL) { // active_index is 0-based
+    if (active_index < 0 || out_peer == NULL) {
         return false;
     }
-
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             if (current_active_count == active_index) {
@@ -70,5 +51,5 @@ Boolean GetPeerByIndex(int active_index, peer_t *out_peer)
             current_active_count++;
         }
     }
-    return false; // active_index out of bounds
+    return false;
 }

--- a/classic_mac/peer.h
+++ b/classic_mac/peer.h
@@ -1,17 +1,12 @@
 #ifndef PEER_MAC_H
-#define PEER_MAC_H
-
+#define PEER_MAC_H 
 #include <MacTypes.h>
-#include "../shared/common_defs.h" // For peer_t, MAX_PEERS
-#include "../shared/peer.h"       // For peer_manager_t
-
-extern peer_manager_t gPeerManager; // Manages the actual peer data
-
-void InitPeerList(void); // Initializes gPeerManager
-int AddOrUpdatePeer(const char *ip, const char *username); // Operates on gPeerManager
-Boolean MarkPeerInactive(const char *ip); // Operates on gPeerManager
-void PruneTimedOutPeers(void); // Operates on gPeerManager
-Boolean GetPeerByIndex(int active_index, peer_t *out_peer); // Gets from gPeerManager by logical active index
-// Boolean GetSelectedPeerInfo(peer_t *outPeer); // REMOVED - Logic moved to dialog_peerlist.c
-
+#include "../shared/common_defs.h"
+#include "../shared/peer.h"
+extern peer_manager_t gPeerManager;
+void InitPeerList(void);
+int AddOrUpdatePeer(const char *ip, const char *username);
+Boolean MarkPeerInactive(const char *ip);
+void PruneTimedOutPeers(void);
+Boolean GetPeerByIndex(int active_index, peer_t *out_peer);
 #endif

--- a/shared/logging.h
+++ b/shared/logging.h
@@ -1,25 +1,16 @@
 #ifndef LOGGING_SHARED_H
-#define LOGGING_SHARED_H
-
+#define LOGGING_SHARED_H 
 #ifdef __MACOS__
-#include <MacTypes.h> // For Boolean
+#include <MacTypes.h>
 #else
 #ifndef __cplusplus
-#include <stdbool.h> // For bool
-#define Boolean bool // Define Boolean for POSIX if not C++
+#include <stdbool.h>
+#define Boolean bool
 #endif
 #endif
-
-// Include stdarg.h for functions using "..." as a good practice,
-// though only implementations strictly need va_list etc.
 #include <stdarg.h>
-
-// Shared logging functions, to be implemented by each platform
 void log_message(const char *format, ...);
 void display_user_message(const char *format, ...);
-
-// Functions implemented in shared/logging.c
 void set_debug_output_enabled(Boolean enabled);
 Boolean is_debug_output_enabled(void);
-
-#endif /* LOGGING_SHARED_H */
+#endif


### PR DESCRIPTION
…b drag crash

Refactored Classic Mac message display scrollbar handling:
1. Initial Refactoring:
   - Moved scrollbar click handling (arrows, page up/down, and initial thumb logic) from main.c into dialog_messages.c (HandleMessagesScrollClick and MyScrollAction).
   - Removed redundant control part code defines from dialog_messages.c.
   - Aimed to better encapsulate GUI component logic.

2. Crash Fix for Thumb Dragging:
   - Identified a crash when dragging the scrollbar thumb, likely due to stack corruption when TrackControl invoked MyScrollAction with an invalid control handle for the thumb part.
   - main.c now calls TrackControl with a nil action proc for the thumb part (kControlIndicatorPart).
   - After TrackControl returns for a thumb drag, main.c retrieves the new scrollbar value and calls a dedicated function (ScrollMessagesTEToValue in dialog_messages.c) to scroll the TextEdit content.
   - MyScrollAction and HandleMessagesScrollClick in dialog_messages.c no longer handle 'inThumb' events directly, as this is now managed by main.c post-TrackControl.
   - Added ScrollMessagesTEToValue to dialog_messages.h and .c for this purpose.

This resolves the crash and further improves the organization of the scrollbar interaction code.