### PR TITLE
Refactor: Centralize logging logic into shared module

### DIFF
--- a/classic_mac/dialog.c
+++ b/classic_mac/dialog.c
@@ -33,13 +33,13 @@ Boolean InitDialog(void)
     Handle itemHandle;
     Rect itemRect;
     GrafPtr oldPort;
-    log_internal_message("Loading dialog resource ID %d...", kBaseResID);
+    log_debug("Loading dialog resource ID %d...", kBaseResID);
     gMainWindow = GetNewDialog(kBaseResID, NULL, (WindowPtr) - 1L);
     if (gMainWindow == NULL) {
-        log_internal_message("Fatal: GetNewDialog failed (Error: %d). Check DLOG resource ID %d.", ResError(), kBaseResID);
+        log_debug("Fatal: GetNewDialog failed (Error: %d). Check DLOG resource ID %d.", ResError(), kBaseResID);
         return false;
     }
-    log_internal_message("Dialog loaded successfully (gMainWindow: 0x%lX).", (unsigned long)gMainWindow);
+    log_debug("Dialog loaded successfully (gMainWindow: 0x%lX).", (unsigned long)gMainWindow);
     GetPort(&oldPort);
     SetPort(GetWindowPort(gMainWindow));
     messagesOk = InitMessagesTEAndScrollbar(gMainWindow);
@@ -48,7 +48,7 @@ Boolean InitDialog(void)
     gDialogTEInitialized = (messagesOk && inputOk);
     gDialogListInitialized = listOk;
     if (!gDialogTEInitialized || !gDialogListInitialized) {
-        log_internal_message("Error: One or more dialog components (TEs, List) failed to initialize. Cleaning up.");
+        log_debug("Error: One or more dialog components (TEs, List) failed to initialize. Cleaning up.");
         if (listOk) CleanupPeerListControl();
         if (inputOk) CleanupInputTE();
         if (messagesOk) CleanupMessagesTEAndScrollbar();
@@ -62,48 +62,48 @@ Boolean InitDialog(void)
         if (itemType == (ctrlItem + chkCtrl)) {
             ctrlHandle = (ControlHandle)itemHandle;
             SetControlValue(ctrlHandle, is_debug_output_enabled() ? 1 : 0);
-            log_internal_message("Debug checkbox (Item %d) initialized to: %s", kDebugCheckbox, is_debug_output_enabled() ? "ON" : "OFF");
+            log_debug("Debug checkbox (Item %d) initialized to: %s", kDebugCheckbox, is_debug_output_enabled() ? "ON" : "OFF");
         } else {
-            log_internal_message("Warning: Item %d (kDebugCheckbox) is not a checkbox (Type: %d)! Cannot set initial debug state.", kDebugCheckbox, itemType);
+            log_debug("Warning: Item %d (kDebugCheckbox) is not a checkbox (Type: %d)! Cannot set initial debug state.", kDebugCheckbox, itemType);
         }
     } else {
-        log_internal_message("Warning: Item %d (kDebugCheckbox) handle is NULL! Cannot set initial state.", kDebugCheckbox);
+        log_debug("Warning: Item %d (kDebugCheckbox) handle is NULL! Cannot set initial state.", kDebugCheckbox);
     }
     GetDialogItem(gMainWindow, kBroadcastCheckbox, &itemType, &itemHandle, &itemRect);
     if (itemHandle != NULL) {
         if (itemType == (ctrlItem + chkCtrl)) {
             ctrlHandle = (ControlHandle)itemHandle;
             SetControlValue(ctrlHandle, 0);
-            log_internal_message("Broadcast checkbox (Item %d) initialized to: OFF", kBroadcastCheckbox);
+            log_debug("Broadcast checkbox (Item %d) initialized to: OFF", kBroadcastCheckbox);
         } else {
-            log_internal_message("Warning: Item %d (kBroadcastCheckbox) is not a checkbox (Type: %d)! Cannot set initial state.", kBroadcastCheckbox, itemType);
+            log_debug("Warning: Item %d (kBroadcastCheckbox) is not a checkbox (Type: %d)! Cannot set initial state.", kBroadcastCheckbox, itemType);
         }
     } else {
-        log_internal_message("Warning: Item %d (kBroadcastCheckbox) handle is NULL! Cannot set initial state.", kBroadcastCheckbox);
+        log_debug("Warning: Item %d (kBroadcastCheckbox) handle is NULL! Cannot set initial state.", kBroadcastCheckbox);
     }
     UpdatePeerDisplayList(true);
-    log_internal_message("Setting focus to input field (item %d)...", kInputTextEdit);
+    log_debug("Setting focus to input field (item %d)...", kInputTextEdit);
     ActivateInputTE(true);
     UpdateDialogControls();
-    log_internal_message("Initial UpdateDialogControls() called from InitDialog.");
+    log_debug("Initial UpdateDialogControls() called from InitDialog.");
     SetPort(oldPort);
-    log_internal_message("InitDialog finished successfully.");
+    log_debug("InitDialog finished successfully.");
     return true;
 }
 void CleanupDialog(void)
 {
-    log_internal_message("Cleaning up Dialog...");
+    log_debug("Cleaning up Dialog...");
     CleanupPeerListControl();
     CleanupInputTE();
     CleanupMessagesTEAndScrollbar();
     if (gMainWindow != NULL) {
-        log_internal_message("Disposing dialog window...");
+        log_debug("Disposing dialog window...");
         DisposeDialog(gMainWindow);
         gMainWindow = NULL;
     }
     gDialogTEInitialized = false;
     gDialogListInitialized = false;
-    log_internal_message("Dialog cleanup complete.");
+    log_debug("Dialog cleanup complete.");
 }
 void HandleSendButtonClick(void)
 {
@@ -117,18 +117,18 @@ void HandleSendButtonClick(void)
     OSErr sendErr = noErr;
     int i;
     if (!gDialogTEInitialized || gInputTE == NULL) {
-        log_internal_message("Error (HandleSendButtonClick): Input TE not initialized.");
+        log_debug("Error (HandleSendButtonClick): Input TE not initialized.");
         SysBeep(10);
         return;
     }
     if (!GetInputText(inputCStr, sizeof(inputCStr))) {
-        log_internal_message("Error: Could not get text from input field for sending.");
+        log_debug("Error: Could not get text from input field for sending.");
         SysBeep(10);
         ActivateInputTE(true);
         return;
     }
     if (strlen(inputCStr) == 0) {
-        log_internal_message("Send Action: Input field is empty. No action taken.");
+        log_debug("Send Action: Input field is empty. No action taken.");
         ActivateInputTE(true);
         return;
     }
@@ -137,13 +137,13 @@ void HandleSendButtonClick(void)
     if (itemHandle != NULL && itemType == (ctrlItem + chkCtrl)) {
         broadcastCheckboxHandle = (ControlHandle)itemHandle;
         isBroadcast = (GetControlValue(broadcastCheckboxHandle) == 1);
-        log_to_file_only("Broadcast checkbox state: %s", isBroadcast ? "Checked" : "Unchecked");
+        log_debug("Broadcast checkbox state: %s", isBroadcast ? "Checked" : "Unchecked");
     } else {
-        log_internal_message("Warning: Broadcast item %d is not a checkbox or handle is NULL! Assuming not broadcast.", kBroadcastCheckbox);
+        log_debug("Warning: Broadcast item %d is not a checkbox or handle is NULL! Assuming not broadcast.", kBroadcastCheckbox);
     }
     if (isBroadcast) {
         int sent_count = 0;
-        log_internal_message("Attempting broadcast of: '%s'", inputCStr);
+        log_debug("Attempting broadcast of: '%s'", inputCStr);
         sprintf(displayMsg, "You (Broadcast): %s", inputCStr);
         AppendToMessagesTE(displayMsg);
         AppendToMessagesTE("\r");
@@ -158,7 +158,7 @@ void HandleSendButtonClick(void)
                 if (sendErr == noErr) {
                     sent_count++;
                 } else {
-                    log_internal_message("Broadcast send to %s@%s failed: %d",
+                    log_debug("Broadcast send to %s@%s failed: %d",
                                          gPeerManager.peers[i].username, gPeerManager.peers[i].ip, sendErr);
                 }
             }
@@ -166,12 +166,12 @@ void HandleSendButtonClick(void)
         sprintf(displayMsg, "Broadcast sent to %d active peer(s).", sent_count);
         AppendToMessagesTE(displayMsg);
         AppendToMessagesTE("\r");
-        log_internal_message("Broadcast of '%s' completed. Sent to %d peers.", inputCStr, sent_count);
+        log_debug("Broadcast of '%s' completed. Sent to %d peers.", inputCStr, sent_count);
         ClearInputText();
     } else {
         peer_t targetPeer;
         if (DialogPeerList_GetSelectedPeer(&targetPeer)) {
-            log_internal_message("Attempting sync send to selected peer %s@%s: '%s'",
+            log_debug("Attempting sync send to selected peer %s@%s: '%s'",
                                  targetPeer.username, targetPeer.ip, inputCStr);
             sendErr = MacTCP_SendMessageSync(targetPeer.ip,
                                              inputCStr,
@@ -183,7 +183,7 @@ void HandleSendButtonClick(void)
                 sprintf(displayMsg, "You (to %s): %s", targetPeer.username, inputCStr);
                 AppendToMessagesTE(displayMsg);
                 AppendToMessagesTE("\r");
-                log_internal_message("Sync send completed successfully.");
+                log_debug("Sync send completed successfully.");
                 ClearInputText();
             } else {
                 if (sendErr == streamBusyErr) {
@@ -193,11 +193,11 @@ void HandleSendButtonClick(void)
                 }
                 AppendToMessagesTE(displayMsg);
                 AppendToMessagesTE("\r");
-                log_internal_message("Error sending message to %s: %d", targetPeer.ip, sendErr);
+                log_debug("Error sending message to %s: %d", targetPeer.ip, sendErr);
                 SysBeep(10);
             }
         } else {
-            log_internal_message("Error: Cannot send, no peer selected in the list or selection invalid.");
+            log_debug("Error: Cannot send, no peer selected in the list or selection invalid.");
             AppendToMessagesTE("Please select a peer to send to, or check Broadcast.\r");
             SysBeep(10);
         }
@@ -214,7 +214,7 @@ void UpdateDialogControls(void)
     GrafPtr oldPort;
     GrafPtr windowPort = GetWindowPort(gMainWindow);
     if (windowPort == NULL) {
-        log_internal_message("UpdateDialogControls Error: Window port is NULL for gMainWindow!");
+        log_debug("UpdateDialogControls Error: Window port is NULL for gMainWindow!");
         return;
     }
     GetPort(&oldPort);

--- a/classic_mac/dialog_input.c
+++ b/classic_mac/dialog_input.c
@@ -14,7 +14,7 @@ Boolean InitInputTE(DialogPtr dialog)
     DialogItemType itemType;
     Handle itemHandle;
     Rect itemRect;
-    log_internal_message("Initializing Input TE (as UserItem)...");
+    log_debug("Initializing Input TE (as UserItem)...");
     GetDialogItem(dialog, kInputTextEdit, &itemType, &itemHandle, &itemRect);
     if (itemType == userItem) {
         Rect teViewRect = itemRect;
@@ -22,17 +22,17 @@ Boolean InitInputTE(DialogPtr dialog)
         InsetRect(&teViewRect, 1, 1);
         InsetRect(&teDestRect, 1, 1);
         if (teViewRect.bottom <= teViewRect.top || teViewRect.right <= teViewRect.left) {
-            log_internal_message("ERROR: Input TE itemRect too small after insetting for border. Original: (%d,%d,%d,%d)",
+            log_debug("ERROR: Input TE itemRect too small after insetting for border. Original: (%d,%d,%d,%d)",
                                  itemRect.top, itemRect.left, itemRect.bottom, itemRect.right);
             gInputTE = NULL;
             return false;
         }
         gInputTE = TENew(&teDestRect, &teViewRect);
         if (gInputTE == NULL) {
-            log_internal_message("CRITICAL ERROR: TENew failed for Input TE! Out of memory?");
+            log_debug("CRITICAL ERROR: TENew failed for Input TE! Out of memory?");
             return false;
         } else {
-            log_internal_message("TENew succeeded for Input TE. Handle: 0x%lX. ViewRect for TE: (%d,%d,%d,%d)",
+            log_debug("TENew succeeded for Input TE. Handle: 0x%lX. ViewRect for TE: (%d,%d,%d,%d)",
                                  (unsigned long)gInputTE, teViewRect.top, teViewRect.left, teViewRect.bottom, teViewRect.right);
             TESetText((Ptr)"", 0, gInputTE);
             TECalText(gInputTE);
@@ -40,19 +40,19 @@ Boolean InitInputTE(DialogPtr dialog)
             return true;
         }
     } else {
-        log_internal_message("ERROR: Item %d (kInputTextEdit) is Type: %d. Expected userItem. Cannot initialize Input TE.", kInputTextEdit, itemType);
+        log_debug("ERROR: Item %d (kInputTextEdit) is Type: %d. Expected userItem. Cannot initialize Input TE.", kInputTextEdit, itemType);
         gInputTE = NULL;
         return false;
     }
 }
 void CleanupInputTE(void)
 {
-    log_internal_message("Cleaning up Input TE...");
+    log_debug("Cleaning up Input TE...");
     if (gInputTE != NULL) {
         TEDispose(gInputTE);
         gInputTE = NULL;
     }
-    log_internal_message("Input TE cleanup finished.");
+    log_debug("Input TE cleanup finished.");
 }
 void HandleInputTEClick(DialogPtr dialog, EventRecord *theEvent)
 {
@@ -80,26 +80,26 @@ void HandleInputTEUpdate(DialogPtr dialog)
         GetPort(&oldPort);
         SetPort(GetWindowPort(dialog));
         GetDialogItem(dialog, kInputTextEdit, &itemTypeIgnored, &itemHandleIgnored, &userItemRect);
-        log_to_file_only("HandleInputTEUpdate: UserItemRect for kInputTextEdit is (%d,%d,%d,%d)",
+        log_debug("HandleInputTEUpdate: UserItemRect for kInputTextEdit is (%d,%d,%d,%d)",
                          userItemRect.top, userItemRect.left, userItemRect.bottom, userItemRect.right);
         FrameRect(&userItemRect);
-        log_to_file_only("HandleInputTEUpdate: FrameRect called.");
+        log_debug("HandleInputTEUpdate: FrameRect called.");
         SignedByte teState = HGetState((Handle)gInputTE);
         HLock((Handle)gInputTE);
         if (*gInputTE != NULL) {
             teActualViewRect = (**gInputTE).viewRect;
             EraseRect(&teActualViewRect);
-            log_to_file_only("HandleInputTEUpdate: EraseRect called for TE's viewRect (%d,%d,%d,%d)",
+            log_debug("HandleInputTEUpdate: EraseRect called for TE's viewRect (%d,%d,%d,%d)",
                              teActualViewRect.top, teActualViewRect.left, teActualViewRect.bottom, teActualViewRect.right);
             TEUpdate(&teActualViewRect, gInputTE);
-            log_to_file_only("HandleInputTEUpdate: TEUpdate called.");
+            log_debug("HandleInputTEUpdate: TEUpdate called.");
         } else {
-            log_internal_message("HandleInputTEUpdate ERROR: gInputTE deref failed after HLock!");
+            log_debug("HandleInputTEUpdate ERROR: gInputTE deref failed after HLock!");
         }
         HSetState((Handle)gInputTE, teState);
         SetPort(oldPort);
     } else {
-        log_to_file_only("HandleInputTEUpdate: gInputTE is NULL, skipping update.");
+        log_debug("HandleInputTEUpdate: gInputTE is NULL, skipping update.");
     }
 }
 void ActivateInputTE(Boolean activating)
@@ -107,10 +107,10 @@ void ActivateInputTE(Boolean activating)
     if (gInputTE != NULL) {
         if (activating) {
             TEActivate(gInputTE);
-            log_to_file_only("ActivateInputTE: Activating Input TE.");
+            log_debug("ActivateInputTE: Activating Input TE.");
         } else {
             TEDeactivate(gInputTE);
-            log_to_file_only("ActivateInputTE: Deactivating Input TE.");
+            log_debug("ActivateInputTE: Deactivating Input TE.");
         }
     }
 }
@@ -118,7 +118,7 @@ Boolean GetInputText(char *buffer, short bufferSize)
 {
     if (gInputTE == NULL || buffer == NULL || bufferSize <= 0) {
         if (buffer && bufferSize > 0) buffer[0] = '\0';
-        log_internal_message("Error: GetInputText called with NULL TE/buffer or zero size.");
+        log_debug("Error: GetInputText called with NULL TE/buffer or zero size.");
         return false;
     }
     SignedByte teState = HGetState((Handle)gInputTE);
@@ -130,7 +130,7 @@ Boolean GetInputText(char *buffer, short bufferSize)
         Size copyLen = textLen;
         if (copyLen >= bufferSize) {
             copyLen = bufferSize - 1;
-            log_internal_message("Warning: Input text truncated during GetInputText (buffer size %d, needed %ld).", bufferSize, (long)textLen + 1);
+            log_debug("Warning: Input text truncated during GetInputText (buffer size %d, needed %ld).", bufferSize, (long)textLen + 1);
         }
         SignedByte textHandleState = HGetState(textH);
         HLock(textH);
@@ -139,7 +139,7 @@ Boolean GetInputText(char *buffer, short bufferSize)
         buffer[copyLen] = '\0';
         success = true;
     } else {
-        log_internal_message("Error: Cannot get text from Input TE (NULL TE record or hText).");
+        log_debug("Error: Cannot get text from Input TE (NULL TE record or hText).");
         buffer[0] = '\0';
         success = false;
     }
@@ -155,10 +155,10 @@ void ClearInputText(void)
             TESetText((Ptr)"", 0, gInputTE);
             TECalText(gInputTE);
         } else {
-            log_internal_message("ClearInputText Error: gInputTE deref failed!");
+            log_debug("ClearInputText Error: gInputTE deref failed!");
         }
         HSetState((Handle)gInputTE, teState);
-        log_internal_message("Input field cleared.");
+        log_debug("Input field cleared.");
         if (gMainWindow != NULL) {
             HandleInputTEUpdate(gMainWindow);
         }

--- a/classic_mac/dialog_messages.c
+++ b/classic_mac/dialog_messages.c
@@ -34,11 +34,11 @@ pascal void MyScrollAction(ControlHandle theControl, short partCode)
         if (partCode != 0 && partCode != kControlIndicatorPart) {
             HandleMessagesScrollClick(theControl, partCode);
         } else if (partCode == kControlIndicatorPart) {
-            log_internal_message("MyScrollAction: WARNING - Called with inThumb (part %d) for control 0x%lX. Main.c should handle this.",
+            log_debug("MyScrollAction: WARNING - Called with inThumb (part %d) for control 0x%lX. Main.c should handle this.",
                                  partCode, (unsigned long)theControl);
         }
     } else {
-        log_internal_message("MyScrollAction: Called for unexpected control 0x%lX, part %d",
+        log_debug("MyScrollAction: Called for unexpected control 0x%lX, part %d",
                              (unsigned long)theControl, partCode);
     }
 }
@@ -50,30 +50,30 @@ Boolean InitMessagesTEAndScrollbar(DialogPtr dialog)
     Rect scrollBarRect;
     Boolean teOk = false;
     Boolean scrollBarOk = false;
-    log_internal_message("Initializing Messages TE...");
+    log_debug("Initializing Messages TE...");
     GetDialogItem(dialog, kMessagesTextEdit, &itemType, &itemHandle, &destRectMessages);
     if (itemType == userItem) {
         viewRectMessages = destRectMessages;
         gMessagesTE = TENew(&destRectMessages, &viewRectMessages);
         if (gMessagesTE == NULL) {
-            log_internal_message("CRITICAL ERROR: TENew failed for Messages TE! Out of memory?");
+            log_debug("CRITICAL ERROR: TENew failed for Messages TE! Out of memory?");
             teOk = false;
         } else {
-            log_internal_message("TENew succeeded for Messages TE. Handle: 0x%lX", (unsigned long)gMessagesTE);
+            log_debug("TENew succeeded for Messages TE. Handle: 0x%lX", (unsigned long)gMessagesTE);
             TEAutoView(false, gMessagesTE);
             teOk = true;
         }
     } else {
-        log_internal_message("ERROR: Item %d is NOT a UserItem (Type: %d)! Expected UserItem for TENew.", kMessagesTextEdit, itemType);
+        log_debug("ERROR: Item %d is NOT a UserItem (Type: %d)! Expected UserItem for TENew.", kMessagesTextEdit, itemType);
         gMessagesTE = NULL;
         teOk = false;
     }
     if (teOk) {
-        log_internal_message("Initializing Messages Scrollbar...");
+        log_debug("Initializing Messages Scrollbar...");
         GetDialogItem(dialog, kMessagesScrollbar, &itemType, &itemHandle, &scrollBarRect);
         if (itemHandle != NULL) {
             gMessagesScrollBar = (ControlHandle)itemHandle;
-            log_internal_message("Scrollbar handle obtained: 0x%lX (ItemType was %d).", (unsigned long)gMessagesScrollBar, itemType);
+            log_debug("Scrollbar handle obtained: 0x%lX (ItemType was %d).", (unsigned long)gMessagesScrollBar, itemType);
             SetControlMinimum(gMessagesScrollBar, 0);
             SetControlMaximum(gMessagesScrollBar, 0);
             SetControlValue(gMessagesScrollBar, 0);
@@ -81,7 +81,7 @@ Boolean InitMessagesTEAndScrollbar(DialogPtr dialog)
             HiliteControl(gMessagesScrollBar, 255);
             scrollBarOk = true;
         } else {
-            log_internal_message("ERROR: Item %d (Messages Scrollbar) handle is NULL! Check DITL resource.", kMessagesScrollbar);
+            log_debug("ERROR: Item %d (Messages Scrollbar) handle is NULL! Check DITL resource.", kMessagesScrollbar);
             gMessagesScrollBar = NULL;
             scrollBarOk = false;
             TEDispose(gMessagesTE);
@@ -93,20 +93,20 @@ Boolean InitMessagesTEAndScrollbar(DialogPtr dialog)
 }
 void CleanupMessagesTEAndScrollbar(void)
 {
-    log_internal_message("Cleaning up Messages TE...");
+    log_debug("Cleaning up Messages TE...");
     if (gMessagesTE != NULL) {
         TEDispose(gMessagesTE);
         gMessagesTE = NULL;
     }
     gMessagesScrollBar = NULL;
-    log_internal_message("Messages TE cleanup finished.");
+    log_debug("Messages TE cleanup finished.");
 }
 void AppendToMessagesTE(const char *text)
 {
     GrafPtr oldPort;
     Boolean scrolledToBottom = false;
     if (gMessagesTE == NULL) {
-        log_internal_message("AppendToMessagesTE: gMessagesTE is NULL. Cannot append.");
+        log_debug("AppendToMessagesTE: gMessagesTE is NULL. Cannot append.");
         return;
     }
     if (text == NULL || text[0] == '\0') {
@@ -116,7 +116,7 @@ void AppendToMessagesTE(const char *text)
     if (gMainWindow != NULL) {
         SetPort(GetWindowPort(gMainWindow));
     } else {
-        log_internal_message("AppendToMessagesTE Warning: gMainWindow is NULL! Port not set.");
+        log_debug("AppendToMessagesTE Warning: gMainWindow is NULL! Port not set.");
     }
     SignedByte teState = HGetState((Handle)gMessagesTE);
     HLock((Handle)gMessagesTE);
@@ -140,10 +140,10 @@ void AppendToMessagesTE(const char *text)
                 ScrollMessagesTEToValue(newMaxScroll);
             }
         } else {
-            log_internal_message("Warning: Messages TE field near full. Cannot append.");
+            log_debug("Warning: Messages TE field near full. Cannot append.");
         }
     } else {
-        log_internal_message("ERROR in AppendToMessagesTE: *gMessagesTE is NULL after HLock!");
+        log_debug("ERROR in AppendToMessagesTE: *gMessagesTE is NULL after HLock!");
     }
     HSetState((Handle)gMessagesTE, teState);
     SetPort(oldPort);
@@ -170,7 +170,7 @@ void AdjustMessagesScrollbar(void)
             linesInView = 1;
             totalLines = 0;
             currentVal = 0;
-            log_to_file_only("AdjustMessagesScrollbar Warning: lineHeight is %d!", lineHeight);
+            log_debug("AdjustMessagesScrollbar Warning: lineHeight is %d!", lineHeight);
         }
         maxScroll = totalLines - linesInView;
         if (maxScroll < 0) maxScroll = 0;
@@ -192,7 +192,7 @@ void AdjustMessagesScrollbar(void)
         }
         HiliteControl(gMessagesScrollBar, hiliteValue);
     } else {
-        log_internal_message("AdjustMessagesScrollbar Error: gMessagesTE deref failed!");
+        log_debug("AdjustMessagesScrollbar Error: gMessagesTE deref failed!");
     }
     HSetState((Handle)gMessagesTE, teState);
 }
@@ -200,7 +200,7 @@ void HandleMessagesScrollClick(ControlHandle theControl, short partCode)
 {
     if (gMessagesTE == NULL || partCode == 0 || partCode == kControlIndicatorPart) {
         if (partCode == kControlIndicatorPart) {
-            log_to_file_only("HandleMessagesScrollClick: Received inThumb (part %d), ignoring as main.c handles it.", partCode);
+            log_debug("HandleMessagesScrollClick: Received inThumb (part %d), ignoring as main.c handles it.", partCode);
         }
         return;
     }
@@ -212,7 +212,7 @@ void HandleMessagesScrollClick(ControlHandle theControl, short partCode)
     SignedByte teState = HGetState((Handle)gMessagesTE);
     HLock((Handle)gMessagesTE);
     if (*gMessagesTE == NULL) {
-        log_internal_message("HandleMessagesScrollClick Error: gMessagesTE dereference failed!");
+        log_debug("HandleMessagesScrollClick Error: gMessagesTE dereference failed!");
         HSetState((Handle)gMessagesTE, teState);
         return;
     }
@@ -220,7 +220,7 @@ void HandleMessagesScrollClick(ControlHandle theControl, short partCode)
     viewHeight = (**gMessagesTE).viewRect.bottom - (**gMessagesTE).viewRect.top;
     HSetState((Handle)gMessagesTE, teState);
     if (lineHeight <= 0) {
-        log_internal_message("HandleMessagesScrollClick Warning: lineHeight is %d! Cannot scroll.", lineHeight);
+        log_debug("HandleMessagesScrollClick Warning: lineHeight is %d! Cannot scroll.", lineHeight);
         return;
     }
     pageScroll = viewHeight / lineHeight;
@@ -242,7 +242,7 @@ void HandleMessagesScrollClick(ControlHandle theControl, short partCode)
         linesToScroll = pageScroll;
         break;
     default:
-        log_to_file_only("HandleMessagesScrollClick: Ignoring unknown partCode %d", partCode);
+        log_debug("HandleMessagesScrollClick: Ignoring unknown partCode %d", partCode);
         return;
     }
     newScroll = currentScroll + linesToScroll;
@@ -260,13 +260,13 @@ void ScrollMessagesTEToValue(short newScrollValue)
     SignedByte teState = HGetState((Handle)gMessagesTE);
     HLock((Handle)gMessagesTE);
     if (*gMessagesTE == NULL) {
-        log_internal_message("ScrollMessagesTEToValue Error: gMessagesTE deref failed!");
+        log_debug("ScrollMessagesTEToValue Error: gMessagesTE deref failed!");
         HSetState((Handle)gMessagesTE, teState);
         return;
     }
     short lineHeight = (**gMessagesTE).lineHeight;
     if (lineHeight <= 0) {
-        log_internal_message("ScrollMessagesTEToValue Warning: lineHeight is %d! Cannot scroll.", lineHeight);
+        log_debug("ScrollMessagesTEToValue Warning: lineHeight is %d! Cannot scroll.", lineHeight);
         HSetState((Handle)gMessagesTE, teState);
         return;
     }
@@ -322,7 +322,7 @@ void ScrollMessagesTE(short deltaPixels)
         if (gMainWindow != NULL) {
             SetPort(GetWindowPort(gMainWindow));
         } else {
-            log_internal_message("ScrollMessagesTE Warning: gMainWindow is NULL! Port not set.");
+            log_debug("ScrollMessagesTE Warning: gMainWindow is NULL! Port not set.");
         }
         SignedByte teState = HGetState((Handle)gMessagesTE);
         HLock((Handle)gMessagesTE);
@@ -331,7 +331,7 @@ void ScrollMessagesTE(short deltaPixels)
             TEScroll(0, deltaPixels, gMessagesTE);
             InvalRect(&viewRectToInvalidate);
         } else {
-            log_internal_message("ScrollMessagesTE Error: gMessagesTE dereference failed before TEScroll!");
+            log_debug("ScrollMessagesTE Error: gMessagesTE dereference failed before TEScroll!");
         }
         HSetState((Handle)gMessagesTE, teState);
         SetPort(oldPort);

--- a/classic_mac/dialog_peerlist.c
+++ b/classic_mac/dialog_peerlist.c
@@ -22,10 +22,10 @@ Boolean InitPeerListControl(DialogPtr dialog)
     Point cellSize;
     FontInfo fontInfo;
     Boolean listOk = false;
-    log_internal_message("Initializing Peer List Control...");
+    log_debug("Initializing Peer List Control...");
     GetDialogItem(dialog, kPeerListUserItem, &itemType, &itemHandle, &destRectList);
     if (itemType == userItem) {
-        log_internal_message("Item %d is UserItem. Rect: (%d,%d,%d,%d)", kPeerListUserItem,
+        log_debug("Item %d is UserItem. Rect: (%d,%d,%d,%d)", kPeerListUserItem,
                              destRectList.top, destRectList.left, destRectList.bottom, destRectList.right);
         GrafPtr oldPort;
         GetPort(&oldPort);
@@ -34,28 +34,28 @@ Boolean InitPeerListControl(DialogPtr dialog)
         SetPort(oldPort);
         cellSize.v = fontInfo.ascent + fontInfo.descent + fontInfo.leading;
         if (cellSize.v <= 0) {
-            log_internal_message("Warning: Calculated cell height is %d, using default 12.", cellSize.v);
+            log_debug("Warning: Calculated cell height is %d, using default 12.", cellSize.v);
             cellSize.v = 12;
         }
         cellSize.h = destRectList.right - destRectList.left;
         SetRect(&dataBounds, 0, 0, 1, 0);
-        log_internal_message("Calling LNew for Peer List (Cell Size: H%d, V%d)...", cellSize.h, cellSize.v);
+        log_debug("Calling LNew for Peer List (Cell Size: H%d, V%d)...", cellSize.h, cellSize.v);
         gPeerListHandle = LNew(&destRectList, &dataBounds, cellSize, 0, (WindowPtr)dialog,
                                true,
                                false,
                                false,
                                true);
         if (gPeerListHandle == NULL) {
-            log_internal_message("CRITICAL ERROR: LNew failed for Peer List! (Error: %d)", ResError());
+            log_debug("CRITICAL ERROR: LNew failed for Peer List! (Error: %d)", ResError());
             listOk = false;
         } else {
-            log_internal_message("LNew succeeded for Peer List. Handle: 0x%lX", (unsigned long)gPeerListHandle);
+            log_debug("LNew succeeded for Peer List. Handle: 0x%lX", (unsigned long)gPeerListHandle);
             (*gPeerListHandle)->selFlags = lOnlyOne;
             LActivate(true, gPeerListHandle);
             listOk = true;
         }
     } else {
-        log_internal_message("ERROR: Item %d is NOT a UserItem (Type: %d)! Expected UserItem for LNew.", kPeerListUserItem, itemType);
+        log_debug("ERROR: Item %d is NOT a UserItem (Type: %d)! Expected UserItem for LNew.", kPeerListUserItem, itemType);
         gPeerListHandle = NULL;
         listOk = false;
     }
@@ -63,14 +63,14 @@ Boolean InitPeerListControl(DialogPtr dialog)
 }
 void CleanupPeerListControl(void)
 {
-    log_internal_message("Cleaning up Peer List Control...");
+    log_debug("Cleaning up Peer List Control...");
     if (gPeerListHandle != NULL) {
         LActivate(false, gPeerListHandle);
         LDispose(gPeerListHandle);
         gPeerListHandle = NULL;
     }
     gLastSelectedCell.v = -1;
-    log_internal_message("Peer List Control cleanup finished.");
+    log_debug("Peer List Control cleanup finished.");
 }
 Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
 {
@@ -85,20 +85,20 @@ Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
         SignedByte listState = HGetState((Handle)gPeerListHandle);
         HLock((Handle)gPeerListHandle);
         if (*gPeerListHandle == NULL) {
-            log_internal_message("HandlePeerListClick Error: gPeerListHandle deref failed after HLock!");
+            log_debug("HandlePeerListClick Error: gPeerListHandle deref failed after HLock!");
             HSetState((Handle)gPeerListHandle, listState);
             return false;
         }
         if (PtInRect(localClick, &(**gPeerListHandle).rView)) {
             clickWasInContent = true;
-            log_to_file_only("HandlePeerListClick: Click inside Peer List view rect. Calling LClick.");
+            log_debug("HandlePeerListClick: Click inside Peer List view rect. Calling LClick.");
             (void)LClick(localClick, theEvent->modifiers, gPeerListHandle);
             Cell clickedCell = LLastClick(gPeerListHandle);
             Cell cellToVerify = clickedCell;
             if (clickedCell.v >= 0 && clickedCell.h >= 0) {
                 if (LGetSelect(false, &cellToVerify, gPeerListHandle)) {
                     gLastSelectedCell = clickedCell;
-                    log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) IS selected. Unchecking broadcast.", gLastSelectedCell.h, gLastSelectedCell.v);
+                    log_debug("HandlePeerListClick: LLastClick cell (%d,%d) IS selected. Unchecking broadcast.", gLastSelectedCell.h, gLastSelectedCell.v);
                     DialogItemType itemType;
                     Handle itemHandle;
                     Rect itemRect;
@@ -111,19 +111,19 @@ Boolean HandlePeerListClick(DialogPtr dialog, EventRecord *theEvent)
                         broadcastCheckboxHandle = (ControlHandle)itemHandle;
                         SetControlValue(broadcastCheckboxHandle, 0);
                     } else {
-                        log_internal_message("HandlePeerListClick: Could not find/set broadcast checkbox (item %d).", kBroadcastCheckbox);
+                        log_debug("HandlePeerListClick: Could not find/set broadcast checkbox (item %d).", kBroadcastCheckbox);
                     }
                     SetPort(clickOldPort);
                 } else {
-                    log_to_file_only("HandlePeerListClick: LLastClick cell (%d,%d) is NOT selected by LGetSelect(false,...). Clearing selection.", clickedCell.h, clickedCell.v);
+                    log_debug("HandlePeerListClick: LLastClick cell (%d,%d) is NOT selected by LGetSelect(false,...). Clearing selection.", clickedCell.h, clickedCell.v);
                     SetPt(&gLastSelectedCell, 0, -1);
                 }
             } else {
-                log_to_file_only("HandlePeerListClick: LLastClick returned invalid cell (%d,%d) after LClick. Clearing selection.", clickedCell.h, clickedCell.v);
+                log_debug("HandlePeerListClick: LLastClick returned invalid cell (%d,%d) after LClick. Clearing selection.", clickedCell.h, clickedCell.v);
                 SetPt(&gLastSelectedCell, 0, -1);
             }
         } else {
-            log_to_file_only("HandlePeerListClick: Click was outside Peer List view rect.");
+            log_debug("HandlePeerListClick: Click was outside Peer List view rect.");
         }
         HSetState((Handle)gPeerListHandle, listState);
     }
@@ -140,31 +140,31 @@ void UpdatePeerDisplayList(Boolean forceRedraw)
     peer_t oldSelectedPeerData;
     Boolean hadOldSelectionData = false;
     if (gPeerListHandle == NULL) {
-        log_internal_message("Skipping UpdatePeerDisplayList: List not initialized.");
+        log_debug("Skipping UpdatePeerDisplayList: List not initialized.");
         return;
     }
     if (gLastSelectedCell.v >= 0) {
         hadOldSelectionData = DialogPeerList_GetSelectedPeer(&oldSelectedPeerData);
         if (hadOldSelectionData) {
-            log_to_file_only("UpdatePeerDisplayList: Attempting to preserve selection for peer %s@%s (was display row %d).", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
+            log_debug("UpdatePeerDisplayList: Attempting to preserve selection for peer %s@%s (was display row %d).", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
         } else {
-            log_to_file_only("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but DialogPeerList_GetSelectedPeer failed. No specific peer to preserve.", gLastSelectedCell.v);
+            log_debug("UpdatePeerDisplayList: gLastSelectedCell.v was %d, but DialogPeerList_GetSelectedPeer failed. No specific peer to preserve.", gLastSelectedCell.v);
         }
     } else {
-        log_to_file_only("UpdatePeerDisplayList: No prior selection (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
+        log_debug("UpdatePeerDisplayList: No prior selection (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
     }
     PruneTimedOutPeers();
     listState = HGetState((Handle)gPeerListHandle);
     HLock((Handle)gPeerListHandle);
     if (*gPeerListHandle == NULL) {
-        log_internal_message("UpdatePeerDisplayList Error: gPeerListHandle deref failed after HLock!");
+        log_debug("UpdatePeerDisplayList Error: gPeerListHandle deref failed after HLock!");
         HSetState((Handle)gPeerListHandle, listState);
         return;
     }
     currentListLengthInRows = (**gPeerListHandle).dataBounds.bottom;
     if (currentListLengthInRows > 0) {
         LDelRow(currentListLengthInRows, 0, gPeerListHandle);
-        log_to_file_only("UpdatePeerDisplayList: Deleted %d rows from List Manager.", currentListLengthInRows);
+        log_debug("UpdatePeerDisplayList: Deleted %d rows from List Manager.", currentListLengthInRows);
     }
     Cell tempNewSelectedCell = {0, -1};
     for (int i = 0; i < MAX_PEERS; i++) {
@@ -187,10 +187,10 @@ void UpdatePeerDisplayList(Boolean forceRedraw)
     if (oldSelectionStillValidAndFound) {
         LSetSelect(true, tempNewSelectedCell, gPeerListHandle);
         gLastSelectedCell = tempNewSelectedCell;
-        log_to_file_only("UpdatePeerDisplayList: Reselected peer '%s@%s' at new display row %d.", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
+        log_debug("UpdatePeerDisplayList: Reselected peer '%s@%s' at new display row %d.", oldSelectedPeerData.username, oldSelectedPeerData.ip, gLastSelectedCell.v);
     } else {
         if (hadOldSelectionData) {
-            log_to_file_only("UpdatePeerDisplayList: Previous selection '%s@%s' not found/reselected or became inactive.", oldSelectedPeerData.username, oldSelectedPeerData.ip);
+            log_debug("UpdatePeerDisplayList: Previous selection '%s@%s' not found/reselected or became inactive.", oldSelectedPeerData.username, oldSelectedPeerData.ip);
         }
         if (!oldSelectionStillValidAndFound) {
             SetPt(&gLastSelectedCell, 0, -1);
@@ -210,12 +210,12 @@ void UpdatePeerDisplayList(Boolean forceRedraw)
             }
             HSetState((Handle)gPeerListHandle, listState);
             SetPort(oldPortForDrawing);
-            log_internal_message("Peer list updated. Active peers: %d. Invalidating list rect.", activePeerCount);
+            log_debug("Peer list updated. Active peers: %d. Invalidating list rect.", activePeerCount);
         } else {
-            log_internal_message("Peer list updated, but cannot invalidate rect (window port is NULL).");
+            log_debug("Peer list updated, but cannot invalidate rect (window port is NULL).");
         }
     } else {
-        log_to_file_only("UpdatePeerDisplayList: No significant change detected for redraw. Active: %d, OldRows: %d.", activePeerCount, currentListLengthInRows);
+        log_debug("UpdatePeerDisplayList: No significant change detected for redraw. Active: %d, OldRows: %d.", activePeerCount, currentListLengthInRows);
     }
 }
 void HandlePeerListUpdate(DialogPtr dialog)
@@ -229,7 +229,7 @@ void HandlePeerListUpdate(DialogPtr dialog)
             LUpdate(windowPort->visRgn, gPeerListHandle);
             SetPort(oldPort);
         } else {
-            log_internal_message("HandlePeerListUpdate Error: Cannot update list, window port is NULL.");
+            log_debug("HandlePeerListUpdate Error: Cannot update list, window port is NULL.");
         }
     }
 }
@@ -239,7 +239,7 @@ Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer)
         return false;
     }
     if (gLastSelectedCell.v < 0) {
-        log_to_file_only("DialogPeerList_GetSelectedPeer: No peer selected (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
+        log_debug("DialogPeerList_GetSelectedPeer: No peer selected (gLastSelectedCell.v = %d).", gLastSelectedCell.v);
         return false;
     }
     int selectedDisplayRow = gLastSelectedCell.v;
@@ -248,14 +248,14 @@ Boolean DialogPeerList_GetSelectedPeer(peer_t *outPeer)
         if (gPeerManager.peers[i].active) {
             if (current_active_peer_index == selectedDisplayRow) {
                 *outPeer = gPeerManager.peers[i];
-                log_to_file_only("DialogPeerList_GetSelectedPeer: Found selected peer '%s'@'%s' at display row %d (data index %d).",
+                log_debug("DialogPeerList_GetSelectedPeer: Found selected peer '%s'@'%s' at display row %d (data index %d).",
                                  (outPeer->username[0] ? outPeer->username : "???"), outPeer->ip, selectedDisplayRow, i);
                 return true;
             }
             current_active_peer_index++;
         }
     }
-    log_internal_message("DialogPeerList_GetSelectedPeer Warning: Selected row %d is out of bounds or peer became inactive (current active peers: %d).",
+    log_debug("DialogPeerList_GetSelectedPeer Warning: Selected row %d is out of bounds or peer became inactive (current active peers: %d).",
                          selectedDisplayRow, current_active_peer_index);
     SetPt(&gLastSelectedCell, 0, -1);
     return false;
@@ -275,16 +275,16 @@ void DialogPeerList_DeselectAll(void)
         }
         HSetState((Handle)gPeerListHandle, listState);
         SetPort(oldPortForList);
-        log_to_file_only("DialogPeerList_DeselectAll: Cleared selection and invalidated view.");
+        log_debug("DialogPeerList_DeselectAll: Cleared selection and invalidated view.");
     } else {
-        log_to_file_only("DialogPeerList_DeselectAll: No selection to clear or list not initialized.");
+        log_debug("DialogPeerList_DeselectAll: No selection to clear or list not initialized.");
     }
 }
 void ActivatePeerList(Boolean activating)
 {
     if (gPeerListHandle != NULL) {
         LActivate(activating, gPeerListHandle);
-        log_to_file_only("ActivatePeerList: List 0x%lX %s.",
+        log_debug("ActivatePeerList: List 0x%lX %s.",
                          (unsigned long)gPeerListHandle, activating ? "activated" : "deactivated");
     }
 }

--- a/classic_mac/logging.c
+++ b/classic_mac/logging.c
@@ -1,135 +1,69 @@
-#include "logging.h"
-#include "../shared/logging.h"
-#include "dialog.h"
-#include "dialog_messages.h"
+#include "logging.h"           // For local declarations
+#include "../shared/logging.h" // For shared function calls and type definitions
+#include "dialog.h"            // For gMainWindow, gMessagesTE, gDialogTEInitialized
+#include "dialog_messages.h"   // For AppendToMessagesTE
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+
 #ifdef __MACOS__
-#include <OSUtils.h>
+#include <OSUtils.h> // For GetTime, DateTimeRec
 #endif
-#define MAX_LOG_LINE_LENGTH_MAC 1024
-#define USER_MESSAGE_BUFFER_SIZE_MAC (MAX_LOG_LINE_LENGTH_MAC - 60)
-#define TIMESTAMP_BUFFER_SIZE_MAC 20
-static FILE *g_platform_log_file_mac = NULL;
-static char g_log_file_name_mac[256];
+
+// Buffer sizes are now primarily managed in shared/logging.c
+#define MAX_LOG_LINE_LENGTH_MAC_DISPLAY 256 // For constructing message for AppendToMessagesTE
+
+// Guard to prevent re-entrancy if AppendToMessagesTE itself calls log_debug
 static Boolean g_classic_mac_logging_to_te_in_progress = false;
-static void get_platform_timestamp(char *buffer, size_t buffer_size)
-{
+
+void classic_mac_platform_get_timestamp(char *buffer, size_t buffer_size) {
 #ifdef __MACOS__
     DateTimeRec dt_rec;
     GetTime(&dt_rec);
+    // Ensure we don't overflow buffer; snprintf would be better if available
+    // For simplicity with classic Mac, assuming buffer_size is adequate.
     sprintf(buffer, "%04d-%02d-%02d %02d:%02d:%02d",
             (int)dt_rec.year, (int)dt_rec.month, (int)dt_rec.day,
             (int)dt_rec.hour, (int)dt_rec.minute, (int)dt_rec.second);
 #else
+    // Fallback for non-Mac builds, though this file is __MACOS__ specific
     strncpy(buffer, "0000-00-00 00:00:00", buffer_size);
     if (buffer_size > 0) buffer[buffer_size - 1] = '\0';
 #endif
 }
-void log_init(const char *log_file_name_suggestion, platform_display_debug_log_func_t display_func)
-{
-    if (g_platform_log_file_mac != NULL) {
-        fclose(g_platform_log_file_mac);
-        g_platform_log_file_mac = NULL;
-    }
-    if (log_file_name_suggestion) {
-        strncpy(g_log_file_name_mac, log_file_name_suggestion, sizeof(g_log_file_name_mac) - 1);
-        g_log_file_name_mac[sizeof(g_log_file_name_mac) - 1] = '\0';
-    } else {
-        strcpy(g_log_file_name_mac, "csend_mac.log");
-    }
-    g_platform_log_file_mac = fopen(g_log_file_name_mac, "a");
-    if (g_platform_log_file_mac != NULL) {
-        char timestamp[TIMESTAMP_BUFFER_SIZE_MAC];
-        get_platform_timestamp(timestamp, sizeof(timestamp));
-        fprintf(g_platform_log_file_mac, "\n--- [%s] Log Session Started ---\n", timestamp);
-        fflush(g_platform_log_file_mac);
-    }
-    shared_logging_set_platform_callback(display_func);
-}
-void log_shutdown(void)
-{
-    if (g_platform_log_file_mac != NULL) {
-        char timestamp[TIMESTAMP_BUFFER_SIZE_MAC];
-        get_platform_timestamp(timestamp, sizeof(timestamp));
-        fprintf(g_platform_log_file_mac, "--- [%s] Log Session Ended ---\n\n", timestamp);
-        fflush(g_platform_log_file_mac);
-        fclose(g_platform_log_file_mac);
-        g_platform_log_file_mac = NULL;
-    }
-    shared_logging_clear_platform_callback();
-}
-void log_internal_message(const char *format, ...)
-{
-    char message_body[USER_MESSAGE_BUFFER_SIZE_MAC];
-    char timestamp_str[TIMESTAMP_BUFFER_SIZE_MAC];
-    char full_log_message[MAX_LOG_LINE_LENGTH_MAC];
-    char timestamp_and_prefix_for_ui[TIMESTAMP_BUFFER_SIZE_MAC + 10];
-    va_list args;
-    va_start(args, format);
-    vsprintf(message_body, format, args);
-    va_end(args);
-    message_body[USER_MESSAGE_BUFFER_SIZE_MAC - 1] = '\0';
-    get_platform_timestamp(timestamp_str, sizeof(timestamp_str));
-    if (g_platform_log_file_mac != NULL) {
-        sprintf(full_log_message, "%s [DEBUG] %s", timestamp_str, message_body);
-        fprintf(g_platform_log_file_mac, "%s\n", full_log_message);
-        fflush(g_platform_log_file_mac);
-    }
-    if (is_debug_output_enabled()) {
-        platform_display_debug_log_func_t display_func = shared_logging_get_platform_callback();
-        if (display_func != NULL) {
-            sprintf(timestamp_and_prefix_for_ui, "%s [DEBUG] ", timestamp_str);
-            display_func(timestamp_and_prefix_for_ui, message_body);
-        }
-    }
-}
-void log_app_event(const char *format, ...)
-{
-    char message_body[USER_MESSAGE_BUFFER_SIZE_MAC];
-    char timestamp_str[TIMESTAMP_BUFFER_SIZE_MAC];
-    char full_log_message[MAX_LOG_LINE_LENGTH_MAC];
-    va_list args;
-    va_start(args, format);
-    vsprintf(message_body, format, args);
-    va_end(args);
-    message_body[USER_MESSAGE_BUFFER_SIZE_MAC - 1] = '\0';
-    get_platform_timestamp(timestamp_str, sizeof(timestamp_str));
-    if (g_platform_log_file_mac != NULL) {
-        sprintf(full_log_message, "%s %s", timestamp_str, message_body);
-        fprintf(g_platform_log_file_mac, "%s\n", full_log_message);
-        fflush(g_platform_log_file_mac);
-    }
-}
-void log_to_file_only(const char *format, ...)
-{
-    char message_body[USER_MESSAGE_BUFFER_SIZE_MAC];
-    char timestamp_str[TIMESTAMP_BUFFER_SIZE_MAC];
-    char full_log_message[MAX_LOG_LINE_LENGTH_MAC];
-    va_list args;
-    va_start(args, format);
-    vsprintf(message_body, format, args);
-    va_end(args);
-    message_body[USER_MESSAGE_BUFFER_SIZE_MAC - 1] = '\0';
-    get_platform_timestamp(timestamp_str, sizeof(timestamp_str));
-    if (g_platform_log_file_mac != NULL) {
-        sprintf(full_log_message, "%s [DEBUG] %s", timestamp_str, message_body);
-        fprintf(g_platform_log_file_mac, "%s\n", full_log_message);
-        fflush(g_platform_log_file_mac);
-    }
-}
-void classic_mac_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body)
-{
-    char full_ui_message[MAX_LOG_LINE_LENGTH_MAC];
+
+void classic_mac_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body) {
+    char full_ui_message[MAX_LOG_LINE_LENGTH_MAC_DISPLAY];
+
     if (g_classic_mac_logging_to_te_in_progress) {
+        // Avoid recursion if AppendToMessagesTE itself logs something
         return;
     }
+
     if (gMainWindow != NULL && gMessagesTE != NULL && gDialogTEInitialized) {
         g_classic_mac_logging_to_te_in_progress = true;
+
+        // Construct the full message for the TE
+        // Again, careful with buffer sizes. sprintf is used for simplicity here.
         sprintf(full_ui_message, "%s%s", timestamp_and_prefix, message_body);
+        full_ui_message[MAX_LOG_LINE_LENGTH_MAC_DISPLAY -1] = '\0'; // Ensure null termination
+
         AppendToMessagesTE(full_ui_message);
-        AppendToMessagesTE("\r");
+        AppendToMessagesTE("\r"); // Add a carriage return for TE display
+
         g_classic_mac_logging_to_te_in_progress = false;
     }
+    // If dialog isn't ready, debug messages to UI are silently dropped.
 }
+
+// The log_init, log_shutdown, log_debug (formerly log_internal_message),
+// and log_app_event functions are now primarily in shared/logging.c.
+// The platform-specific main.c will call the shared log_init with
+// pointers to the above callback functions.
+
+// log_to_file_only is removed. If specific messages should *never* go to UI
+// even when debug is enabled, that requires a different approach (e.g. log levels,
+// or direct calls to a file-writing utility not part of the public log_debug API).
+// For now, all log_debug calls are subject to the UI display toggle.
+// Calls to the old log_to_file_only should be changed to log_debug.

--- a/classic_mac/logging.h
+++ b/classic_mac/logging.h
@@ -1,6 +1,17 @@
-#ifndef CLASSIC_MAC_LOGGING_H_WRAPPER
-#define CLASSIC_MAC_LOGGING_H_WRAPPER
-#include "../shared/logging.h"
+#ifndef CLASSIC_MAC_LOGGING_H
+#define CLASSIC_MAC_LOGGING_H
+
+#include <stddef.h> // For size_t
+
+// Platform-specific implementation for getting a timestamp.
+void classic_mac_platform_get_timestamp(char *buffer, size_t buffer_size);
+
+// Platform-specific implementation for displaying a debug log message in the dialog.
 void classic_mac_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body);
-void log_to_file_only(const char *format, ...);
-#endif
+
+// This function is no longer needed as its purpose is covered by log_debug
+// and the debug UI display toggle. If truly file-only debug messages are needed,
+// that's a more advanced logging feature (e.g., log levels).
+// void log_debug(const char *format, ...);
+
+#endif // CLASSIC_MAC_LOGGING_H

--- a/classic_mac/mactcp_discovery.c
+++ b/classic_mac/mactcp_discovery.c
@@ -32,11 +32,11 @@ static void mac_send_discovery_response(uint32_t dest_ip_addr_host, uint16_t des
     udp_port dest_port_mac = dest_port_host;
     OSErr sendErr = SendDiscoveryResponseSync(gMacTCPRefNum, gMyUsername, gMyLocalIPStr, dest_ip_net, dest_port_mac);
     if (sendErr != noErr) {
-        log_internal_message("Error sending sync discovery response: %d", sendErr);
+        log_debug("Error sending sync discovery response: %d", sendErr);
     } else {
         char tempIPStr[INET_ADDRSTRLEN];
         AddrToStr(dest_ip_net, tempIPStr);
-        log_to_file_only("Sent DISCOVERY_RESPONSE to %s:%u", tempIPStr, dest_port_mac);
+        log_debug("Sent DISCOVERY_RESPONSE to %s:%u", tempIPStr, dest_port_mac);
     }
 }
 static int mac_add_or_update_peer(const char *ip, const char *username, void *platform_context)
@@ -56,9 +56,9 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum)
     OSErr err;
     UDPiopb pbCreate;
     const unsigned short specificPort = PORT_UDP;
-    log_internal_message("Initializing UDP Discovery Endpoint (Async Read Poll / Sync Write)...");
+    log_debug("Initializing UDP Discovery Endpoint (Async Read Poll / Sync Write)...");
     if (macTCPRefNum == 0) {
-        log_internal_message("Error (InitUDP): macTCPRefNum is 0.");
+        log_debug("Error (InitUDP): macTCPRefNum is 0.");
         return paramErr;
     }
     gUDPStream = NULL;
@@ -68,10 +68,10 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum)
     gLastBroadcastTimeTicks = 0;
     gUDPRecvBuffer = NewPtrClear(kMinUDPBufSize);
     if (gUDPRecvBuffer == NULL) {
-        log_internal_message("Fatal Error: Could not allocate UDP receive buffer (%ld bytes).", (long)kMinUDPBufSize);
+        log_debug("Fatal Error: Could not allocate UDP receive buffer (%ld bytes).", (long)kMinUDPBufSize);
         return memFullErr;
     }
-    log_internal_message("Allocated %ld bytes for UDP receive buffer at 0x%lX.", (long)kMinUDPBufSize, (unsigned long)gUDPRecvBuffer);
+    log_debug("Allocated %ld bytes for UDP receive buffer at 0x%lX.", (long)kMinUDPBufSize, (unsigned long)gUDPRecvBuffer);
     memset(&pbCreate, 0, sizeof(UDPiopb));
     pbCreate.ioCompletion = nil;
     pbCreate.ioCRefNum = macTCPRefNum;
@@ -81,39 +81,39 @@ OSErr InitUDPDiscoveryEndpoint(short macTCPRefNum)
     pbCreate.csParam.create.rcvBuffLen = kMinUDPBufSize;
     pbCreate.csParam.create.notifyProc = nil;
     pbCreate.csParam.create.localPort = specificPort;
-    log_internal_message("Calling PBControlSync (UDPCreate) for port %u...", specificPort);
+    log_debug("Calling PBControlSync (UDPCreate) for port %u...", specificPort);
     err = PBControlSync((ParmBlkPtr)&pbCreate);
     StreamPtr returnedStreamPtr = pbCreate.udpStream;
     unsigned short assignedPort = pbCreate.csParam.create.localPort;
-    log_internal_message("DEBUG: After PBControlSync(UDPCreate): err=%d, StreamPtr=0x%lX, AssignedPort=%u",
+    log_debug("DEBUG: After PBControlSync(UDPCreate): err=%d, StreamPtr=0x%lX, AssignedPort=%u",
                          err, (unsigned long)returnedStreamPtr, assignedPort);
     if (err != noErr) {
-        log_internal_message("Error (InitUDP): UDPCreate failed (Error: %d).", err);
+        log_debug("Error (InitUDP): UDPCreate failed (Error: %d).", err);
         DisposePtr(gUDPRecvBuffer);
         gUDPRecvBuffer = NULL;
         return err;
     }
     if (returnedStreamPtr == NULL) {
-        log_internal_message("Error (InitUDP): UDPCreate succeeded but returned NULL stream pointer.");
+        log_debug("Error (InitUDP): UDPCreate succeeded but returned NULL stream pointer.");
         DisposePtr(gUDPRecvBuffer);
         gUDPRecvBuffer = NULL;
         return ioErr;
     }
     if (assignedPort != specificPort && specificPort != 0) {
-        log_internal_message("Warning (InitUDP): UDPCreate assigned port %u instead of requested %u.", assignedPort, specificPort);
+        log_debug("Warning (InitUDP): UDPCreate assigned port %u instead of requested %u.", assignedPort, specificPort);
     }
     gUDPStream = returnedStreamPtr;
-    log_internal_message("UDP Endpoint created successfully (StreamPtr: 0x%lX) on assigned port %u.", (unsigned long)gUDPStream, assignedPort);
+    log_debug("UDP Endpoint created successfully (StreamPtr: 0x%lX) on assigned port %u.", (unsigned long)gUDPStream, assignedPort);
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
     gLastBroadcastTimeTicks = 0;
     err = StartAsyncUDPRead();
     if (err != noErr && err != 1) {
-        log_internal_message("Error (InitUDP): Failed to start initial async UDP read (polling). Error: %d", err);
+        log_debug("Error (InitUDP): Failed to start initial async UDP read (polling). Error: %d", err);
         CleanupUDPDiscoveryEndpoint(macTCPRefNum);
         return err;
     } else {
-        log_internal_message("Initial asynchronous UDP read (polling) STARTING.");
+        log_debug("Initial asynchronous UDP read (polling) STARTING.");
     }
     return noErr;
 }
@@ -121,9 +121,9 @@ void CleanupUDPDiscoveryEndpoint(short macTCPRefNum)
 {
     UDPiopb pbRelease;
     OSErr err;
-    log_internal_message("Cleaning up UDP Discovery Endpoint (Async)...");
+    log_debug("Cleaning up UDP Discovery Endpoint (Async)...");
     if (gUDPStream != NULL) {
-        log_internal_message("UDP Stream 0x%lX was open. Attempting synchronous release...", (unsigned long)gUDPStream);
+        log_debug("UDP Stream 0x%lX was open. Attempting synchronous release...", (unsigned long)gUDPStream);
         gUDPReadPending = false;
         gUDPBfrReturnPending = false;
         memset(&pbRelease, 0, sizeof(UDPiopb));
@@ -135,38 +135,38 @@ void CleanupUDPDiscoveryEndpoint(short macTCPRefNum)
         pbRelease.csParam.create.rcvBuffLen = 0;
         err = PBControlSync((ParmBlkPtr)&pbRelease);
         if (err != noErr) {
-            log_internal_message("Warning: Synchronous UDPRelease failed during cleanup (Error: %d).", err);
+            log_debug("Warning: Synchronous UDPRelease failed during cleanup (Error: %d).", err);
         } else {
-            log_internal_message("Synchronous UDPRelease succeeded.");
+            log_debug("Synchronous UDPRelease succeeded.");
         }
         gUDPStream = NULL;
     } else {
-        log_internal_message("UDP Stream was not open or already cleaned up.");
+        log_debug("UDP Stream was not open or already cleaned up.");
     }
     if (gUDPRecvBuffer != NULL) {
-        log_internal_message("Disposing UDP receive buffer at 0x%lX.", (unsigned long)gUDPRecvBuffer);
+        log_debug("Disposing UDP receive buffer at 0x%lX.", (unsigned long)gUDPRecvBuffer);
         DisposePtr(gUDPRecvBuffer);
         gUDPRecvBuffer = NULL;
     }
     gUDPReadPending = false;
     gUDPBfrReturnPending = false;
     gLastBroadcastTimeTicks = 0;
-    log_internal_message("UDP Discovery Endpoint cleanup finished.");
+    log_debug("UDP Discovery Endpoint cleanup finished.");
 }
 OSErr StartAsyncUDPRead(void)
 {
     OSErr err;
     if (gUDPStream == NULL) return invalidStreamPtr;
     if (gUDPReadPending) {
-        log_to_file_only("StartAsyncUDPRead: UDPRead already pending.");
+        log_debug("StartAsyncUDPRead: UDPRead already pending.");
         return 1;
     }
     if (gUDPBfrReturnPending) {
-        log_to_file_only("StartAsyncUDPRead: Cannot start read, buffer return is pending.");
+        log_debug("StartAsyncUDPRead: Cannot start read, buffer return is pending.");
         return 1;
     }
     if (gUDPRecvBuffer == NULL) {
-        log_internal_message("Error (StartAsyncUDPRead): gUDPRecvBuffer is NULL.");
+        log_debug("Error (StartAsyncUDPRead): gUDPRecvBuffer is NULL.");
         return invalidBufPtr;
     }
     memset(&gUDPReadPB, 0, sizeof(UDPiopb));
@@ -181,11 +181,11 @@ OSErr StartAsyncUDPRead(void)
     gUDPReadPB.ioResult = 1;
     err = PBControlAsync((ParmBlkPtr)&gUDPReadPB);
     if (err != noErr) {
-        log_internal_message("Error (StartAsyncUDPRead): PBControlAsync(UDPRead - polling) failed immediately. Error: %d", err);
+        log_debug("Error (StartAsyncUDPRead): PBControlAsync(UDPRead - polling) failed immediately. Error: %d", err);
         gUDPReadPending = false;
         return err;
     }
-    log_to_file_only("StartAsyncUDPRead: Async UDPRead initiated for polling.");
+    log_debug("StartAsyncUDPRead: Async UDPRead initiated for polling.");
     return 1;
 }
 static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr,
@@ -201,7 +201,7 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     if (myUsername == NULL || myLocalIPStr == NULL) return paramErr;
     formatted_len = format_message(staticBuffer, BUFFER_SIZE, msgType, myUsername, myLocalIPStr, content);
     if (formatted_len <= 0) {
-        log_internal_message("Error (SendUDPSyncInternal): format_message failed for '%s'.", msgType);
+        log_debug("Error (SendUDPSyncInternal): format_message failed for '%s'.", msgType);
         return paramErr;
     }
     staticWDS[0].length = formatted_len - 1;
@@ -220,15 +220,15 @@ static OSErr SendUDPSyncInternal(short macTCPRefNum, const char *myUsername, con
     pbSync.csParam.send.sendLength = 0;
     err = PBControlSync((ParmBlkPtr)&pbSync);
     if (err != noErr) {
-        log_internal_message("Error (SendUDPSync): PBControlSync(UDPWrite) for '%s' failed. Error: %d", msgType, err);
+        log_debug("Error (SendUDPSync): PBControlSync(UDPWrite) for '%s' failed. Error: %d", msgType, err);
         return err;
     }
-    log_to_file_only("SendUDPSyncInternal: Sent '%s' to IP %lu:%u.", msgType, (unsigned long)destIP, destPort);
+    log_debug("SendUDPSyncInternal: Sent '%s' to IP %lu:%u.", msgType, (unsigned long)destIP, destPort);
     return noErr;
 }
 OSErr SendDiscoveryBroadcastSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr)
 {
-    log_to_file_only("Sending Discovery Broadcast...");
+    log_debug("Sending Discovery Broadcast...");
     return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
                                MSG_DISCOVERY, "",
                                BROADCAST_IP, PORT_UDP,
@@ -236,7 +236,7 @@ OSErr SendDiscoveryBroadcastSync(short macTCPRefNum, const char *myUsername, con
 }
 OSErr SendDiscoveryResponseSync(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr, ip_addr destIP, udp_port destPort)
 {
-    log_to_file_only("Sending Discovery Response to IP %lu:%u...", (unsigned long)destIP, destPort);
+    log_debug("Sending Discovery Response to IP %lu:%u...", (unsigned long)destIP, destPort);
     return SendUDPSyncInternal(macTCPRefNum, myUsername, myLocalIPStr,
                                MSG_DISCOVERY_RESPONSE, "",
                                destIP, destPort,
@@ -247,11 +247,11 @@ OSErr ReturnUDPBufferAsync(Ptr dataPtr, unsigned short bufferSize)
     OSErr err;
     if (gUDPStream == NULL) return invalidStreamPtr;
     if (gUDPBfrReturnPending) {
-        log_to_file_only("ReturnUDPBufferAsync: Buffer return already pending.");
+        log_debug("ReturnUDPBufferAsync: Buffer return already pending.");
         return 1;
     }
     if (dataPtr == NULL) {
-        log_internal_message("Error (ReturnUDPBufferAsync): dataPtr is NULL.");
+        log_debug("Error (ReturnUDPBufferAsync): dataPtr is NULL.");
         return invalidBufPtr;
     }
     memset(&gUDPBfrReturnPB, 0, sizeof(UDPiopb));
@@ -265,11 +265,11 @@ OSErr ReturnUDPBufferAsync(Ptr dataPtr, unsigned short bufferSize)
     gUDPBfrReturnPB.ioResult = 1;
     err = PBControlAsync((ParmBlkPtr)&gUDPBfrReturnPB);
     if (err != noErr) {
-        log_internal_message("CRITICAL Error (ReturnUDPBufferAsync): PBControlAsync(UDPBfrReturn - polling) failed immediately. Error: %d.", err);
+        log_debug("CRITICAL Error (ReturnUDPBufferAsync): PBControlAsync(UDPBfrReturn - polling) failed immediately. Error: %d.", err);
         gUDPBfrReturnPending = false;
         return err;
     }
-    log_to_file_only("ReturnUDPBufferAsync: Async UDPBfrReturn initiated for buffer 0x%lX.", (unsigned long)dataPtr);
+    log_debug("ReturnUDPBufferAsync: Async UDPBfrReturn initiated for buffer 0x%lX.", (unsigned long)dataPtr);
     return 1;
 }
 void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *myLocalIPStr)
@@ -281,12 +281,12 @@ void CheckSendBroadcast(short macTCPRefNum, const char *myUsername, const char *
         gLastBroadcastTimeTicks = currentTimeTicks;
     }
     if (gLastBroadcastTimeTicks == 0 || (currentTimeTicks - gLastBroadcastTimeTicks) >= intervalTicks) {
-        log_to_file_only("CheckSendBroadcast: Interval elapsed. Sending broadcast.");
+        log_debug("CheckSendBroadcast: Interval elapsed. Sending broadcast.");
         OSErr sendErr = SendDiscoveryBroadcastSync(macTCPRefNum, myUsername, myLocalIPStr);
         if (sendErr == noErr) {
             gLastBroadcastTimeTicks = currentTimeTicks;
         } else {
-            log_internal_message("Sync broadcast initiation failed (Error: %d)", sendErr);
+            log_debug("Sync broadcast initiation failed (Error: %d)", sendErr);
         }
     }
 }
@@ -313,7 +313,7 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP)
                         OSErr addrErr = AddrToStr(senderIPNet, senderIPStr);
                         if (addrErr != noErr) {
                             sprintf(senderIPStr, "%lu.%lu.%lu.%lu", (senderIPNet >> 24) & 0xFF, (senderIPNet >> 16) & 0xFF, (senderIPNet >> 8) & 0xFF, senderIPNet & 0xFF);
-                            log_to_file_only("PollUDPListener: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.", addrErr, (unsigned long)senderIPNet, senderIPStr);
+                            log_debug("PollUDPListener: AddrToStr failed (%d) for sender IP %lu. Using fallback '%s'.", addrErr, (unsigned long)senderIPNet, senderIPStr);
                         }
                         uint32_t sender_ip_addr_host_order_for_shared = (uint32_t)senderIPNet;
                         discovery_logic_process_packet((const char *)dataPtr, dataLength,
@@ -323,20 +323,20 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP)
                     } else {
                         char selfIPStr[INET_ADDRSTRLEN];
                         AddrToStr(senderIPNet, selfIPStr);
-                        log_to_file_only("PollUDPListener: Ignored UDP packet from self (%s).", selfIPStr);
+                        log_debug("PollUDPListener: Ignored UDP packet from self (%s).", selfIPStr);
                     }
                     OSErr returnErr = ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
                     if (returnErr != noErr && returnErr != 1) {
-                        log_internal_message("CRITICAL Error (PollUDPListener): Failed to initiate async UDPBfrReturn (polling) using pointer 0x%lX after processing. Error: %d.", (unsigned long)dataPtr, returnErr);
+                        log_debug("CRITICAL Error (PollUDPListener): Failed to initiate async UDPBfrReturn (polling) using pointer 0x%lX after processing. Error: %d.", (unsigned long)dataPtr, returnErr);
                     } else {
-                        log_to_file_only("PollUDPListener: Initiated return for buffer 0x%lX.", (unsigned long)dataPtr);
+                        log_debug("PollUDPListener: Initiated return for buffer 0x%lX.", (unsigned long)dataPtr);
                     }
                 } else {
-                    log_to_file_only("DEBUG: Async UDPRead (polling) returned 0 bytes.");
+                    log_debug("DEBUG: Async UDPRead (polling) returned 0 bytes.");
                     ReturnUDPBufferAsync(dataPtr, kMinUDPBufSize);
                 }
             } else {
-                log_internal_message("Error (PollUDPListener): Polled async UDPRead completed with error: %d", ioResult);
+                log_debug("Error (PollUDPListener): Polled async UDPRead completed with error: %d", ioResult);
                 ReturnUDPBufferAsync(gUDPReadPB.csParam.receive.rcvBuff, kMinUDPBufSize);
             }
         }
@@ -346,9 +346,9 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP)
         if (ioResult <= 0) {
             gUDPBfrReturnPending = false;
             if (ioResult != noErr) {
-                log_internal_message("CRITICAL Error (PollUDPListener): Polled async UDPBfrReturn completed with error: %d.", ioResult);
+                log_debug("CRITICAL Error (PollUDPListener): Polled async UDPBfrReturn completed with error: %d.", ioResult);
             } else {
-                log_to_file_only("PollUDPListener: Async UDPBfrReturn completed successfully.");
+                log_debug("PollUDPListener: Async UDPBfrReturn completed successfully.");
                 if (!gUDPReadPending) {
                     StartAsyncUDPRead();
                 }
@@ -356,7 +356,7 @@ void PollUDPListener(short macTCPRefNum, ip_addr myLocalIP)
         }
     }
     if (!gUDPReadPending && !gUDPBfrReturnPending && gUDPStream != NULL) {
-        log_to_file_only("PollUDPListener: No UDP read or buffer return pending, starting new read.");
+        log_debug("PollUDPListener: No UDP read or buffer return pending, starting new read.");
         StartAsyncUDPRead();
     }
 }

--- a/classic_mac/mactcp_messaging.c
+++ b/classic_mac/mactcp_messaging.c
@@ -61,12 +61,12 @@ static int mac_tcp_add_or_update_peer(const char *ip, const char *username, void
     (void)platform_context;
     int addResult = AddOrUpdatePeer(ip, username);
     if (addResult > 0) {
-        log_internal_message("Peer connected/updated via TCP: %s@%s", username, ip);
+        log_debug("Peer connected/updated via TCP: %s@%s", username, ip);
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     } else if (addResult == 0) {
-        log_to_file_only("Peer updated via TCP: %s@%s", username, ip);
+        log_debug("Peer updated via TCP: %s@%s", username, ip);
     } else {
-        log_internal_message("Peer list full or error, could not add/update %s@%s from TCP connection", username, ip);
+        log_debug("Peer list full or error, could not add/update %s@%s from TCP connection", username, ip);
     }
     return addResult;
 }
@@ -79,16 +79,16 @@ static void mac_tcp_display_text_message(const char *username, const char *ip, c
         sprintf(displayMsg, "%s: %s", username ? username : "???", message_content ? message_content : "");
         AppendToMessagesTE(displayMsg);
         AppendToMessagesTE("\r");
-        log_internal_message("Message from %s@%s: %s", username, ip, message_content);
+        log_debug("Message from %s@%s: %s", username, ip, message_content);
     } else {
-        log_internal_message("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
+        log_debug("Error (mac_tcp_display_text_message): Cannot display message, dialog not ready.");
     }
 }
 static void mac_tcp_mark_peer_inactive(const char *ip, void *platform_context)
 {
     (void)platform_context;
     if (!ip) return;
-    log_internal_message("Peer %s has sent QUIT notification via TCP.", ip);
+    log_debug("Peer %s has sent QUIT notification via TCP.", ip);
     if (MarkPeerInactive(ip)) {
         if (gMainWindow != NULL && gPeerListHandle != NULL) UpdatePeerDisplayList(true);
     }
@@ -96,30 +96,30 @@ static void mac_tcp_mark_peer_inactive(const char *ip, void *platform_context)
 OSErr InitTCP(short macTCPRefNum)
 {
     OSErr err;
-    log_internal_message("Initializing Single TCP Stream (Async Passive Open / Sync Poll Strategy)...");
+    log_debug("Initializing Single TCP Stream (Async Passive Open / Sync Poll Strategy)...");
     if (macTCPRefNum == 0) return paramErr;
     if (gTCPStream != NULL || gTCPState != TCP_STATE_UNINITIALIZED) {
-        log_internal_message("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
+        log_debug("Error (InitTCP): Already initialized or in unexpected state (%d)?", gTCPState);
         return streamAlreadyOpen;
     }
     gTCPInternalBuffer = NewPtrClear(kTCPInternalBufferSize);
     gTCPRecvBuffer = NewPtrClear(kTCPRecvBufferSize);
     if (gTCPInternalBuffer == NULL || gTCPRecvBuffer == NULL) {
-        log_internal_message("Fatal Error: Could not allocate TCP buffers.");
+        log_debug("Fatal Error: Could not allocate TCP buffers.");
         if (gTCPInternalBuffer) DisposePtr(gTCPInternalBuffer);
         if (gTCPRecvBuffer) DisposePtr(gTCPRecvBuffer);
         gTCPInternalBuffer = gTCPRecvBuffer = NULL;
         return memFullErr;
     }
-    log_internal_message("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
-    log_internal_message("Creating Single Stream...");
+    log_debug("Allocated TCP buffers (Internal: %ld, Recv: %ld).", (long)kTCPInternalBufferSize, (long)kTCPRecvBufferSize);
+    log_debug("Creating Single Stream...");
     err = LowTCPCreateSync(macTCPRefNum, &gTCPStream, gTCPInternalBuffer, kTCPInternalBufferSize);
     if (err != noErr || gTCPStream == NULL) {
-        log_internal_message("Error: Failed to create TCP Stream: %d", err);
+        log_debug("Error: Failed to create TCP Stream: %d", err);
         CleanupTCP(macTCPRefNum);
         return err;
     }
-    log_internal_message("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
+    log_debug("Single TCP Stream created (0x%lX).", (unsigned long)gTCPStream);
     memset(&gTCPPassiveOpenPB, 0, sizeof(TCPiopb));
     gTCPPassiveOpenPB.ioCompletion = nil;
     gTCPPassiveOpenPB.ioCRefNum = gMacTCPRefNum;
@@ -129,18 +129,18 @@ OSErr InitTCP(short macTCPRefNum)
     gIsSending = false;
     gPeerIP = 0;
     gPeerPort = 0;
-    log_internal_message("TCP initialization complete. State: IDLE.");
+    log_debug("TCP initialization complete. State: IDLE.");
     return noErr;
 }
 void CleanupTCP(short macTCPRefNum)
 {
-    log_internal_message("Cleaning up Single TCP Stream...");
+    log_debug("Cleaning up Single TCP Stream...");
     StreamPtr streamToRelease = gTCPStream;
     TCPState stateBeforeCleanup = gTCPState;
     gTCPState = TCP_STATE_RELEASING;
     gTCPStream = NULL;
     if (stateBeforeCleanup == TCP_STATE_CONNECTED_IN || stateBeforeCleanup == TCP_STATE_PASSIVE_OPEN_PENDING) {
-        log_internal_message("Cleanup: Attempting synchronous abort (best effort)...");
+        log_debug("Cleanup: Attempting synchronous abort (best effort)...");
         if (streamToRelease != NULL) {
             StreamPtr currentGlobalStream = gTCPStream;
             gTCPStream = streamToRelease;
@@ -149,12 +149,12 @@ void CleanupTCP(short macTCPRefNum)
         }
     }
     if (streamToRelease != NULL && macTCPRefNum != 0) {
-        log_internal_message("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
+        log_debug("Attempting sync release of stream 0x%lX...", (unsigned long)streamToRelease);
         OSErr relErr = LowTCPReleaseSync(macTCPRefNum, streamToRelease);
-        if (relErr != noErr) log_internal_message("Warning: Sync release failed: %d", relErr);
-        else log_to_file_only("Sync release successful.");
+        if (relErr != noErr) log_debug("Warning: Sync release failed: %d", relErr);
+        else log_debug("Sync release successful.");
     } else if (streamToRelease != NULL) {
-        log_internal_message("Warning: Cannot release stream, MacTCP refnum is 0.");
+        log_debug("Warning: Cannot release stream, MacTCP refnum is 0.");
     }
     gTCPState = TCP_STATE_UNINITIALIZED;
     gIsSending = false;
@@ -169,7 +169,7 @@ void CleanupTCP(short macTCPRefNum)
         DisposePtr(gTCPInternalBuffer);
         gTCPInternalBuffer = NULL;
     }
-    log_internal_message("TCP cleanup finished.");
+    log_debug("TCP cleanup finished.");
 }
 void PollTCP(GiveTimePtr giveTime)
 {
@@ -186,9 +186,9 @@ void PollTCP(GiveTimePtr giveTime)
     }
     switch (gTCPState) {
     case TCP_STATE_IDLE:
-        log_to_file_only("PollTCP: State IDLE. Attempting ASYNC Passive Open (ULP: %ds)...", kTCPPassiveOpenULPTimeoutSeconds);
+        log_debug("PollTCP: State IDLE. Attempting ASYNC Passive Open (ULP: %ds)...", kTCPPassiveOpenULPTimeoutSeconds);
         if (!gPassiveOpenPBInitialized) {
-            log_internal_message("PollTCP CRITICAL: gTCPPassiveOpenPB not initialized!");
+            log_debug("PollTCP CRITICAL: gTCPPassiveOpenPB not initialized!");
             gTCPState = TCP_STATE_ERROR;
             break;
         }
@@ -210,10 +210,10 @@ void PollTCP(GiveTimePtr giveTime)
         gTCPPassiveOpenPB.ioResult = 1;
         err = PBControlAsync((ParmBlkPtr)&gTCPPassiveOpenPB);
         if (err == noErr) {
-            log_to_file_only("PollTCP: Async TCPPassiveOpen initiated.");
+            log_debug("PollTCP: Async TCPPassiveOpen initiated.");
             gTCPState = TCP_STATE_PASSIVE_OPEN_PENDING;
         } else {
-            log_internal_message("PollTCP: PBControlAsync(TCPPassiveOpen) failed immediately: %d. Retrying after delay.", err);
+            log_debug("PollTCP: PBControlAsync(TCPPassiveOpen) failed immediately: %d. Retrying after delay.", err);
             gTCPState = TCP_STATE_IDLE;
             Delay(kErrorRetryDelayTicks, &dummyTimer);
         }
@@ -228,18 +228,18 @@ void PollTCP(GiveTimePtr giveTime)
             gPeerPort = gTCPPassiveOpenPB.csParam.open.remotePort;
             char senderIPStr[INET_ADDRSTRLEN];
             AddrToStr(gPeerIP, senderIPStr);
-            log_internal_message("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
+            log_debug("PollTCP: Incoming connection from %s:%u.", senderIPStr, gPeerPort);
             gTCPState = TCP_STATE_CONNECTED_IN;
             goto CheckConnectedInData;
         } else {
             err = gTCPPassiveOpenPB.ioResult;
             if (err == kRequestAbortedErr) {
-                log_internal_message("PollTCP: Async Passive Open was aborted (err %d), likely by a send operation. Returning to IDLE.", err);
+                log_debug("PollTCP: Async Passive Open was aborted (err %d), likely by a send operation. Returning to IDLE.", err);
             } else {
-                log_internal_message("PollTCP: Async Passive Open failed: %d.", err);
+                log_debug("PollTCP: Async Passive Open failed: %d.", err);
             }
             if (err == kDuplicateSocketErr || err == kConnectionExistsErr) {
-                log_internal_message("PollTCP: Attempting Abort to clear stream after Passive Open failure (%d).", err);
+                log_debug("PollTCP: Attempting Abort to clear stream after Passive Open failure (%d).", err);
                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
             }
             gTCPState = TCP_STATE_IDLE;
@@ -248,10 +248,10 @@ void PollTCP(GiveTimePtr giveTime)
         break;
     case TCP_STATE_CONNECTED_IN:
 CheckConnectedInData:
-        log_to_file_only("PollTCP: State CONNECTED_IN. Checking status...");
+        log_debug("PollTCP: State CONNECTED_IN. Checking status...");
         err = LowTCPStatusSyncPoll(kTCPStatusPollTimeoutTicks, giveTime, &amountUnread, &connectionState);
         if (err != noErr) {
-            log_internal_message("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
+            log_debug("PollTCP: Error getting status while CONNECTED_IN: %d. Aborting.", err);
             LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
             gTCPState = TCP_STATE_IDLE;
             break;
@@ -259,33 +259,33 @@ CheckConnectedInData:
         if (connectionState != 8 && connectionState != 10 && connectionState != 12 && connectionState != 14) {
             char peerIPStr[INET_ADDRSTRLEN];
             AddrToStr(gPeerIP, peerIPStr);
-            log_internal_message("PollTCP: Connection state is %d (not Established/Closing) for %s. Aborting and returning to IDLE.", connectionState, peerIPStr);
+            log_debug("PollTCP: Connection state is %d (not Established/Closing) for %s. Aborting and returning to IDLE.", connectionState, peerIPStr);
             LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
             gTCPState = TCP_STATE_IDLE;
             break;
         }
-        log_to_file_only("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
+        log_debug("PollTCP: Status OK (State %d). Unread data: %u bytes.", connectionState, amountUnread);
         if (amountUnread > 0) {
             unsigned short bytesToRead = kTCPRecvBufferSize;
             Boolean markFlag = false, urgentFlag = false;
-            log_to_file_only("PollTCP: Attempting synchronous Rcv poll...");
+            log_debug("PollTCP: Attempting synchronous Rcv poll...");
             err = LowTCPRcvSyncPoll(kTCPRecvPollTimeoutTicks, gTCPRecvBuffer, &bytesToRead, &markFlag, &urgentFlag, giveTime);
             if (err == noErr) {
-                log_to_file_only("PollTCP: Rcv poll got %u bytes.", bytesToRead);
+                log_debug("PollTCP: Rcv poll got %u bytes.", bytesToRead);
                 ProcessTCPReceive(bytesToRead);
             } else if (err == kConnectionClosingErr) {
                 char peerIPStr[INET_ADDRSTRLEN];
                 AddrToStr(gPeerIP, peerIPStr);
-                log_internal_message("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
+                log_debug("PollTCP: Rcv poll indicated connection closing by peer %s. Processing final %u bytes.", peerIPStr, bytesToRead);
                 if (bytesToRead > 0) ProcessTCPReceive(bytesToRead);
                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 gTCPState = TCP_STATE_IDLE;
             } else if (err == commandTimeout) {
-                log_to_file_only("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
+                log_debug("PollTCP: Rcv poll timed out despite status showing data? Odd. Will retry status.");
             } else {
                 char peerIPStr[INET_ADDRSTRLEN];
                 AddrToStr(gPeerIP, peerIPStr);
-                log_internal_message("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
+                log_debug("PollTCP: Rcv poll failed for %s: %d. Aborting.", peerIPStr, err);
                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 gTCPState = TCP_STATE_IDLE;
             }
@@ -293,18 +293,18 @@ CheckConnectedInData:
             if (connectionState == 14) {
                 char peerIPStr[INET_ADDRSTRLEN];
                 AddrToStr(gPeerIP, peerIPStr);
-                log_internal_message("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Aborting to clean up. Returning to IDLE.", peerIPStr);
+                log_debug("PollTCP: Peer %s has closed (State: CLOSE_WAIT). Aborting to clean up. Returning to IDLE.", peerIPStr);
                 LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
                 gTCPState = TCP_STATE_IDLE;
             } else if (connectionState != 8) {
                 char peerIPStr[INET_ADDRSTRLEN];
                 AddrToStr(gPeerIP, peerIPStr);
-                log_to_file_only("PollTCP: Peer %s in closing state %d with no data. Waiting for MacTCP.", peerIPStr, connectionState);
+                log_debug("PollTCP: Peer %s in closing state %d with no data. Waiting for MacTCP.", peerIPStr, connectionState);
             }
         }
         break;
     default:
-        log_internal_message("PollTCP: In unexpected state %d.", gTCPState);
+        log_debug("PollTCP: In unexpected state %d.", gTCPState);
         gTCPState = TCP_STATE_IDLE;
         break;
     }
@@ -325,11 +325,11 @@ OSErr MacTCP_SendMessageSync(const char *peerIPStr,
     char messageBuffer[BUFFER_SIZE];
     int formattedLen;
     struct wdsEntry sendWDS[2];
-    log_to_file_only("MacTCP_SendMessageSync: Request to send '%s' to %s", msg_type, peerIPStr);
+    log_debug("MacTCP_SendMessageSync: Request to send '%s' to %s", msg_type, peerIPStr);
     if (gMacTCPRefNum == 0) return notOpenErr;
     if (gTCPStream == NULL && gTCPState != TCP_STATE_RELEASING && gTCPState != TCP_STATE_UNINITIALIZED) {
         if (gTCPStream == NULL) {
-            log_internal_message("Error (SendMessage): gTCPStream is NULL and not in deep cleanup state.");
+            log_debug("Error (SendMessage): gTCPStream is NULL and not in deep cleanup state.");
             return kInvalidStreamPtrErr;
         }
     }
@@ -337,71 +337,71 @@ OSErr MacTCP_SendMessageSync(const char *peerIPStr,
         return paramErr;
     }
     if (gTCPState == TCP_STATE_PASSIVE_OPEN_PENDING) {
-        log_internal_message("SendMessage: Stream was in PASSIVE_OPEN_PENDING. Aborting pending listen to allow send.");
+        log_debug("SendMessage: Stream was in PASSIVE_OPEN_PENDING. Aborting pending listen to allow send.");
         OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
         if (abortErr == noErr) {
-            log_to_file_only("SendMessage: Abort of pending passive open successful.");
+            log_debug("SendMessage: Abort of pending passive open successful.");
         } else {
-            log_internal_message("SendMessage: Abort of pending passive open FAILED: %d. Send may fail.", abortErr);
+            log_debug("SendMessage: Abort of pending passive open FAILED: %d. Send may fail.", abortErr);
             return (abortErr == commandTimeout) ? streamBusyErr : abortErr;
         }
         gTCPState = TCP_STATE_IDLE;
     }
     if (gIsSending) {
-        log_internal_message("Warning (SendMessage): Send already in progress.");
+        log_debug("Warning (SendMessage): Send already in progress.");
         return streamBusyErr;
     }
     if (gTCPState != TCP_STATE_IDLE) {
-        log_internal_message("Warning (SendMessage): Stream not IDLE (state %d) after attempting to clear. Cannot send now.", gTCPState);
+        log_debug("Warning (SendMessage): Stream not IDLE (state %d) after attempting to clear. Cannot send now.", gTCPState);
         return streamBusyErr;
     }
     gIsSending = true;
     err = ParseIPv4(peerIPStr, &targetIP);
     if (err != noErr || targetIP == 0) {
-        log_internal_message("Error (SendMessage): Invalid peer IP '%s'.", peerIPStr);
+        log_debug("Error (SendMessage): Invalid peer IP '%s'.", peerIPStr);
         finalErr = paramErr;
         goto SendMessageCleanup;
     }
     formattedLen = format_message(messageBuffer, BUFFER_SIZE, msg_type, local_username, local_ip_str, message_content ? message_content : "");
     if (formattedLen <= 0) {
-        log_internal_message("Error (SendMessage): format_message failed for type '%s'.", msg_type);
+        log_debug("Error (SendMessage): format_message failed for type '%s'.", msg_type);
         finalErr = paramErr;
         goto SendMessageCleanup;
     }
-    log_to_file_only("SendMessage: Connecting to %s...", peerIPStr);
+    log_debug("SendMessage: Connecting to %s...", peerIPStr);
     err = LowTCPActiveOpenSyncPoll(kConnectULPTimeoutSeconds, targetIP, PORT_TCP, giveTime);
     if (err == noErr) {
-        log_to_file_only("SendMessage: Connected successfully to %s.", peerIPStr);
+        log_debug("SendMessage: Connected successfully to %s.", peerIPStr);
         sendWDS[0].length = formattedLen - 1;
         sendWDS[0].ptr = (Ptr)messageBuffer;
         sendWDS[1].length = 0;
         sendWDS[1].ptr = NULL;
-        log_to_file_only("SendMessage: Sending data (%d bytes)...", sendWDS[0].length);
+        log_debug("SendMessage: Sending data (%d bytes)...", sendWDS[0].length);
         err = LowTCPSendSyncPoll(kSendULPTimeoutSeconds, true, (Ptr)sendWDS, giveTime);
         if (err != noErr) {
-            log_internal_message("Error (SendMessage): Send failed to %s: %d", peerIPStr, err);
+            log_debug("Error (SendMessage): Send failed to %s: %d", peerIPStr, err);
             finalErr = err;
         } else {
-            log_to_file_only("SendMessage: Send successful to %s.", peerIPStr);
+            log_debug("SendMessage: Send successful to %s.", peerIPStr);
         }
-        log_to_file_only("SendMessage: Aborting connection to %s...", peerIPStr);
+        log_debug("SendMessage: Aborting connection to %s...", peerIPStr);
         OSErr abortErr = LowTCPAbortSyncPoll(kAbortULPTimeoutSeconds, giveTime);
         if (abortErr != noErr) {
-            log_internal_message("Warning (SendMessage): Abort failed for %s: %d", peerIPStr, abortErr);
+            log_debug("Warning (SendMessage): Abort failed for %s: %d", peerIPStr, abortErr);
             if (finalErr == noErr) finalErr = abortErr;
         }
     } else {
-        log_internal_message("Error (SendMessage): Connect to %s failed: %d", peerIPStr, err);
+        log_debug("Error (SendMessage): Connect to %s failed: %d", peerIPStr, err);
         finalErr = err;
         if (err == kConnectionExistsErr && strcmp(msg_type, MSG_QUIT) == 0) {
-            log_internal_message("SendMessage: Connect for QUIT to %s failed with connectionExists. Peer might be in TIME_WAIT. Assuming QUIT effectively sent.", peerIPStr);
+            log_debug("SendMessage: Connect for QUIT to %s failed with connectionExists. Peer might be in TIME_WAIT. Assuming QUIT effectively sent.", peerIPStr);
             finalErr = noErr;
         }
     }
 SendMessageCleanup:
     gIsSending = false;
     gTCPState = TCP_STATE_IDLE;
-    log_to_file_only("MacTCP_SendMessageSync to %s for '%s': Released send lock. Final Status: %d.", peerIPStr, msg_type, finalErr);
+    log_debug("MacTCP_SendMessageSync to %s for '%s': Released send lock. Final Status: %d.", peerIPStr, msg_type, finalErr);
     return finalErr;
 }
 static void ProcessTCPReceive(unsigned short dataLength)
@@ -420,12 +420,12 @@ static void ProcessTCPReceive(unsigned short dataLength)
         OSErr addrErr = AddrToStr(gPeerIP, senderIPStrFromConnection);
         if (addrErr != noErr) {
             sprintf(senderIPStrFromConnection, "%lu.%lu.%lu.%lu", (gPeerIP >> 24) & 0xFF, (gPeerIP >> 16) & 0xFF, (gPeerIP >> 8) & 0xFF, gPeerIP & 0xFF);
-            log_to_file_only("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
+            log_debug("ProcessTCPReceive: AddrToStr failed for gPeerIP %lu. Using manual format '%s'.", gPeerIP, senderIPStrFromConnection);
         }
         if (dataLength < kTCPRecvBufferSize) gTCPRecvBuffer[dataLength] = '\0';
         else gTCPRecvBuffer[kTCPRecvBufferSize - 1] = '\0';
         if (parse_message(gTCPRecvBuffer, dataLength, senderIPStrFromPayload, senderUsername, msgType, content) == 0) {
-            log_to_file_only("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
+            log_debug("ProcessTCPReceive: Calling shared handler for '%s' from %s@%s (payload IP: %s).",
                              msgType, senderUsername, senderIPStrFromConnection, senderIPStrFromPayload);
             handle_received_tcp_message(senderIPStrFromConnection,
                                         senderUsername,
@@ -434,15 +434,15 @@ static void ProcessTCPReceive(unsigned short dataLength)
                                         &mac_callbacks,
                                         NULL);
             if (strcmp(msgType, MSG_QUIT) == 0) {
-                log_internal_message("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
+                log_debug("ProcessTCPReceive: QUIT received from %s. State machine will handle closure.", senderIPStrFromConnection);
             }
         } else {
-            log_internal_message("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
+            log_debug("Failed to parse TCP message from %s (%u bytes). Discarding.", senderIPStrFromConnection, dataLength);
         }
     } else if (dataLength == 0) {
-        log_to_file_only("ProcessTCPReceive: Received 0 bytes (likely connection closing signal or KeepAlive).");
+        log_debug("ProcessTCPReceive: Received 0 bytes (likely connection closing signal or KeepAlive).");
     } else {
-        log_internal_message("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
+        log_debug("ProcessTCPReceive: Error - dataLength > 0 but buffer is NULL or other issue?");
     }
 }
 static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCode, SInt16 appPollTimeoutTicks)
@@ -453,12 +453,12 @@ static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCo
     if (gMacTCPRefNum == 0) return notOpenErr;
     if (csCode != TCPCreate && csCode != TCPRelease) {
         if (gTCPStream == NULL) {
-            log_internal_message("Error (LowLevelSyncPoll %d): gTCPStream is NULL.", csCode);
+            log_debug("Error (LowLevelSyncPoll %d): gTCPStream is NULL.", csCode);
             return kInvalidStreamPtrErr;
         }
         pBlock->tcpStream = gTCPStream;
     } else if (csCode == TCPRelease && pBlock->tcpStream == NULL) {
-        log_internal_message("Error (LowLevelSyncPoll TCPRelease): pBlock->tcpStream is NULL.");
+        log_debug("Error (LowLevelSyncPoll TCPRelease): pBlock->tcpStream is NULL.");
         return kInvalidStreamPtrErr;
     }
     pBlock->ioCompletion = nil;
@@ -467,13 +467,13 @@ static OSErr LowLevelSyncPoll(TCPiopb *pBlock, GiveTimePtr giveTime, SInt16 csCo
     pBlock->csCode = csCode;
     err = PBControlAsync((ParmBlkPtr)pBlock);
     if (err != noErr) {
-        log_internal_message("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
+        log_debug("Error (LowLevelSyncPoll %d): PBControlAsync failed immediately: %d", csCode, err);
         return err;
     }
     while (pBlock->ioResult > 0) {
         giveTime();
         if (appPollTimeoutTicks > 0 && (TickCount() - startTime) >= (unsigned long)appPollTimeoutTicks) {
-            log_to_file_only("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
+            log_debug("LowLevelSyncPoll (%d): App-level poll timeout (%d ticks) reached.", csCode, appPollTimeoutTicks);
             return commandTimeout;
         }
     }
@@ -496,12 +496,12 @@ static OSErr LowTCPCreateSync(short macTCPRefNum, StreamPtr *streamPtrOut, Ptr r
     if (err == noErr) {
         *streamPtrOut = pbCreate.tcpStream;
         if (*streamPtrOut == NULL) {
-            log_internal_message("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
+            log_debug("Error (LowTCPCreateSync): PBControlSync ok but returned NULL stream.");
             err = ioErr;
         }
     } else {
         *streamPtrOut = NULL;
-        log_internal_message("Error (LowTCPCreateSync): PBControlSync failed: %d", err);
+        log_debug("Error (LowTCPCreateSync): PBControlSync failed: %d", err);
     }
     return err;
 }
@@ -567,7 +567,7 @@ static OSErr LowTCPStatusSyncPoll(SInt16 appPollTimeoutTicks, GiveTimePtr giveTi
     } else {
         *amtUnread = 0;
         *connState = 0;
-        log_internal_message("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
+        log_debug("Warning (LowTCPStatusSyncPoll): Failed: %d", err);
         if (err == kInvalidStreamPtrErr) err = kConnectionDoesntExistErr;
     }
     return err;
@@ -578,19 +578,19 @@ static OSErr LowTCPAbortSyncPoll(Byte ulpTimeoutSeconds, GiveTimePtr giveTime)
     TCPiopb pbAbort;
     SInt16 pollTimeout;
     if (gTCPStream == NULL) {
-        log_to_file_only("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
+        log_debug("LowTCPAbortSyncPoll: Stream is NULL, nothing to abort.");
         return noErr;
     }
     memset(&pbAbort, 0, sizeof(TCPiopb));
     pollTimeout = (SInt16)ulpTimeoutSeconds * 60 + 30;
     err = LowLevelSyncPoll(&pbAbort, giveTime, TCPAbort, pollTimeout);
     if (err == kConnectionDoesntExistErr || err == kInvalidStreamPtrErr || err == kRequestAbortedErr) {
-        log_to_file_only("LowTCPAbortSyncPoll: Abort completed (err %d). Considered OK for reset.", err);
+        log_debug("LowTCPAbortSyncPoll: Abort completed (err %d). Considered OK for reset.", err);
         err = noErr;
     } else if (err != noErr) {
-        log_internal_message("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
+        log_debug("Warning (LowTCPAbortSyncPoll): Abort poll failed with error: %d", err);
     } else {
-        log_to_file_only("LowTCPAbortSyncPoll: Abort poll successful.");
+        log_debug("LowTCPAbortSyncPoll: Abort poll successful.");
     }
     return err;
 }
@@ -606,9 +606,9 @@ static OSErr LowTCPReleaseSync(short macTCPRefNum, StreamPtr streamToRelease)
     pbRelease.tcpStream = streamToRelease;
     err = PBControlSync((ParmBlkPtr)&pbRelease);
     if (err != noErr && err != kInvalidStreamPtrErr) {
-        log_internal_message("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
+        log_debug("Warning (LowTCPReleaseSync): PBControlSync failed: %d", err);
     } else if (err == kInvalidStreamPtrErr) {
-        log_to_file_only("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
+        log_debug("Info (LowTCPReleaseSync): Stream 0x%lX already invalid or released. Error: %d", (unsigned long)streamToRelease, err);
         err = noErr;
     }
     return err;

--- a/classic_mac/mactcp_network.c
+++ b/classic_mac/mactcp_network.c
@@ -20,92 +20,92 @@ OSErr InitializeNetworking(void)
     OSErr err;
     ParamBlockRec pbOpen;
     CntrlParam cntrlPB;
-    log_internal_message("Initializing Networking...");
+    log_debug("Initializing Networking...");
     memset(&pbOpen, 0, sizeof(ParamBlockRec));
     pbOpen.ioParam.ioNamePtr = (StringPtr)kTCPDriverName;
     pbOpen.ioParam.ioPermssn = fsCurPerm;
-    log_internal_message("Attempting PBOpenSync for .IPP driver...");
+    log_debug("Attempting PBOpenSync for .IPP driver...");
     err = PBOpenSync(&pbOpen);
     if (err != noErr) {
-        log_internal_message("Error: PBOpenSync for MacTCP driver failed. Error: %d", err);
+        log_debug("Error: PBOpenSync for MacTCP driver failed. Error: %d", err);
         gMacTCPRefNum = 0;
         return err;
     }
     gMacTCPRefNum = pbOpen.ioParam.ioRefNum;
-    log_internal_message("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
+    log_debug("PBOpenSync succeeded (RefNum: %d).", gMacTCPRefNum);
     memset(&cntrlPB, 0, sizeof(CntrlParam));
     cntrlPB.ioCRefNum = gMacTCPRefNum;
     cntrlPB.csCode = ipctlGetAddr;
-    log_internal_message("Attempting PBControlSync for ipctlGetAddr...");
+    log_debug("Attempting PBControlSync for ipctlGetAddr...");
     err = PBControlSync((ParmBlkPtr)&cntrlPB);
     if (err != noErr) {
-        log_internal_message("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
+        log_debug("Error: PBControlSync(ipctlGetAddr) failed. Error: %d", err);
         gMacTCPRefNum = 0;
         return err;
     }
-    log_internal_message("PBControlSync(ipctlGetAddr) succeeded.");
+    log_debug("PBControlSync(ipctlGetAddr) succeeded.");
     BlockMoveData(&cntrlPB.csParam[0], &gMyLocalIP, sizeof(ip_addr));
-    log_internal_message("Attempting OpenResolver...");
+    log_debug("Attempting OpenResolver...");
     err = OpenResolver(NULL);
     if (err != noErr) {
-        log_internal_message("Error: OpenResolver failed. Error: %d", err);
+        log_debug("Error: OpenResolver failed. Error: %d", err);
         gMacTCPRefNum = 0;
         return err;
     } else {
-        log_internal_message("OpenResolver succeeded.");
+        log_debug("OpenResolver succeeded.");
     }
-    log_internal_message("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
+    log_debug("Attempting AddrToStr for IP: %lu...", gMyLocalIP);
     err = AddrToStr(gMyLocalIP, gMyLocalIPStr);
     if (err != noErr) {
-        log_internal_message("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
+        log_debug("Warning: AddrToStr returned error %d. Result string: '%s'", err, gMyLocalIPStr);
         if (gMyLocalIP == 0 || gMyLocalIPStr[0] == '\0' || strcmp(gMyLocalIPStr, "0.0.0.0") == 0) {
-            log_internal_message("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
+            log_debug("Error: AddrToStr failed to get a valid IP string. Using fallback 127.0.0.1 for display/formatting.");
             strcpy(gMyLocalIPStr, "127.0.0.1");
             if (gMyLocalIP == 0) {
                 ParseIPv4("127.0.0.1", &gMyLocalIP);
             }
         }
     } else {
-        log_internal_message("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
+        log_debug("AddrToStr finished. Local IP: '%s'", gMyLocalIPStr);
     }
     err = InitUDPDiscoveryEndpoint(gMacTCPRefNum);
     if (err != noErr) {
-        log_internal_message("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
+        log_debug("Fatal: UDP Discovery initialization failed (%d). Cleaning up.", err);
         CloseResolver();
         gMacTCPRefNum = 0;
         return err;
     }
     err = InitTCP(gMacTCPRefNum);
     if (err != noErr) {
-        log_internal_message("Fatal: TCP initialization failed (%d). Cleaning up.", err);
+        log_debug("Fatal: TCP initialization failed (%d). Cleaning up.", err);
         CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
         CloseResolver();
         gMacTCPRefNum = 0;
         return err;
     }
-    log_internal_message("Networking initialization complete.");
+    log_debug("Networking initialization complete.");
     return noErr;
 }
 void CleanupNetworking(void)
 {
     OSErr err;
-    log_internal_message("Cleaning up Networking (Streams, DNR, Driver)...");
+    log_debug("Cleaning up Networking (Streams, DNR, Driver)...");
     CleanupTCP(gMacTCPRefNum);
     CleanupUDPDiscoveryEndpoint(gMacTCPRefNum);
-    log_internal_message("Attempting CloseResolver...");
+    log_debug("Attempting CloseResolver...");
     err = CloseResolver();
     if (err != noErr) {
-        log_internal_message("Warning: CloseResolver failed. Error: %d", err);
+        log_debug("Warning: CloseResolver failed. Error: %d", err);
     } else {
-        log_internal_message("CloseResolver succeeded.");
+        log_debug("CloseResolver succeeded.");
     }
     if (gMacTCPRefNum != 0) {
-        log_internal_message("MacTCP driver (RefNum: %d) was opened by this application. It will remain open for the system.", gMacTCPRefNum);
+        log_debug("MacTCP driver (RefNum: %d) was opened by this application. It will remain open for the system.", gMacTCPRefNum);
         gMacTCPRefNum = 0;
     } else {
-        log_internal_message("MacTCP driver was not opened by this application or already cleaned up.");
+        log_debug("MacTCP driver was not opened by this application or already cleaned up.");
     }
-    log_internal_message("Networking cleanup complete.");
+    log_debug("Networking cleanup complete.");
 }
 void YieldTimeToSystem(void)
 {
@@ -129,14 +129,14 @@ OSErr ParseIPv4(const char *ip_str, ip_addr *out_addr)
         char *endptr;
         parts[i] = strtoul(token, &endptr, 10);
         if (*endptr != '\0' || parts[i] > 255) {
-            log_internal_message("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
+            log_debug("ParseIPv4: Invalid part '%s' in IP string '%s'", token, ip_str);
             *out_addr = 0;
             return paramErr;
         }
         i++;
     }
     if (i != 4) {
-        log_internal_message("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
+        log_debug("ParseIPv4: Incorrect number of parts (%d) in IP string '%s'", i, ip_str);
         *out_addr = 0;
         return paramErr;
     }

--- a/classic_mac/main.c
+++ b/classic_mac/main.c
@@ -13,79 +13,123 @@
 #include <OSUtils.h>
 #include <Sound.h>
 #include <stdio.h>
-#include "logging.h"
+
+// Shared and platform-specific headers
+#include "../shared/logging.h"    // For shared log_init, log_shutdown, log_debug, log_app_event
+#include "../shared/protocol.h"   // For MSG_QUIT, etc.
+#include "logging.h"              // For Classic Mac platform-specific callback declarations (classic_mac_platform_...)
 #include "mactcp_network.h"
+#include "mactcp_discovery.h"
+#include "mactcp_messaging.h"
 #include "dialog.h"
-#include "peer.h"
 #include "dialog_peerlist.h"
 #include "dialog_input.h"
 #include "dialog_messages.h"
-#include "./mactcp_messaging.h"
-#include "mactcp_discovery.h"
-#include "../shared/protocol.h"
+#include "peer.h"
+
+// Global variables
 Boolean gDone = false;
 unsigned long gLastPeerListUpdateTime = 0;
-const unsigned long kPeerListUpdateIntervalTicks = 5 * 60;
-const unsigned long kQuitMessageDelayTicks = 120;
+
+// Constants
+const unsigned long kPeerListUpdateIntervalTicks = 5 * 60; // 5 seconds
+const unsigned long kQuitMessageDelayTicks = 120;          // 2 seconds
+
+// Forward declarations
 void InitializeToolbox(void);
 void MainEventLoop(void);
 void HandleEvent(EventRecord *event);
 void HandleIdleTasks(void);
-int main(void)
-{
+
+int main(void) {
     OSErr networkErr;
     Boolean dialogOk;
-    char ui_message_buffer[256];
-    log_init("csend_mac.log", classic_mac_platform_display_debug_log);
-    log_app_event("Starting Classic Mac P2P Messenger...");
+    char ui_message_buffer[256]; // For messages directly to UI, not through logger's debug display
+
+    // 1. Initialize platform-specific logging callbacks structure
+    platform_logging_callbacks_t classic_mac_log_callbacks = {
+        .get_timestamp = classic_mac_platform_get_timestamp,
+        .display_debug_log = classic_mac_platform_display_debug_log
+    };
+
+    // 2. Call shared log_init
+    // It's generally safe to call this early. If file opening fails, logging to file
+    // will be skipped, but UI logging (if enabled) and other functionalities can proceed.
+    log_init("csend_mac.log", &classic_mac_log_callbacks);
+    // set_debug_output_enabled(true); // Uncomment to have debug messages in UI by default
+
+    // 3. Standard Mac application initialization
     MaxApplZone();
-    log_internal_message("MaxApplZone called.");
-    InitializeToolbox();
-    log_internal_message("Toolbox Initialized.");
-    networkErr = InitializeNetworking();
+    InitializeToolbox(); // This calls InitGraf, InitFonts, etc.
+
+    // 4. Log application start and initial setup steps
+    log_app_event("Starting Classic Mac P2P Messenger...");
+    log_debug("MaxApplZone called.");
+    log_debug("Toolbox Initialized.");
+
+    // 5. Initialize networking
+    networkErr = InitializeNetworking(); // This function now uses log_debug internally
     if (networkErr != noErr) {
-        sprintf(ui_message_buffer, "Fatal: Network initialization failed (%d). Exiting.", (int)networkErr);
-        log_app_event("%s", ui_message_buffer);
+        // Log the fatal error. This will go to the file if it was opened.
+        log_app_event("Fatal: Network initialization failed (%d). Exiting.", (int)networkErr);
+        // Since the dialog isn't up, we can't use AppendToMessagesTE.
+        // A simple Alert could be shown here, or rely on the log file for post-mortem.
+        // Example: StopAlert(128, NULL); where 128 is an ALRT resource ID.
         log_shutdown();
         return 1;
     }
-    InitPeerList();
-    log_internal_message("Peer list data structure initialized.");
-    dialogOk = InitDialog();
+
+    // 6. Initialize peer list data structure
+    InitPeerList(); // This function might call log_debug
+    log_debug("Peer list data structure initialized.");
+
+    // 7. Initialize the main dialog window
+    dialogOk = InitDialog(); // This function now uses log_debug internally
     if (!dialogOk) {
         log_app_event("Fatal: Dialog initialization failed. Exiting.");
-        CleanupNetworking();
+        // Dialog init failed, so can't use AppendToMessagesTE.
+        CleanupNetworking(); // Clean up what was initialized
         log_shutdown();
         return 1;
     }
+
+    // 8. Display initial message in the dialog and log main loop entry
     AppendToMessagesTE("Classic Mac P2P Messenger Started.\r");
-    log_internal_message("Entering main event loop...");
+    log_debug("Entering main event loop...");
+
+    // 9. Run the main event loop
     MainEventLoop();
-    log_internal_message("Exited main event loop.");
+
+    // 10. Shutdown sequence
+    log_debug("Exited main event loop.");
     log_app_event("Initiating shutdown sequence...");
     AppendToMessagesTE("Shutting down...\r");
+
     int quit_sent_count = 0;
     int quit_active_peers = 0;
     OSErr last_quit_err = noErr;
     unsigned long dummyTimerForDelay;
+
+    // Send QUIT messages to active peers
     for (int i = 0; i < MAX_PEERS; i++) {
         if (gPeerManager.peers[i].active) {
             quit_active_peers++;
-            log_internal_message("Attempting to send QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
+            log_debug("Attempting to send QUIT to %s@%s", gPeerManager.peers[i].username, gPeerManager.peers[i].ip);
             OSErr current_quit_err = MacTCP_SendMessageSync(
                                          gPeerManager.peers[i].ip, "", MSG_QUIT, gMyUsername, gMyLocalIPStr, YieldTimeToSystem);
             if (current_quit_err == noErr) {
                 quit_sent_count++;
             } else {
-                log_internal_message("Failed to send QUIT to %s@%s: Error %d", gPeerManager.peers[i].username, gPeerManager.peers[i].ip, (int)current_quit_err);
+                log_debug("Failed to send QUIT to %s@%s: Error %d", gPeerManager.peers[i].username, gPeerManager.peers[i].ip, (int)current_quit_err);
                 if (last_quit_err == noErr || (last_quit_err == streamBusyErr && current_quit_err != streamBusyErr)) {
                     last_quit_err = current_quit_err;
                 }
             }
-            YieldTimeToSystem();
-            Delay(kQuitMessageDelayTicks, &dummyTimerForDelay);
+            YieldTimeToSystem(); // Give time for MacTCP to process
+            Delay(kQuitMessageDelayTicks, &dummyTimerForDelay); // Brief pause
         }
     }
+
     if (quit_active_peers > 0) {
         sprintf(ui_message_buffer, "Finished sending QUIT messages. Sent to %d of %d active peers. Last error (if any): %d", quit_sent_count, quit_active_peers, (int)last_quit_err);
         log_app_event("%s", ui_message_buffer);
@@ -95,69 +139,88 @@ int main(void)
         log_app_event("No active peers to send QUIT messages to.");
         AppendToMessagesTE("No active peers to send QUIT messages to.\r");
     }
+
     if (last_quit_err == streamBusyErr) {
-        log_internal_message("Warning: Sending QUIT messages encountered a stream busy error.");
+        log_debug("Warning: Sending QUIT messages encountered a stream busy error.");
     } else if (last_quit_err != noErr) {
-        log_internal_message("Warning: Sending QUIT messages encountered error: %d.", (int)last_quit_err);
+        log_debug("Warning: Sending QUIT messages encountered error: %d.", (int)last_quit_err);
     }
-    CleanupDialog();
-    CleanupNetworking();
+
+    // 11. Clean up resources
+    CleanupDialog();    // Uses log_debug internally
+    CleanupNetworking(); // Uses log_debug internally
+
     log_app_event("Application terminated gracefully.");
-    log_shutdown();
+    log_shutdown(); // Finalize and close the log file
     return 0;
 }
-void InitializeToolbox(void)
-{
+
+void InitializeToolbox(void) {
     InitGraf(&qd.thePort);
     InitFonts();
     InitWindows();
     InitMenus();
     TEInit();
-    InitDialogs(NULL);
+    InitDialogs(NULL); // Pass NULL for resumeProc
     InitCursor();
 }
-void MainEventLoop(void)
-{
+
+void MainEventLoop(void) {
     EventRecord event;
     Boolean gotEvent;
-    long sleepTime = 1L;
+    long sleepTime = 1L; // Minimal sleep for WaitNextEvent polling
+
     while (!gDone) {
+        // Handle background TE idling
         if (gMessagesTE != NULL) TEIdle(gMessagesTE);
-        IdleInputTE();
+        IdleInputTE(); // For the input TextEdit field
+
+        // Handle other periodic tasks
         HandleIdleTasks();
+
+        // Wait for an event
         gotEvent = WaitNextEvent(everyEvent, &event, sleepTime, NULL);
+
         if (gotEvent) {
             Boolean eventHandledByApp = false;
+
             if (event.what == mouseDown) {
                 WindowPtr whichWindow;
                 short windowPart = FindWindow(event.where, &whichWindow);
+
                 if (whichWindow == (WindowPtr)gMainWindow && windowPart == inContent) {
                     Point localPt = event.where;
                     ControlHandle foundControl;
                     short foundControlPart;
                     GrafPtr oldPort;
+
                     GetPort(&oldPort);
-                    SetPort(GetWindowPort(gMainWindow));
+                    SetPort(GetWindowPort(gMainWindow)); // Target the dialog's port
                     GlobalToLocal(&localPt);
+
+                    // Check for clicks in controls first
                     foundControlPart = FindControl(localPt, whichWindow, &foundControl);
+
                     if (foundControl == gMessagesScrollBar && foundControlPart != 0 &&
-                            (**foundControl).contrlVis && (**foundControl).contrlHilite == 0) {
-                        log_internal_message("MouseDown: Click in Messages Scrollbar (part %d).", foundControlPart);
-                        if (foundControlPart == kControlIndicatorPart) {
+                        (**foundControl).contrlVis && (**foundControl).contrlHilite == 0) {
+                        log_debug("MouseDown: Click in Messages Scrollbar (part %d).", foundControlPart);
+                        if (foundControlPart == kControlIndicatorPart) { // Thumb drag
                             short oldValue = GetControlValue(foundControl);
-                            TrackControl(foundControl, localPt, nil);
+                            TrackControl(foundControl, localPt, nil); // Use nil for direct tracking
                             short newValue = GetControlValue(foundControl);
-                            log_internal_message("MouseDown: Scrollbar thumb drag. OldVal=%d, NewVal=%d", oldValue, newValue);
+                            log_debug("MouseDown: Scrollbar thumb drag. OldVal=%d, NewVal=%d", oldValue, newValue);
                             if (newValue != oldValue) {
                                 ScrollMessagesTEToValue(newValue);
                             }
-                        } else {
-                            TrackControl(foundControl, localPt, &MyScrollAction);
+                        } else { // Click in arrows or page regions
+                            TrackControl(foundControl, localPt, &MyScrollAction); // Use action procedure
                         }
                         eventHandledByApp = true;
                     } else if (gPeerListHandle != NULL && PtInRect(localPt, &(**gPeerListHandle).rView)) {
+                        // Click in Peer List (List Manager user item)
                         eventHandledByApp = HandlePeerListClick(gMainWindow, &event);
                     } else {
+                        // Check for click in Input TextEdit user item
                         Rect inputTERectDITL;
                         DialogItemType itemTypeDITL;
                         Handle itemHandleDITL;
@@ -167,9 +230,11 @@ void MainEventLoop(void)
                             eventHandledByApp = true;
                         }
                     }
-                    SetPort(oldPort);
+                    SetPort(oldPort); // Restore original port
                 }
             }
+
+            // If not handled by specific content clicks, try DialogSelect for DITL items
             if (!eventHandledByApp) {
                 if (IsDialogEvent(&event)) {
                     DialogPtr whichDialog;
@@ -182,6 +247,7 @@ void MainEventLoop(void)
                             Rect itemRect;
                             GrafPtr oldPortForDrawing;
                             short currentValue;
+
                             switch (itemHit) {
                             case kSendButton:
                                 HandleSendButtonClick();
@@ -191,10 +257,12 @@ void MainEventLoop(void)
                                 if (itemHandle && itemType == (ctrlItem + chkCtrl)) {
                                     controlH = (ControlHandle)itemHandle;
                                     currentValue = GetControlValue(controlH);
-                                    SetControlValue(controlH, !currentValue);
+                                    SetControlValue(controlH, !currentValue); // Toggle
                                     Boolean newState = (GetControlValue(controlH) == 1);
-                                    set_debug_output_enabled(newState);
-                                    log_internal_message("Debug output %s.", newState ? "ENABLED" : "DISABLED");
+                                    set_debug_output_enabled(newState); // Update shared log state
+                                    log_debug("Debug output %s.", newState ? "ENABLED" : "DISABLED");
+
+                                    // Redraw the checkbox
                                     GetPort(&oldPortForDrawing);
                                     SetPort(GetWindowPort(gMainWindow));
                                     InvalRect(&itemRect);
@@ -206,13 +274,14 @@ void MainEventLoop(void)
                                 if (itemHandle && itemType == (ctrlItem + chkCtrl)) {
                                     controlH = (ControlHandle)itemHandle;
                                     currentValue = GetControlValue(controlH);
-                                    SetControlValue(controlH, !currentValue);
-                                    if (GetControlValue(controlH) == 1) {
-                                        log_internal_message("Broadcast checkbox checked. Deselecting peer.");
-                                        DialogPeerList_DeselectAll();
+                                    SetControlValue(controlH, !currentValue); // Toggle
+                                    if (GetControlValue(controlH) == 1) { // If now checked
+                                        log_debug("Broadcast checkbox checked. Deselecting peer.");
+                                        DialogPeerList_DeselectAll(); // Unselect any peer
                                     } else {
-                                        log_internal_message("Broadcast checkbox unchecked.");
+                                        log_debug("Broadcast checkbox unchecked.");
                                     }
+                                    // Redraw the checkbox
                                     GetPort(&oldPortForDrawing);
                                     SetPort(GetWindowPort(gMainWindow));
                                     InvalRect(&itemRect);
@@ -220,103 +289,133 @@ void MainEventLoop(void)
                                 }
                                 break;
                             case kMessagesScrollbar:
-                                log_internal_message("WARNING: DialogSelect returned kMessagesScrollbar for itemHit.");
+                                // This case should ideally be handled by FindControl/TrackControl above
+                                // if it's a direct click on the scrollbar parts.
+                                // DialogSelect returning a scrollbar itemHit is less common for active parts.
+                                log_debug("WARNING: DialogSelect returned kMessagesScrollbar for itemHit %d.", itemHit);
                                 break;
                             default:
-                                log_internal_message("DialogSelect unhandled item: %d", itemHit);
+                                log_debug("DialogSelect unhandled item: %d", itemHit);
                                 break;
                             }
                         }
-                        eventHandledByApp = true;
+                        eventHandledByApp = true; // DialogSelect handled it
                     }
                 }
             }
+
+            // If still not handled, pass to generic event handler
             if (!eventHandledByApp) {
                 HandleEvent(&event);
             }
-        } else {
-            HandleIdleTasks();
+        } else { // No event from WaitNextEvent
+            HandleIdleTasks(); // Perform idle tasks if no event occurred
         }
     }
 }
-void HandleIdleTasks(void)
-{
+
+void HandleIdleTasks(void) {
     unsigned long currentTimeTicks = TickCount();
-    PollUDPListener(gMacTCPRefNum, gMyLocalIP);
-    PollTCP(YieldTimeToSystem);
+
+    // Poll network services
+    PollUDPListener(gMacTCPRefNum, gMyLocalIP); // For discovery packets
+    PollTCP(YieldTimeToSystem);                 // For incoming TCP messages/connections
+
+    // Periodically send discovery broadcast
     CheckSendBroadcast(gMacTCPRefNum, gMyUsername, gMyLocalIPStr);
-    if (gLastPeerListUpdateTime == 0 || (currentTimeTicks < gLastPeerListUpdateTime) ||
-            (currentTimeTicks - gLastPeerListUpdateTime) >= kPeerListUpdateIntervalTicks) {
-        if (gPeerListHandle != NULL) UpdatePeerDisplayList(false);
+
+    // Periodically update the peer list display (prunes timed-out peers internally)
+    if (gLastPeerListUpdateTime == 0 ||                               // First time
+        (currentTimeTicks < gLastPeerListUpdateTime) ||               // TickCount wrapped
+        (currentTimeTicks - gLastPeerListUpdateTime) >= kPeerListUpdateIntervalTicks) {
+        if (gPeerListHandle != NULL) {
+            UpdatePeerDisplayList(false); // false = don't force redraw if no data change
+        }
         gLastPeerListUpdateTime = currentTimeTicks;
     }
 }
-void HandleEvent(EventRecord *event)
-{
+
+void HandleEvent(EventRecord *event) {
     short windowPart;
     WindowPtr whichWindow;
+
     switch (event->what) {
     case mouseDown:
         windowPart = FindWindow(event->where, &whichWindow);
         switch (windowPart) {
         case inMenuBar:
+            // Menu handling would go here if menus were implemented
+            // e.g., DoMenuCommand(MenuSelect(event->where));
             break;
-        case inSysWindow:
+        case inSysWindow: // Click in a Desk Accessory window
             SystemClick(event, whichWindow);
             break;
-        case inDrag:
+        case inDrag: // Click in title bar to drag
             if (whichWindow == (WindowPtr)gMainWindow)
                 DragWindow(whichWindow, event->where, &qd.screenBits.bounds);
             break;
-        case inGoAway:
+        case inGoAway: // Click in close box
             if (whichWindow == (WindowPtr)gMainWindow && TrackGoAway(whichWindow, event->where)) {
-                log_internal_message("Close box clicked. Setting gDone = true.");
-                gDone = true;
+                log_debug("Close box clicked. Setting gDone = true.");
+                gDone = true; // Signal to exit main loop
             }
             break;
-        case inContent:
+        case inContent: // Click in content area not handled by DialogSelect or specific checks
             if (whichWindow != FrontWindow()) {
-                SelectWindow(whichWindow);
+                SelectWindow(whichWindow); // Bring it to front
             } else {
-                log_internal_message("HandleEvent: mouseDown in content of front window (unhandled by specific checks).");
+                // If it's our main window and click wasn't handled, it might be a click
+                // in an empty area or an unhandled part of a user item.
+                log_debug("HandleEvent: mouseDown in content of front window (unhandled by specific checks).");
             }
             break;
         default:
-            log_internal_message("HandleEvent: mouseDown in unknown window part: %d", windowPart);
+            log_debug("HandleEvent: mouseDown in unknown window part: %d", windowPart);
             break;
         }
         break;
+
     case keyDown:
     case autoKey:
+        // Handle key events, primarily for TextEdit in the input field
         if (HandleInputTEKeyDown(event)) {
+            // Event was handled by the input TE (e.g., character typed)
         } else {
+            // Key event not handled by input TE (e.g., command key, or TE not active)
+            // Could add global key commands here if needed
         }
         break;
-    case updateEvt:
+
+    case updateEvt: // Window needs to be redrawn
         whichWindow = (WindowPtr)event->message;
         BeginUpdate(whichWindow);
         if (whichWindow == (WindowPtr)gMainWindow) {
-            DrawDialog(whichWindow);
-            UpdateDialogControls();
+            DrawDialog(whichWindow);    // Redraws standard dialog items
+            UpdateDialogControls();     // Redraws custom user items (TEs, List)
         }
+        // Could handle updates for other windows here if any
         EndUpdate(whichWindow);
         break;
-    case activateEvt:
+
+    case activateEvt: // Window activation/deactivation
         whichWindow = (WindowPtr)event->message;
         if (whichWindow == (WindowPtr)gMainWindow) {
             Boolean becomingActive = ((event->modifiers & activeFlag) != 0);
-            ActivateDialogTE(becomingActive);
-            ActivatePeerList(becomingActive);
+            ActivateDialogTE(becomingActive);     // Activate/deactivate TEs
+            ActivatePeerList(becomingActive);     // Activate/deactivate List Manager
+            // Activate/deactivate scrollbar
             if (gMessagesScrollBar != NULL) {
                 short maxScroll = GetControlMaximum(gMessagesScrollBar);
-                short hiliteValue = 255;
+                short hiliteValue = 255; // Dimmed (inactive)
                 if (becomingActive && maxScroll > 0 && (**gMessagesScrollBar).contrlVis) {
-                    hiliteValue = 0;
+                    hiliteValue = 0; // Active
                 }
                 HiliteControl(gMessagesScrollBar, hiliteValue);
             }
         }
         break;
+
+    // Other event types (diskEvt, osEvt, etc.) can be handled here if needed
     default:
         break;
     }

--- a/classic_mac/peer.c
+++ b/classic_mac/peer.c
@@ -18,22 +18,22 @@ Boolean MarkPeerInactive(const char *ip)
     int index = peer_shared_find_by_ip(&gPeerManager, ip);
     if (index != -1) {
         if (gPeerManager.peers[index].active) {
-            log_internal_message("Marking peer %s@%s as inactive due to QUIT message.", gPeerManager.peers[index].username, ip);
+            log_debug("Marking peer %s@%s as inactive due to QUIT message.", gPeerManager.peers[index].username, ip);
             gPeerManager.peers[index].active = 0;
             return true;
         } else {
-            log_to_file_only("MarkPeerInactive: Peer %s was already inactive.", ip);
+            log_debug("MarkPeerInactive: Peer %s was already inactive.", ip);
             return false;
         }
     }
-    log_to_file_only("MarkPeerInactive: Peer %s not found in list.", ip);
+    log_debug("MarkPeerInactive: Peer %s not found in list.", ip);
     return false;
 }
 void PruneTimedOutPeers(void)
 {
     int pruned_count = peer_shared_prune_timed_out(&gPeerManager);
     if (pruned_count > 0) {
-        log_internal_message("Pruned %d timed-out peer(s).", pruned_count);
+        log_debug("Pruned %d timed-out peer(s).", pruned_count);
     }
 }
 Boolean GetPeerByIndex(int active_index, peer_t *out_peer)

--- a/posix/logging.c
+++ b/posix/logging.c
@@ -1,19 +1,21 @@
-#include "logging.h"
+#include "logging.h" // For local declarations if any, or just for consistency
+#include "../shared/logging.h" // To ensure types match if we were to use them here
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
 #include <time.h>
-#define MAX_LOG_LINE_LENGTH_POSIX 1024
-#define USER_MESSAGE_BUFFER_SIZE_POSIX (MAX_LOG_LINE_LENGTH_POSIX - 60)
-#define TIMESTAMP_BUFFER_SIZE_POSIX 20
-static FILE *g_platform_log_file_posix = NULL;
-static char g_log_file_name_posix[256];
-static void get_platform_timestamp(char *buffer, size_t buffer_size)
-{
+#include <stdarg.h> // Only if we were to re-implement log_debug/log_app_event here
+
+// Buffer sizes are now primarily managed in shared/logging.c
+// We only need TIMESTAMP_BUFFER_SIZE_POSIX if get_platform_timestamp uses it locally,
+// but it's better if it respects the passed buffer_size.
+
+void posix_platform_get_timestamp(char *buffer, size_t buffer_size) {
     time_t now;
     struct tm *local_time_info;
+
     time(&now);
     local_time_info = localtime(&now);
+
     if (local_time_info != NULL) {
         strftime(buffer, buffer_size, "%Y-%m-%d %H:%M:%S", local_time_info);
     } else {
@@ -21,83 +23,15 @@ static void get_platform_timestamp(char *buffer, size_t buffer_size)
         if (buffer_size > 0) buffer[buffer_size - 1] = '\0';
     }
 }
-void posix_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body)
-{
+
+void posix_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body) {
+    // This function is called by the shared logger when debug UI output is enabled.
+    // It should print to the console.
     printf("%s%s\n", timestamp_and_prefix, message_body);
     fflush(stdout);
 }
-void log_init(const char *log_file_name_suggestion, platform_display_debug_log_func_t display_func)
-{
-    if (g_platform_log_file_posix != NULL) {
-        fclose(g_platform_log_file_posix);
-        g_platform_log_file_posix = NULL;
-    }
-    if (log_file_name_suggestion) {
-        strncpy(g_log_file_name_posix, log_file_name_suggestion, sizeof(g_log_file_name_posix) - 1);
-        g_log_file_name_posix[sizeof(g_log_file_name_posix) - 1] = '\0';
-    } else {
-        strcpy(g_log_file_name_posix, "csend_posix.log");
-    }
-    g_platform_log_file_posix = fopen(g_log_file_name_posix, "a");
-    if (g_platform_log_file_posix == NULL) {
-        perror("Error opening log file");
-    } else {
-        char timestamp[TIMESTAMP_BUFFER_SIZE_POSIX];
-        get_platform_timestamp(timestamp, sizeof(timestamp));
-        fprintf(g_platform_log_file_posix, "\n--- [%s] Log Session Started ---\n", timestamp);
-        fflush(g_platform_log_file_posix);
-    }
-    shared_logging_set_platform_callback(display_func);
-}
-void log_shutdown(void)
-{
-    if (g_platform_log_file_posix != NULL) {
-        char timestamp[TIMESTAMP_BUFFER_SIZE_POSIX];
-        get_platform_timestamp(timestamp, sizeof(timestamp));
-        fprintf(g_platform_log_file_posix, "--- [%s] Log Session Ended ---\n\n", timestamp);
-        fflush(g_platform_log_file_posix);
-        fclose(g_platform_log_file_posix);
-        g_platform_log_file_posix = NULL;
-    }
-    shared_logging_clear_platform_callback();
-}
-void log_internal_message(const char *format, ...)
-{
-    char message_body[USER_MESSAGE_BUFFER_SIZE_POSIX];
-    char timestamp_str[TIMESTAMP_BUFFER_SIZE_POSIX];
-    char full_log_message[MAX_LOG_LINE_LENGTH_POSIX];
-    char timestamp_and_prefix_for_ui[TIMESTAMP_BUFFER_SIZE_POSIX + 10];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(message_body, USER_MESSAGE_BUFFER_SIZE_POSIX, format, args);
-    va_end(args);
-    get_platform_timestamp(timestamp_str, sizeof(timestamp_str));
-    if (g_platform_log_file_posix != NULL) {
-        snprintf(full_log_message, MAX_LOG_LINE_LENGTH_POSIX, "%s [DEBUG] %s", timestamp_str, message_body);
-        fprintf(g_platform_log_file_posix, "%s\n", full_log_message);
-        fflush(g_platform_log_file_posix);
-    }
-    if (is_debug_output_enabled()) {
-        platform_display_debug_log_func_t display_func = shared_logging_get_platform_callback();
-        if (display_func != NULL) {
-            snprintf(timestamp_and_prefix_for_ui, sizeof(timestamp_and_prefix_for_ui), "%s [DEBUG] ", timestamp_str);
-            display_func(timestamp_and_prefix_for_ui, message_body);
-        }
-    }
-}
-void log_app_event(const char *format, ...)
-{
-    char message_body[USER_MESSAGE_BUFFER_SIZE_POSIX];
-    char timestamp_str[TIMESTAMP_BUFFER_SIZE_POSIX];
-    char full_log_message[MAX_LOG_LINE_LENGTH_POSIX];
-    va_list args;
-    va_start(args, format);
-    vsnprintf(message_body, USER_MESSAGE_BUFFER_SIZE_POSIX, format, args);
-    va_end(args);
-    get_platform_timestamp(timestamp_str, sizeof(timestamp_str));
-    if (g_platform_log_file_posix != NULL) {
-        snprintf(full_log_message, MAX_LOG_LINE_LENGTH_POSIX, "%s %s", timestamp_str, message_body);
-        fprintf(g_platform_log_file_posix, "%s\n", full_log_message);
-        fflush(g_platform_log_file_posix);
-    }
-}
+
+// The log_init, log_shutdown, log_debug (formerly log_internal_message),
+// and log_app_event functions are now primarily in shared/logging.c.
+// The platform-specific main.c will call the shared log_init with
+// pointers to the above callback functions.

--- a/posix/logging.h
+++ b/posix/logging.h
@@ -1,5 +1,16 @@
-#ifndef POSIX_LOGGING_H_WRAPPER
-#define POSIX_LOGGING_H_WRAPPER
-#include "../shared/logging.h"
+#ifndef POSIX_LOGGING_H
+#define POSIX_LOGGING_H
+
+#include <stddef.h> // For size_t
+
+// Platform-specific implementation for getting a timestamp.
+void posix_platform_get_timestamp(char *buffer, size_t buffer_size);
+
+// Platform-specific implementation for displaying a debug log message on the terminal.
 void posix_platform_display_debug_log(const char *timestamp_and_prefix, const char *message_body);
-#endif
+
+// No need for posix_log_init or posix_log_shutdown declarations here,
+// as main.c will call the shared log_init/log_shutdown directly.
+// These functions are the callbacks themselves.
+
+#endif // POSIX_LOGGING_H

--- a/posix/main.c
+++ b/posix/main.c
@@ -2,61 +2,131 @@
 #include "discovery.h"
 #include "messaging.h"
 #include "ui_terminal.h"
-#include "logging.h"
-#include "../shared/logging.h"
+#include "logging.h"             // For POSIX platform-specific callback declarations
+#include "../shared/logging.h"   // For shared log_init, log_shutdown, log_debug, log_app_event
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <pthread.h>
-int main(int argc, char *argv[])
-{
-    app_state_t state;
-    pthread_t listener_tid, discovery_tid, input_tid;
+#include <signal.h> // For sigaction in init_app_state, though it's in peer.c
+
+// app_state_t is defined in peer.h, g_state is also there.
+
+int main(int argc, char *argv[]) {
+    app_state_t state; // g_state will be set in init_app_state
+    pthread_t listener_tid = 0, discovery_tid = 0, input_tid = 0;
     char username[32] = "anonymous";
+
     if (argc > 1) {
         strncpy(username, argv[1], sizeof(username) - 1);
         username[sizeof(username) - 1] = '\0';
     }
+
+    // 1. Initialize platform-specific logging callbacks structure
+    platform_logging_callbacks_t posix_log_callbacks = {
+        .get_timestamp = posix_platform_get_timestamp,
+        .display_debug_log = posix_platform_display_debug_log
+    };
+
+    // 2. Call shared log_init
+    log_init("csend_posix.log", &posix_log_callbacks);
+    // set_debug_output_enabled(true); // Uncomment to have debug messages in UI by default
+
+    // 3. Initialize application state (includes signal handlers via g_state)
+    // init_app_state itself might call log_debug, so log_init should be called before it.
     init_app_state(&state, username);
-    log_init("csend_posix.log", posix_platform_display_debug_log);
+
+    // 4. Log application start
     log_app_event("Starting P2P messaging application as '%s'", state.username);
     terminal_display_app_message("Starting P2P messaging application as '%s'", state.username);
+
+    // 5. Initialize network listeners
     if (init_listener(&state) < 0) {
-        log_internal_message("Fatal: Failed to initialize TCP listener. Exiting.");
+        // log_debug is used inside init_listener for detailed errors
+        log_app_event("Fatal: Failed to initialize TCP listener. Exiting."); // More user-facing summary
         cleanup_app_state(&state);
         log_shutdown();
         return EXIT_FAILURE;
     }
     if (init_discovery(&state) < 0) {
-        log_internal_message("Fatal: Failed to initialize UDP discovery. Exiting.");
+        // log_debug is used inside init_discovery for detailed errors
+        log_app_event("Fatal: Failed to initialize UDP discovery. Exiting."); // More user-facing summary
         cleanup_app_state(&state);
         log_shutdown();
         return EXIT_FAILURE;
     }
+
+    // 6. Create threads
     int listener_err = pthread_create(&listener_tid, NULL, listener_thread, &state);
     int discovery_err = pthread_create(&discovery_tid, NULL, discovery_thread, &state);
     int input_err = pthread_create(&input_tid, NULL, user_input_thread, &state);
+
     if (listener_err != 0 || discovery_err != 0 || input_err != 0) {
-        log_internal_message("Fatal: Failed to create one or more threads. Exiting.");
-        state.running = 0;
+        log_app_event("Fatal: Failed to create one or more threads. Exiting.");
+        state.running = 0; // Signal all threads to stop
+
+        // Attempt to join threads that might have started to ensure clean exit
+        // It's a bit tricky if some created and others failed.
+        // pthread_cancel could be used, but join is generally preferred if threads check 'running'.
+        if (input_err == 0 && input_tid != 0) {
+             // listener_thread and discovery_thread use select() with timeout,
+             // and check state.running. input_thread also uses select().
+             // Setting state.running = 0 should make them exit.
+             // If they block indefinitely, pthread_cancel might be needed, but that's more complex.
+            log_debug("Cancelling input thread due to other thread creation failure.");
+            pthread_cancel(input_tid); // Or signal it in a more graceful way if possible
+        }
+        if (discovery_err == 0 && discovery_tid != 0) {
+            log_debug("Cancelling discovery thread due to other thread creation failure.");
+            pthread_cancel(discovery_tid);
+        }
+        if (listener_err == 0 && listener_tid != 0) {
+            log_debug("Cancelling listener thread due to other thread creation failure.");
+            pthread_cancel(listener_tid);
+        }
+        
+        // Wait for them to actually exit
+        if (input_err == 0 && input_tid != 0) pthread_join(input_tid, NULL);
+        if (discovery_err == 0 && discovery_tid != 0) pthread_join(discovery_tid, NULL);
+        if (listener_err == 0 && listener_tid != 0) pthread_join(listener_tid, NULL);
+
         cleanup_app_state(&state);
         log_shutdown();
         return EXIT_FAILURE;
     }
-    log_internal_message("Threads created successfully.");
+
+    log_debug("All application threads created successfully.");
+
+    // 7. Wait for user input thread to terminate (e.g., on /quit command)
     pthread_join(input_tid, NULL);
-    log_internal_message("User input thread finished. Initiating shutdown...");
-    state.running = 0;
-    log_internal_message("Waiting for listener thread to finish...");
-    pthread_join(listener_tid, NULL);
-    log_internal_message("Listener thread joined.");
-    log_internal_message("Waiting for discovery thread to finish...");
-    pthread_join(discovery_tid, NULL);
-    log_internal_message("Discovery thread joined.");
-    cleanup_app_state(&state);
+    log_debug("User input thread finished. Main thread initiating shutdown...");
+
+    // 8. Signal other threads to stop and wait for them
+    // state.running should have been set to 0 by the input_thread or a signal handler
+    if (state.running) { // If not already set by quit or signal
+        log_debug("Main thread explicitly setting running=0.");
+        state.running = 0;
+    }
+
+    // The select calls in listener and discovery threads have timeouts,
+    // so they will check state.running periodically.
+    // Closing sockets can also help unblock them if they are in a blocking recv/accept.
+    // This is handled in cleanup_app_state.
+
+    log_debug("Main thread: Waiting for listener thread to join...");
+    if (listener_tid != 0) pthread_join(listener_tid, NULL);
+    log_debug("Main thread: Listener thread joined.");
+
+    log_debug("Main thread: Waiting for discovery thread to join...");
+    if (discovery_tid != 0) pthread_join(discovery_tid, NULL);
+    log_debug("Main thread: Discovery thread joined.");
+
+    // 9. Clean up resources
+    cleanup_app_state(&state); // This closes sockets, destroys mutex
     log_app_event("Application terminated gracefully.");
     terminal_display_app_message("Application terminated gracefully.");
-    log_shutdown();
+    log_shutdown(); // Finalize and close the log file
+
     return EXIT_SUCCESS;
 }

--- a/posix/messaging.c
+++ b/posix/messaging.c
@@ -2,6 +2,7 @@
 #include "network.h"
 #include "../shared/protocol.h"
 #include "../shared/messaging.h"
+#include "../shared/logging.h"
 #include "logging.h"
 #include "ui_terminal.h"
 #include <stdio.h>
@@ -18,7 +19,7 @@ static int posix_tcp_add_or_update_peer(const char *ip, const char *username, vo
 {
     app_state_t *state = (app_state_t *)platform_context;
     if (!state) {
-        log_internal_message("Error (posix_tcp_add_or_update_peer): NULL platform_context.");
+        log_debug("Error (posix_tcp_add_or_update_peer): NULL platform_context.");
         return -1;
     }
     return add_peer(state, ip, username);
@@ -33,7 +34,7 @@ static void posix_tcp_mark_peer_inactive(const char *ip, void *platform_context)
 {
     app_state_t *state = (app_state_t *)platform_context;
     if (!state || !ip) {
-        log_internal_message("Error (posix_tcp_mark_peer_inactive): NULL platform_context or IP.");
+        log_debug("Error (posix_tcp_mark_peer_inactive): NULL platform_context or IP.");
         return;
     }
     pthread_mutex_lock(&state->peers_mutex);
@@ -41,12 +42,12 @@ static void posix_tcp_mark_peer_inactive(const char *ip, void *platform_context)
     if (index != -1) {
         if (state->peer_manager.peers[index].active) {
             state->peer_manager.peers[index].active = 0;
-            log_internal_message("Marked peer %s@%s as inactive.", state->peer_manager.peers[index].username, ip);
+            log_debug("Marked peer %s@%s as inactive.", state->peer_manager.peers[index].username, ip);
         } else {
-            log_internal_message("posix_tcp_mark_peer_inactive: Peer %s was already inactive.", ip);
+            log_debug("posix_tcp_mark_peer_inactive: Peer %s was already inactive.", ip);
         }
     } else {
-        log_internal_message("posix_tcp_mark_peer_inactive: Peer %s not found.", ip);
+        log_debug("posix_tcp_mark_peer_inactive: Peer %s not found.", ip);
     }
     pthread_mutex_unlock(&state->peers_mutex);
 }
@@ -79,7 +80,7 @@ int init_listener(app_state_t *state)
         state->tcp_socket = -1;
         return -1;
     }
-    log_internal_message("TCP listener initialized on port %d", PORT_TCP);
+    log_debug("TCP listener initialized on port %d", PORT_TCP);
     return 0;
 }
 int send_message(const char *ip, const char *message, const char *msg_type, const char *sender_username)
@@ -103,17 +104,17 @@ int send_message(const char *ip, const char *message, const char *msg_type, cons
         return -1;
     }
     if (connect(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-        log_internal_message("Failed to connect to %s:%d - %s", ip, PORT_TCP, strerror(errno));
+        log_debug("Failed to connect to %s:%d - %s", ip, PORT_TCP, strerror(errno));
         close(sock);
         return -1;
     }
     if (get_local_ip(local_ip, INET_ADDRSTRLEN) < 0) {
-        log_internal_message("Warning: send_message failed to get local IP. Using 'unknown'.");
+        log_debug("Warning: send_message failed to get local IP. Using 'unknown'.");
         strcpy(local_ip, "unknown");
     }
     formatted_len = format_message(buffer, BUFFER_SIZE, msg_type, sender_username, local_ip, message);
     if (formatted_len <= 0) {
-        log_internal_message("Error: Failed to format outgoing message (buffer too small?).");
+        log_debug("Error: Failed to format outgoing message (buffer too small?).");
         close(sock);
         return -1;
     }
@@ -145,7 +146,7 @@ void *listener_thread(void *arg)
         .display_text_message = posix_tcp_display_text_message,
         .mark_peer_inactive = posix_tcp_mark_peer_inactive
     };
-    log_internal_message("Listener thread started");
+    log_debug("Listener thread started");
     while (state->running) {
         FD_ZERO(&readfds);
         FD_SET(state->tcp_socket, &readfds);
@@ -169,7 +170,7 @@ void *listener_thread(void *arg)
             continue;
         }
         inet_ntop(AF_INET, &client_addr.sin_addr, sender_ip, INET_ADDRSTRLEN);
-        log_internal_message("Accepted connection from %s", sender_ip);
+        log_debug("Accepted connection from %s", sender_ip);
         memset(buffer, 0, BUFFER_SIZE);
         bytes_read = read(client_sock, buffer, BUFFER_SIZE - 1);
         if (bytes_read > 0) {
@@ -177,10 +178,10 @@ void *listener_thread(void *arg)
                 handle_received_tcp_message(sender_ip, sender_username, msg_type, content,
                                             &posix_callbacks, state);
             } else {
-                log_internal_message("Failed to parse TCP message from %s (%ld bytes)", sender_ip, bytes_read);
+                log_debug("Failed to parse TCP message from %s (%ld bytes)", sender_ip, bytes_read);
             }
         } else if (bytes_read == 0) {
-            log_internal_message("Peer %s disconnected.", sender_ip);
+            log_debug("Peer %s disconnected.", sender_ip);
         } else {
             if (state->running) {
                 perror("TCP read failed");
@@ -188,6 +189,6 @@ void *listener_thread(void *arg)
         }
         close(client_sock);
     }
-    log_internal_message("Listener thread stopped");
+    log_debug("Listener thread stopped");
     return NULL;
 }

--- a/posix/peer.c
+++ b/posix/peer.c
@@ -27,20 +27,20 @@ void init_app_state(app_state_t *state, const char *username)
 }
 void cleanup_app_state(app_state_t *state)
 {
-    log_internal_message("Starting POSIX cleanup...");
+    log_debug("Starting POSIX cleanup...");
     if (state->tcp_socket >= 0) {
-        log_internal_message("Closing TCP socket %d", state->tcp_socket);
+        log_debug("Closing TCP socket %d", state->tcp_socket);
         close(state->tcp_socket);
         state->tcp_socket = -1;
     }
     if (state->udp_socket >= 0) {
-        log_internal_message("Closing UDP socket %d", state->udp_socket);
+        log_debug("Closing UDP socket %d", state->udp_socket);
         close(state->udp_socket);
         state->udp_socket = -1;
     }
-    log_internal_message("Destroying peers mutex");
+    log_debug("Destroying peers mutex");
     pthread_mutex_destroy(&state->peers_mutex);
-    log_internal_message("POSIX cleanup complete");
+    log_debug("POSIX cleanup complete");
     g_state = NULL;
 }
 int add_peer(app_state_t *state, const char *ip, const char *username)

--- a/posix/signal_handler.c
+++ b/posix/signal_handler.c
@@ -1,12 +1,12 @@
 #include "signal_handler.h"
 #include "peer.h"
-#include "logging.h"
+#include "../shared/logging.h"
 void handle_signal(int sig)
 {
     if (g_state != NULL) {
         g_state->running = 0;
     } else {
-        log_internal_message("Warning: Received signal %d before application state was fully initialized.", sig);
+        log_debug("Warning: Received signal %d before application state was fully initialized.", sig);
     }
-    log_internal_message("Received signal %d. Initiating graceful shutdown...", sig);
+    log_debug("Received signal %d. Initiating graceful shutdown...", sig);
 }

--- a/posix/ui_terminal.c
+++ b/posix/ui_terminal.c
@@ -33,7 +33,7 @@ void print_peers(app_state_t *state)
     for (int i = 0; i < MAX_PEERS; i++) {
         if (state->peer_manager.peers[i].active) {
             if (difftime(now, state->peer_manager.peers[i].last_seen) > PEER_TIMEOUT) {
-                log_internal_message("Peer %s@%s timed out (detected in print_peers).",
+                log_debug("Peer %s@%s timed out (detected in print_peers).",
                                      state->peer_manager.peers[i].username,
                                      state->peer_manager.peers[i].ip);
                 state->peer_manager.peers[i].active = 0;
@@ -106,7 +106,7 @@ int handle_command(app_state_t *state, const char *input)
         pthread_mutex_unlock(&state->peers_mutex);
         if (found) {
             if (send_message(target_ip, msg_start, MSG_TEXT, state->username) < 0) {
-                log_internal_message("Failed to send message to %s", target_ip);
+                log_debug("Failed to send message to %s", target_ip);
             } else {
                 log_app_event("Message sent to peer %d (%s)", peer_num_input, target_ip);
                 terminal_display_app_message("Message sent to peer %d (%s)", peer_num_input, target_ip);
@@ -126,7 +126,7 @@ int handle_command(app_state_t *state, const char *input)
             if (state->peer_manager.peers[i].active &&
                     (difftime(time(NULL), state->peer_manager.peers[i].last_seen) <= PEER_TIMEOUT)) {
                 if (send_message(state->peer_manager.peers[i].ip, message_content, MSG_TEXT, state->username) < 0) {
-                    log_internal_message("Failed to send broadcast message to %s", state->peer_manager.peers[i].ip);
+                    log_debug("Failed to send broadcast message to %s", state->peer_manager.peers[i].ip);
                 } else {
                     sent_count++;
                 }
@@ -137,27 +137,27 @@ int handle_command(app_state_t *state, const char *input)
         terminal_display_app_message("Broadcast message sent to %d active peer(s).", sent_count);
         return 0;
     } else if (strcmp(input, "/quit") == 0) {
-        log_internal_message("Initiating quit sequence...");
+        log_debug("Initiating quit sequence...");
         pthread_mutex_lock(&state->peers_mutex);
-        log_internal_message("Sending QUIT notifications to peers...");
+        log_debug("Sending QUIT notifications to peers...");
         int notify_count = 0;
         for (int i = 0; i < MAX_PEERS; i++) {
             if (state->peer_manager.peers[i].active) {
                 if (send_message(state->peer_manager.peers[i].ip, "", MSG_QUIT, state->username) < 0) {
-                    log_internal_message("Failed to send quit notification to %s", state->peer_manager.peers[i].ip);
+                    log_debug("Failed to send quit notification to %s", state->peer_manager.peers[i].ip);
                 } else {
                     notify_count++;
                 }
             }
         }
         pthread_mutex_unlock(&state->peers_mutex);
-        log_internal_message("Quit notifications sent to %d peer(s).", notify_count);
+        log_debug("Quit notifications sent to %d peer(s).", notify_count);
         if (g_state) {
             g_state->running = 0;
         } else {
             state->running = 0;
         }
-        log_internal_message("Exiting application via /quit command...");
+        log_debug("Exiting application via /quit command...");
         return 1;
     } else {
         log_app_event("Unknown command: '%s'. Type /help for available commands.", input);
@@ -197,7 +197,7 @@ void *user_input_thread(void *arg)
         if (fgets(input, BUFFER_SIZE, stdin) == NULL) {
             if (state->running) {
                 if (feof(stdin)) {
-                    log_internal_message("EOF detected on stdin. Exiting input loop.");
+                    log_debug("EOF detected on stdin. Exiting input loop.");
                     if (g_state) g_state->running = 0;
                     else state->running = 0;
                 } else {
@@ -218,7 +218,7 @@ void *user_input_thread(void *arg)
         printf("> ");
         fflush(stdout);
     }
-    log_internal_message("User input thread stopped.");
+    log_debug("User input thread stopped.");
     return NULL;
 }
 void terminal_display_app_message(const char *format, ...)

--- a/shared/discovery.c
+++ b/shared/discovery.c
@@ -13,37 +13,37 @@ void discovery_logic_process_packet(const char *buffer, int len,
     char content[BUFFER_SIZE];
     int add_result;
     if (!callbacks || !callbacks->add_or_update_peer_callback || !callbacks->send_response_callback || !callbacks->notify_peer_list_updated_callback) {
-        log_internal_message("Error (discovery_logic): Invalid callbacks provided.");
+        log_debug("Error (discovery_logic): Invalid callbacks provided.");
         return;
     }
     if (parse_message(buffer, len, sender_ip_from_payload, sender_username, msg_type, content) != 0) {
-        log_internal_message("Discarding invalid/unknown UDP msg from %s (%d bytes) - parse failed.", sender_ip_str, len);
+        log_debug("Discarding invalid/unknown UDP msg from %s (%d bytes) - parse failed.", sender_ip_str, len);
         return;
     }
     if (strcmp(msg_type, MSG_DISCOVERY) == 0) {
-        log_internal_message("Received DISCOVERY from %s@%s", sender_username, sender_ip_str);
+        log_debug("Received DISCOVERY from %s@%s", sender_username, sender_ip_str);
         callbacks->send_response_callback(sender_ip_addr, sender_port, platform_context);
         add_result = callbacks->add_or_update_peer_callback(sender_ip_str, sender_username, platform_context);
         if (add_result > 0) {
-            log_internal_message("New peer added via DISCOVERY: %s@%s", sender_username, sender_ip_str);
+            log_debug("New peer added via DISCOVERY: %s@%s", sender_username, sender_ip_str);
             callbacks->notify_peer_list_updated_callback(platform_context);
         } else if (add_result == 0) {
-            log_internal_message("Existing peer updated via DISCOVERY: %s@%s", sender_username, sender_ip_str);
+            log_debug("Existing peer updated via DISCOVERY: %s@%s", sender_username, sender_ip_str);
         } else {
-            log_internal_message("Peer list full, could not add %s@%s from DISCOVERY", sender_username, sender_ip_str);
+            log_debug("Peer list full, could not add %s@%s from DISCOVERY", sender_username, sender_ip_str);
         }
     } else if (strcmp(msg_type, MSG_DISCOVERY_RESPONSE) == 0) {
-        log_internal_message("Received DISCOVERY_RESPONSE from %s@%s", sender_username, sender_ip_str);
+        log_debug("Received DISCOVERY_RESPONSE from %s@%s", sender_username, sender_ip_str);
         add_result = callbacks->add_or_update_peer_callback(sender_ip_str, sender_username, platform_context);
         if (add_result > 0) {
-            log_internal_message("New peer added via RESPONSE: %s@%s", sender_username, sender_ip_str);
+            log_debug("New peer added via RESPONSE: %s@%s", sender_username, sender_ip_str);
             callbacks->notify_peer_list_updated_callback(platform_context);
         } else if (add_result == 0) {
-            log_internal_message("Existing peer updated via RESPONSE: %s@%s", sender_username, sender_ip_str);
+            log_debug("Existing peer updated via RESPONSE: %s@%s", sender_username, sender_ip_str);
         } else {
-            log_internal_message("Peer list full, could not add %s@%s from RESPONSE", (sender_username[0] != '\0') ? sender_username : "??", sender_ip_str);
+            log_debug("Peer list full, could not add %s@%s from RESPONSE", (sender_username[0] != '\0') ? sender_username : "??", sender_ip_str);
         }
     } else {
-        log_internal_message("Received unhandled UDP message type '%s' from %s@%s.", msg_type, sender_username, sender_ip_str);
+        log_debug("Received unhandled UDP message type '%s' from %s@%s.", msg_type, sender_username, sender_ip_str);
     }
 }

--- a/shared/logging.c
+++ b/shared/logging.c
@@ -1,24 +1,180 @@
 #include "logging.h"
 #include <stdio.h>
+#include <string.h>
+#include <time.h> // For fallback timestamp if platform doesn't provide one
+
+#define MAX_LOG_LINE_LENGTH 1024
+#define USER_MESSAGE_BUFFER_SIZE (MAX_LOG_LINE_LENGTH - 60) // Ample space for timestamp and prefix
+#define TIMESTAMP_BUFFER_SIZE 30 // Generous buffer for timestamp
+
+static FILE *g_log_file = NULL;
+static platform_logging_callbacks_t g_platform_callbacks;
+static Boolean g_callbacks_initialized = false;
 static Boolean g_show_debug_output = false;
-static platform_display_debug_log_func_t g_platform_display_func_ptr = NULL;
-void shared_logging_set_platform_callback(platform_display_debug_log_func_t display_func)
-{
-    g_platform_display_func_ptr = display_func;
+static char g_log_file_name[256];
+
+
+// Fallback timestamp function if platform doesn't provide one (should not happen with new design)
+static void fallback_get_timestamp(char *buffer, size_t buffer_size) {
+    // This is a basic ISO 8601 like format.
+    // Platform specific one is preferred.
+    time_t now;
+    struct tm *local_time_info;
+    time(&now);
+    local_time_info = localtime(&now);
+
+    if (local_time_info != NULL) {
+        strftime(buffer, buffer_size, "%Y-%m-%d %H:%M:%S", local_time_info);
+    } else {
+        strncpy(buffer, "0000-00-00 00:00:00", buffer_size);
+        if (buffer_size > 0) buffer[buffer_size - 1] = '\0';
+    }
 }
-void shared_logging_clear_platform_callback(void)
-{
-    g_platform_display_func_ptr = NULL;
+
+void log_init(const char *log_file_name_suggestion, platform_logging_callbacks_t *callbacks) {
+    if (g_log_file != NULL) {
+        fclose(g_log_file);
+        g_log_file = NULL;
+    }
+
+    if (callbacks != NULL && callbacks->get_timestamp != NULL) {
+        g_platform_callbacks = *callbacks;
+        g_callbacks_initialized = true;
+    } else {
+        // Critical: No timestamp function provided.
+        // Logging to file will be impaired. UI logging might still work if display_debug_log is set.
+        // For now, we'll use a fallback for file logging, but this indicates a setup error.
+        g_platform_callbacks.get_timestamp = fallback_get_timestamp;
+        g_platform_callbacks.display_debug_log = (callbacks != NULL) ? callbacks->display_debug_log : NULL;
+        g_callbacks_initialized = true; // Partially initialized
+        // Consider logging an error here if possible, though the logger itself is what's failing to init.
+    }
+
+    if (log_file_name_suggestion) {
+        strncpy(g_log_file_name, log_file_name_suggestion, sizeof(g_log_file_name) - 1);
+        g_log_file_name[sizeof(g_log_file_name) - 1] = '\0';
+    } else {
+        // Provide a generic default if suggestion is NULL
+        #ifdef __MACOS__
+        strcpy(g_log_file_name, "app_classic_mac.log");
+        #else
+        strcpy(g_log_file_name, "app_posix.log");
+        #endif
+    }
+
+    g_log_file = fopen(g_log_file_name, "a");
+
+    if (g_log_file != NULL) {
+        char timestamp[TIMESTAMP_BUFFER_SIZE];
+        g_platform_callbacks.get_timestamp(timestamp, sizeof(timestamp));
+        fprintf(g_log_file, "\n--- [%s] Log Session Started ---\n", timestamp);
+        fflush(g_log_file);
+    } else {
+        // Cannot open log file. Platform might want to show an error.
+        // For now, logging to file will silently fail.
+        // UI logging might still work.
+    }
 }
-platform_display_debug_log_func_t shared_logging_get_platform_callback(void)
-{
-    return g_platform_display_func_ptr;
+
+void log_shutdown(void) {
+    if (g_log_file != NULL) {
+        char timestamp[TIMESTAMP_BUFFER_SIZE];
+        if (g_callbacks_initialized && g_platform_callbacks.get_timestamp) {
+            g_platform_callbacks.get_timestamp(timestamp, sizeof(timestamp));
+        } else {
+            fallback_get_timestamp(timestamp, sizeof(timestamp)); // Should not happen if init was ok
+        }
+        fprintf(g_log_file, "--- [%s] Log Session Ended ---\n\n", timestamp);
+        fflush(g_log_file);
+        fclose(g_log_file);
+        g_log_file = NULL;
+    }
+    g_callbacks_initialized = false;
+    memset(&g_platform_callbacks, 0, sizeof(platform_logging_callbacks_t)); // Clear callbacks
 }
-void set_debug_output_enabled(Boolean enabled)
-{
+
+void log_debug(const char *format, ...) {
+    char message_body[USER_MESSAGE_BUFFER_SIZE];
+    char timestamp_str[TIMESTAMP_BUFFER_SIZE];
+    char full_log_message[MAX_LOG_LINE_LENGTH];
+    char timestamp_and_prefix_for_ui[TIMESTAMP_BUFFER_SIZE + 10]; // For "[DEBUG] "
+    va_list args;
+
+    va_start(args, format);
+#ifdef __MACOS__
+    // vsprintf is common on Classic Mac, vsnprintf might not be in all compilers/libs
+    vsprintf(message_body, format, args);
+#else
+    vsnprintf(message_body, USER_MESSAGE_BUFFER_SIZE, format, args);
+#endif
+    va_end(args);
+    message_body[USER_MESSAGE_BUFFER_SIZE - 1] = '\0'; // Ensure null termination
+
+    if (g_callbacks_initialized && g_platform_callbacks.get_timestamp) {
+        g_platform_callbacks.get_timestamp(timestamp_str, sizeof(timestamp_str));
+    } else {
+        fallback_get_timestamp(timestamp_str, sizeof(timestamp_str));
+    }
+
+    if (g_log_file != NULL) {
+#ifdef __MACOS__
+        sprintf(full_log_message, "%s [DEBUG] %s", timestamp_str, message_body);
+#else
+        snprintf(full_log_message, MAX_LOG_LINE_LENGTH, "%s [DEBUG] %s", timestamp_str, message_body);
+#endif
+        fprintf(g_log_file, "%s\n", full_log_message);
+        fflush(g_log_file);
+    }
+
+    if (g_show_debug_output && g_callbacks_initialized && g_platform_callbacks.display_debug_log != NULL) {
+#ifdef __MACOS__
+        sprintf(timestamp_and_prefix_for_ui, "%s [DEBUG] ", timestamp_str);
+#else
+        snprintf(timestamp_and_prefix_for_ui, sizeof(timestamp_and_prefix_for_ui), "%s [DEBUG] ", timestamp_str);
+#endif
+        g_platform_callbacks.display_debug_log(timestamp_and_prefix_for_ui, message_body);
+    }
+}
+
+void log_app_event(const char *format, ...) {
+    char message_body[USER_MESSAGE_BUFFER_SIZE];
+    char timestamp_str[TIMESTAMP_BUFFER_SIZE];
+    char full_log_message[MAX_LOG_LINE_LENGTH];
+    va_list args;
+
+    va_start(args, format);
+#ifdef __MACOS__
+    vsprintf(message_body, format, args);
+#else
+    vsnprintf(message_body, USER_MESSAGE_BUFFER_SIZE, format, args);
+#endif
+    va_end(args);
+    message_body[USER_MESSAGE_BUFFER_SIZE - 1] = '\0'; // Ensure null termination
+
+    if (g_callbacks_initialized && g_platform_callbacks.get_timestamp) {
+        g_platform_callbacks.get_timestamp(timestamp_str, sizeof(timestamp_str));
+    } else {
+        fallback_get_timestamp(timestamp_str, sizeof(timestamp_str));
+    }
+
+    if (g_log_file != NULL) {
+#ifdef __MACOS__
+        sprintf(full_log_message, "%s %s", timestamp_str, message_body);
+#else
+        snprintf(full_log_message, MAX_LOG_LINE_LENGTH, "%s %s", timestamp_str, message_body);
+#endif
+        fprintf(g_log_file, "%s\n", full_log_message);
+        fflush(g_log_file);
+    }
+    // App events typically also go to a user-visible, non-debug part of the UI.
+    // This is handled by explicit calls in the application logic (e.g., terminal_display_app_message or AppendToMessagesTE)
+    // rather than through the g_platform_callbacks.display_debug_log.
+}
+
+void set_debug_output_enabled(Boolean enabled) {
     g_show_debug_output = enabled;
 }
-Boolean is_debug_output_enabled(void)
-{
+
+Boolean is_debug_output_enabled(void) {
     return g_show_debug_output;
 }

--- a/shared/logging.h
+++ b/shared/logging.h
@@ -1,22 +1,73 @@
 #ifndef LOGGING_SHARED_H
 #define LOGGING_SHARED_H
+
 #ifdef __MACOS__
-#include <MacTypes.h>
+#include <MacTypes.h> // Provides Boolean
 #else
 #ifndef __cplusplus
 #include <stdbool.h>
-#define Boolean bool
+#define Boolean bool   // Defines Boolean for POSIX
 #endif
 #endif
+
 #include <stdarg.h>
-typedef void (*platform_display_debug_log_func_t)(const char *timestamp_and_prefix, const char *message_body);
-void log_init(const char *log_file_name_suggestion, platform_display_debug_log_func_t display_func);
+#include <stddef.h> // For size_t
+
+// Platform-specific callbacks to be implemented by each platform
+typedef struct {
+    // Function to get a platform-specific timestamp string.
+    void (*get_timestamp)(char *buffer, size_t buffer_size);
+    // Function to display a debug log message on the platform's UI (e.g., console, dialog).
+    // This can be NULL if no UI debug display is available or desired.
+    void (*display_debug_log)(const char *timestamp_and_prefix, const char *message_body);
+} platform_logging_callbacks_t;
+
+/**
+ * @brief Initializes the shared logging system.
+ *
+ * @param log_file_name_suggestion A suggested name for the log file. The implementation may alter it.
+ * @param callbacks A pointer to a struct containing platform-specific callback functions.
+ *                  The get_timestamp callback is mandatory. display_debug_log can be NULL.
+ */
+void log_init(const char *log_file_name_suggestion, platform_logging_callbacks_t *callbacks);
+
+/**
+ * @brief Shuts down the shared logging system and closes the log file.
+ */
 void log_shutdown(void);
-void log_internal_message(const char *format, ...);
+
+/**
+ * @brief Logs a debug message.
+ * Writes to the log file. If debug output is enabled and a display_debug_log callback is provided,
+ * it also sends the message to the platform's debug UI.
+ *
+ * @param format The format string for the message (printf-style).
+ * @param ... Variable arguments for the format string.
+ */
+void log_debug(const char *format, ...);
+
+/**
+ * @brief Logs a general application event.
+ * Writes to the log file only. Does not go to the debug UI display.
+ *
+ * @param format The format string for the message (printf-style).
+ * @param ... Variable arguments for the format string.
+ */
 void log_app_event(const char *format, ...);
+
+/**
+ * @brief Enables or disables debug message output to the platform's UI.
+ * File logging is always active for log_debug messages.
+ *
+ * @param enabled true to enable UI debug output, false to disable.
+ */
 void set_debug_output_enabled(Boolean enabled);
+
+/**
+ * @brief Checks if debug message output to the platform's UI is enabled.
+ *
+ * @return true if UI debug output is enabled, false otherwise.
+ */
 Boolean is_debug_output_enabled(void);
-void shared_logging_set_platform_callback(platform_display_debug_log_func_t display_func);
-void shared_logging_clear_platform_callback(void);
-platform_display_debug_log_func_t shared_logging_get_platform_callback(void);
-#endif
+
+#endif // LOGGING_SHARED_H

--- a/shared/messaging.c
+++ b/shared/messaging.c
@@ -11,25 +11,25 @@ void handle_received_tcp_message(const char *sender_ip,
 {
     int add_result;
     if (!callbacks || !callbacks->add_or_update_peer || !callbacks->display_text_message || !callbacks->mark_peer_inactive) {
-        log_internal_message("Error (handle_received_tcp_message): Invalid or incomplete callbacks provided.");
+        log_debug("Error (handle_received_tcp_message): Invalid or incomplete callbacks provided.");
         return;
     }
     add_result = callbacks->add_or_update_peer(sender_ip, sender_username, platform_context);
     if (add_result > 0) {
-        log_internal_message("Shared TCP Handler: New peer added/updated via TCP: %s@%s", sender_username, sender_ip);
+        log_debug("Shared TCP Handler: New peer added/updated via TCP: %s@%s", sender_username, sender_ip);
     } else if (add_result == 0) {
-        log_internal_message("Shared TCP Handler: Existing peer updated via TCP: %s@%s", sender_username, sender_ip);
+        log_debug("Shared TCP Handler: Existing peer updated via TCP: %s@%s", sender_username, sender_ip);
     } else {
-        log_internal_message("Shared TCP Handler: Peer list full or error adding/updating %s@%s from TCP.", sender_username, sender_ip);
+        log_debug("Shared TCP Handler: Peer list full or error adding/updating %s@%s from TCP.", sender_username, sender_ip);
     }
-    log_internal_message("Shared TCP Handler: Processing message type '%s' from %s@%s", msg_type, sender_username, sender_ip);
+    log_debug("Shared TCP Handler: Processing message type '%s' from %s@%s", msg_type, sender_username, sender_ip);
     if (strcmp(msg_type, MSG_TEXT) == 0) {
-        log_internal_message("Shared TCP Handler: Calling display_text_message callback.");
+        log_debug("Shared TCP Handler: Calling display_text_message callback.");
         callbacks->display_text_message(sender_username, sender_ip, content, platform_context);
     } else if (strcmp(msg_type, MSG_QUIT) == 0) {
-        log_internal_message("Shared TCP Handler: Received QUIT from %s@%s. Calling mark_peer_inactive callback.", sender_username, sender_ip);
+        log_debug("Shared TCP Handler: Received QUIT from %s@%s. Calling mark_peer_inactive callback.", sender_username, sender_ip);
         callbacks->mark_peer_inactive(sender_ip, platform_context);
     } else {
-        log_internal_message("Shared TCP Handler: Received unhandled TCP message type '%s' from %s@%s.", msg_type, sender_username, sender_ip);
+        log_debug("Shared TCP Handler: Received unhandled TCP message type '%s' from %s@%s.", msg_type, sender_username, sender_ip);
     }
 }

--- a/shared/peer.c
+++ b/shared/peer.c
@@ -64,7 +64,7 @@ int peer_shared_add_or_update(peer_manager_t *manager, const char *ip, const cha
         peer_shared_update_entry(new_peer, username);
         return 1;
     }
-    log_internal_message("Peer list is full. Cannot add peer %s@%s.", username ? username : "??", ip);
+    log_debug("Peer list is full. Cannot add peer %s@%s.", username ? username : "??", ip);
     return -1;
 }
 int peer_shared_prune_timed_out(peer_manager_t *manager)
@@ -94,7 +94,7 @@ int peer_shared_prune_timed_out(peer_manager_t *manager)
 #endif
             }
             if (time_diff > timeout_duration) {
-                log_internal_message("Peer %s@%s timed out.", manager->peers[i].username, manager->peers[i].ip);
+                log_debug("Peer %s@%s timed out.", manager->peers[i].username, manager->peers[i].ip);
                 manager->peers[i].active = 0;
                 pruned_count++;
             }

--- a/shared/protocol.c
+++ b/shared/protocol.c
@@ -22,7 +22,7 @@ int format_message(char *buffer, int buffer_size, const char *msg_type,
     int text_part_len;
     int total_len;
     if (buffer == NULL || buffer_size < (int)(sizeof(uint32_t) + 1)) {
-        log_internal_message("Error: format_message buffer too small (%d bytes) or NULL.", buffer_size);
+        log_debug("Error: format_message buffer too small (%d bytes) or NULL.", buffer_size);
         return 0;
     }
     magic_net_order = my_htonl(MSG_MAGIC_NUMBER);
@@ -30,12 +30,12 @@ int format_message(char *buffer, int buffer_size, const char *msg_type,
     if (local_ip_str != NULL && local_ip_str[0] != '\0') {
         ip_to_use = local_ip_str;
     } else {
-        log_internal_message("Warning: format_message received NULL or empty local_ip_str. Using 'unknown'.");
+        log_debug("Warning: format_message received NULL or empty local_ip_str. Using 'unknown'.");
         ip_to_use = "unknown";
     }
     sender_len = snprintf(sender_with_ip, sizeof(sender_with_ip), "%s@%s", sender ? sender : "anon", ip_to_use);
     if (sender_len < 0 || sender_len >= (int)sizeof(sender_with_ip)) {
-        log_internal_message("Error: format_message failed formatting sender@ip.");
+        log_debug("Error: format_message failed formatting sender@ip.");
         return 0;
     }
     int remaining_buffer_size = buffer_size - sizeof(uint32_t);
@@ -45,16 +45,16 @@ int format_message(char *buffer, int buffer_size, const char *msg_type,
                              sender_with_ip,
                              content ? content : "");
     if (text_part_len >= remaining_buffer_size) {
-        log_internal_message("Warning: format_message text part truncated (buffer size %d, needed %d).", remaining_buffer_size, text_part_len + 1);
+        log_debug("Warning: format_message text part truncated (buffer size %d, needed %d).", remaining_buffer_size, text_part_len + 1);
         return 0;
     }
     if (text_part_len < 0) {
-        log_internal_message("Error: format_message failed formatting final text part (encoding error).");
+        log_debug("Error: format_message failed formatting final text part (encoding error).");
         return 0;
     }
     total_len = sizeof(uint32_t) + text_part_len + 1;
     if (total_len > buffer_size) {
-        log_internal_message("Error: format_message internal logic error - total_len > buffer_size.");
+        log_debug("Error: format_message internal logic error - total_len > buffer_size.");
         return 0;
     }
     return total_len;
@@ -84,21 +84,21 @@ int parse_message(const char *buffer, int buffer_len, char *sender_ip, char *sen
     text_part_start = buffer + sizeof(uint32_t);
     text_part_len = buffer_len - sizeof(uint32_t);
     if (text_part_len >= BUFFER_SIZE) {
-        log_internal_message("Parse warning: Text part length (%d) exceeds temp buffer (%d). Truncating.", text_part_len, BUFFER_SIZE - 1);
+        log_debug("Parse warning: Text part length (%d) exceeds temp buffer (%d). Truncating.", text_part_len, BUFFER_SIZE - 1);
         text_part_len = BUFFER_SIZE - 1;
     }
     strncpy(temp_text_part, text_part_start, text_part_len);
     temp_text_part[text_part_len] = '\0';
     token = strtok_r(temp_text_part, "|", &rest);
     if (token == NULL) {
-        log_internal_message("Parse error: Could not find message type token after magic number.");
+        log_debug("Parse error: Could not find message type token after magic number.");
         return -1;
     }
     strncpy(msg_type, token, 31);
     msg_type[31] = '\0';
     token = strtok_r(NULL, "|", &rest);
     if (token == NULL) {
-        log_internal_message("Parse error: Could not find sender@ip token after magic number.");
+        log_debug("Parse error: Could not find sender@ip token after magic number.");
         return -1;
     }
     strncpy(sender_with_ip, token, sizeof(sender_with_ip) - 1);
@@ -112,7 +112,7 @@ int parse_message(const char *buffer, int buffer_len, char *sender_ip, char *sen
         strncpy(sender_ip, at_sign + 1, INET_ADDRSTRLEN - 1);
         sender_ip[INET_ADDRSTRLEN - 1] = '\0';
     } else {
-        log_internal_message("Parse warning: '@' not found in sender token '%s'. Treating as username.", sender_with_ip);
+        log_debug("Parse warning: '@' not found in sender token '%s'. Treating as username.", sender_with_ip);
         strncpy(sender_username, sender_with_ip, 31);
         sender_username[31] = '\0';
         strcpy(sender_ip, "unknown");


### PR DESCRIPTION
Moved core logging functionality (file I/O, timestamping, message formatting) from platform-specific files (posix/logging.c, classic_mac/logging.c) into shared/logging.c.

Key changes:
- Introduced platform_logging_callbacks_t in shared/logging.h for platform-specific timestamp generation and optional UI debug display.
- Shared log_init() now takes these callbacks.
- Shared log_debug() (renamed from log_internal_message) and log_app_event() handle writing to the log file. log_debug() conditionally calls the UI display callback based on a shared toggle state.
- Platform-specific logging.c files now primarily implement these callbacks.
- Updated main.c in both POSIX and Classic Mac to initialize the new shared logging system.
- Replaced all instances of log_internal_message() with log_debug() and classic_mac/log_to_file_only() with log_debug() throughout the codebase.
- Added missing #include \"../shared/logging.h\" in several POSIX C files to resolve implicit function declaration warnings for log_debug/log_app_event.

This change significantly reduces code duplication, standardizes logging behavior across platforms, and improves maintainability of the logging system. The debug UI toggle functionality is preserved for both POSIX and Classic Mac.