### PR TITLE
Use standalone classic-mac-hardware-mcp server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,14 @@
 {
   "mcpServers": {
     "classic-mac-hardware": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "run",
-        "--with", "mcp",
-        "python3",
-        ".claude/mcp-servers/classic-mac-hardware/server.py"
+        "--from",
+        "git+https://github.com/matthewdeaves/classic-mac-hardware-mcp",
+        "classic-mac-hardware-mcp"
       ],
       "env": {
-        "MACHINES_CONFIG": ".claude/mcp-servers/classic-mac-hardware/machines.json"
+        "MACHINES_CONFIG": "~/.config/classic-mac-hardware/machines.json"
       }
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ cmake --build build-ppc-mactcp
 ```
 
 ### Classic Mac
-Deploy `.bin` or `.APPL` to real Classic Mac hardware via FTP or disk image.
+Deploy `.bin` or `.APPL` to real Classic Mac hardware using the [classic-mac-hardware-mcp](https://github.com/matthewdeaves/classic-mac-hardware-mcp) MCP server. Never use raw FTP scripts.
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cmake --build build-ppc-ot
 
 ### Classic Mac
 
-Deploy `.bin` to real hardware via FTP or disk image. The GUI provides a message area, input field, peer list, send button, broadcast checkbox, and debug toggle.
+Deploy `.bin` to real hardware using the [classic-mac-hardware-mcp](https://github.com/matthewdeaves/classic-mac-hardware-mcp) MCP server. The GUI provides a message area, input field, peer list, send button, broadcast checkbox, and debug toggle.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Update .mcp.json to use `uvx` from standalone `matthewdeaves/classic-mac-hardware-mcp` repo
- Update CLAUDE.md and README.md to reference MCP server for hardware deployment
- Removes hardcoded path dependency on peertalk repo

## Test plan
- [ ] Verify MCP server connects via `list_machines`
- [ ] Test file operations against a real Classic Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)